### PR TITLE
ldap_escape does not encode leading/trailing spaces.

### DIFF
--- a/src/Php56/Php56.php
+++ b/src/Php56/Php56.php
@@ -122,17 +122,6 @@ final class Php56
         // Do the main replacement
         $result = strtr($subject, $charMap);
 
-        // Encode leading/trailing spaces if self::LDAP_ESCAPE_DN is passed
-        if ($flags & self::LDAP_ESCAPE_DN) {
-            if ($result[0] === ' ') {
-                $result = '\\20'.substr($result, 1);
-            }
-
-            if ($result[strlen($result) - 1] === ' ') {
-                $result = substr($result, 0, -1).'\\20';
-            }
-        }
-
         return $result;
     }
 }

--- a/tests/Php56/Php56Test.php
+++ b/tests/Php56/Php56Test.php
@@ -80,7 +80,7 @@ class Php56Test extends \PHPUnit_Framework_TestCase
     public function provideLdapEscapeValues()
     {
         return array(
-            array('foo=bar(baz)*', null, p::LDAP_ESCAPE_DN, 'foo\3dbar(baz)*'),
+            array(" foo=bar\r(baz)* ", null, p::LDAP_ESCAPE_DN, ' foo\3dbar'."\r".'(baz)* '),
             array('foo=bar(baz)*', null, null, '\66\6f\6f\3d\62\61\72\28\62\61\7a\29\2a'),
             array('foo=bar(baz)*', null, p::LDAP_ESCAPE_DN | p::LDAP_ESCAPE_FILTER, 'foo\3dbar\28baz\29\2a'),
             array('foo=bar(baz)*', null, p::LDAP_ESCAPE_FILTER, 'foo=bar\28baz\29\2a'),

--- a/tests/Php56/Php56Test.php
+++ b/tests/Php56/Php56Test.php
@@ -67,7 +67,9 @@ class Php56Test extends \PHPUnit_Framework_TestCase
 
     /**
      * Provides values for the ldap_escape shim. These tests come from the official
-     * extension.
+     * extension, with the exception of the last one. The last test accounts for
+     * leading/trailing spaces and carriage returns as outlined in RFC 4514. Those
+     * values are not actually handled by ldap_escape, so make sure we don't either.
      *
      * @see https://github.com/php/php-src/blob/master/ext/ldap/tests/ldap_escape_dn.phpt
      * @see https://github.com/php/php-src/blob/master/ext/ldap/tests/ldap_escape_all.phpt
@@ -80,11 +82,12 @@ class Php56Test extends \PHPUnit_Framework_TestCase
     public function provideLdapEscapeValues()
     {
         return array(
-            array(" foo=bar\r(baz)* ", null, p::LDAP_ESCAPE_DN, ' foo\3dbar'."\r".'(baz)* '),
+            array('foo=bar(baz)*', null, p::LDAP_ESCAPE_DN, 'foo\3dbar(baz)*'),
             array('foo=bar(baz)*', null, null, '\66\6f\6f\3d\62\61\72\28\62\61\7a\29\2a'),
             array('foo=bar(baz)*', null, p::LDAP_ESCAPE_DN | p::LDAP_ESCAPE_FILTER, 'foo\3dbar\28baz\29\2a'),
             array('foo=bar(baz)*', null, p::LDAP_ESCAPE_FILTER, 'foo=bar\28baz\29\2a'),
             array('foo=bar(baz)*', 'ao', null, '\66oo\3d\62a\72\28\62a\7a\29\2a'),
+            array(" foo=bar\r(baz)* ", null, p::LDAP_ESCAPE_DN, ' foo\3dbar'."\r".'(baz)* '),
         );
     }
 }


### PR DESCRIPTION
The `ldap_escape` function in this library is actually more RFC compliant at the moment than the official function. This removes the encoding for a leading/trailing space for escaping a DN. Also, a carriage return should be encoded when escaping a DN but the official function doesn't do that either (neither does the one here, but I put it in the test anyhow). I guess a bug report should probably be opened for the PHP function on their bug tracker.

The escape function in the LDAP component should probably be updated to account for the additional encoding mentioned above, but it doesn't appear to have any tests at all at the moment? 