### PR TITLE
Always use mbstring if it is loaded, since other extensions can potentially overload core string fucntions

### DIFF
--- a/src/Util/Binary.php
+++ b/src/Util/Binary.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Polyfill\Util;
 
-if (2 /* MB_OVERLOAD_STRING */ & (int) ini_get('mbstring.func_overload')) {
+if (extension_loaded('mbstring')) {
     class Binary extends BinaryOnFuncOverload {}
 } else {
     class Binary extends BinaryNoFuncOverload {}


### PR DESCRIPTION
There is little to no cost, since you're already proxying these functions. So why couple to only one potential overload rather than support a more general case.