### PR TITLE
[APCu] A new polyfill for the legacy APC users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,16 @@ matrix:
 
 before_install:
     - composer self-update;
-    - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi;
-    - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then echo "extension = ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
-    - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then php -i; fi;
+    - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then INI_FILE=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; else INI_FILE=/etc/hhvm/php.ini; fi;
+    - echo memory_limit = -1 >> $INI_FILE
+    - echo session.gc_probability = 0 >> $INI_FILE
+    - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
+    - if [[ $TRAVIS_PHP_VERSION = 5.* ]]; then (echo yes | pecl install -f apcu-4.0.10 && echo apc.enable_cli = 1 >> $INI_FILE) || echo "Let's continue without apcu extension"; fi;
+    - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo extension = ldap.so >> $INI_FILE; fi;
+    - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then php -i; fi;
 
 install:
-    - if [ "$TRAVIS_BRANCH" = "master" ]; then export COMPOSER_ROOT_VERSION=dev-master; else export COMPOSER_ROOT_VERSION="$TRAVIS_BRANCH".x-dev; fi;
+    - if [[ $TRAVIS_BRANCH = master ]]; then export COMPOSER_ROOT_VERSION=dev-master; else export COMPOSER_ROOT_VERSION=$TRAVIS_BRANCH.x-dev; fi;
     - composer --prefer-source install;
 
 script:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ compatibility layers for some extensions and functions. It is intended to be
 used when portability across PHP versions and extensions is desired.
 
 Polyfills are provided for:
+- the `apcu` extension when the legacy `apc` extension is installed;
 - the `mbstring` and `iconv` extensions;
 - the `Normalizer` class and the `grapheme_*` functions;
 - the `utf8_encode` and `utf8_decode` functions from the `xml` extension;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ install:
     - IF %PHP%==1 7z x ICU-51.2-dlls.zip -y >nul
     - IF %PHP%==1 del /Q *.zip
     - IF %PHP%==1 cd ext
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/apcu/4.0.10/php_apcu-4.0.10-5.5-nts-vc11-x86.zip
+    - IF %PHP%==1 7z x php_apcu-4.0.10-5.5-nts-vc11-x86.zip -y >nul
     - IF %PHP%==1 appveyor DownloadFile http://nebm.ist.utl.pt/~glopes/misc/intl_win/php_intl-3.0.0-5.3-nts-vc9-x86.zip
     - IF %PHP%==1 7z x php_intl-3.0.0-5.3-nts-vc9-x86.zip -y >nul
     - IF %PHP%==1 del /Q *.zip
@@ -32,6 +34,7 @@ install:
     - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
     - IF %PHP%==1 echo extension_dir=ext >> php.ini
     - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_apcu.dll >> php.ini
     - IF %PHP%==1 echo extension=php_intl.dll >> php.ini
     - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
     - IF %PHP%==1 echo extension=php_ldap.dll >> php.ini

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/intl": "~2.3|~3.0"
     },
     "replace": {
+        "symfony/polyfill-apcu": "self.version",
         "symfony/polyfill-php54": "self.version",
         "symfony/polyfill-php55": "self.version",
         "symfony/polyfill-php56": "self.version",
@@ -37,6 +38,7 @@
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\": "src/" },
         "files": [
+            "src/Apcu/bootstrap.php",
             "src/Php54/bootstrap.php",
             "src/Php55/bootstrap.php",
             "src/Php56/bootstrap.php",
@@ -49,6 +51,7 @@
             "src/Xml/bootstrap.php"
         ],
         "classmap": [
+            "src/Apcu/Resources/stubs",
             "src/Intl/Normalizer/Resources/stubs",
             "src/Php70/Resources/stubs",
             "src/Php54/Resources/stubs"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <ini name="apc.enable_cli" value="1" />
     </php>
 
     <testsuites>

--- a/src/Apcu/Apcu.php
+++ b/src/Apcu/Apcu.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Apcu;
+
+/**
+ * @internal
+ */
+final class Apcu
+{
+    public static function apcu_entry($key, $generator, $ttl = 0)
+    {
+        if (!is_scalar($key)) {
+            throw new \InvalidArgumentException(sprintf('apcu_entry() expects parameter 1 to be string, %s given', __FUNCTION__, gettype($value)));
+        }
+
+        $entry = apcu_fetch($key, $success);
+
+        if ($success) {
+            return $entry;
+        }
+
+        $h = fopen(__FILE__, 'r');
+        flock($h, LOCK_EX);
+        try {
+            $entry = apcu_fetch($key, $success);
+
+            if (!$success) {
+                $entry = call_user_func($generator, $key);
+                apc_store($key, $entry, $ttl);
+            }
+        } catch (\Exception $e) {
+        }
+        flock($h, LOCK_UN);
+
+        if (isset($e)) {
+            throw $e;
+        }
+
+        return $entry;
+    }
+}

--- a/src/Apcu/LICENSE
+++ b/src/Apcu/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2014-2015 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Apcu/README.md
+++ b/src/Apcu/README.md
@@ -1,8 +1,7 @@
-Symfony Polyfill / Util
-=======================
+Symfony Polyfill / APCu
+========================
 
-This component provides binary-safe string functions, using the
-[mbstring](https://php.net/mbstring) extension when available.
+This component provides all `apcu_*` functions and the `APCUIterator` class to users of the legacy APC extension.
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).

--- a/src/Apcu/Resources/stubs/APCUIterator.php
+++ b/src/Apcu/Resources/stubs/APCUIterator.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class APCUIterator extends APCIterator
+{
+    public function __construct($search = null, $format = APC_ITER_ALL, $chunk_size = 100, $list = APC_LIST_ACTIVE)
+    {
+        parent::__construct('user', $search, $format, $chunk_size, $list);
+    }
+}

--- a/src/Apcu/bootstrap.php
+++ b/src/Apcu/bootstrap.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\Apcu as p;
+
+if (!extension_loaded('apc')) {
+    return;
+}
+
+if (!function_exists('apcu_add')) {
+    function apcu_add($key, $var = null, $ttl = 0) { return apc_add($key, $var, $ttl); }
+    function apcu_cache_info($limited = false) { return apc_cache_info('user', $limited); }
+    function apcu_cas($key, $old, $new) { return apc_cas($key, $old, $new); }
+    function apcu_clear_cache() { return apc_clear_cache('user'); }
+    function apcu_dec($key, $step = 1, &$success = false) { return apc_dec($key, $step, $success); }
+    function apcu_delete($key) { return apc_delete($key); }
+    function apcu_exists($keys) { return apc_exists($keys); }
+    function apcu_fetch($key, &$success = false) { return apc_fetch($key, $success); }
+    function apcu_inc($key, $step = 1, &$success = false) { return apc_inc($key, $step, $success); }
+    function apcu_sma_info($limited = false) { return apc_sma_info($limited); }
+    function apcu_store($key, $var = null, $ttl = 0) { return apc_store($key, $var, $ttl); }
+}
+
+if (!function_exists('apcu_entry')) {
+    function apcu_entry($key, $generator, $ttl = 0) { return p\Apcu::apcu_entry($key, $generator, $ttl); }
+}

--- a/src/Apcu/composer.json
+++ b/src/Apcu/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "symfony/polyfill-apcu",
+    "type": "library",
+    "description": "Symfony polyfill backporting apcu_* functions to lower PHP versions",
+    "keywords": ["polyfill", "shim", "compatibility", "portable", "apcu"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Nicolas Grekas",
+            "email": "p@tchwork.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.3"
+    },
+    "autoload": {
+        "files": [ "bootstrap.php" ],
+        "classmap": [ "Resources/stubs" ]
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    }
+}

--- a/src/Iconv/README.md
+++ b/src/Iconv/README.md
@@ -5,7 +5,7 @@ This component provides a native PHP implementation of the
 [php.net/iconv](http://php.net/iconv) functions
 (short of [`ob_iconv_handler`](http://php.net/manual/en/function.ob-iconv-handler.php)).
 
-More information can be found in the 
+More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
 
 License

--- a/src/Intl/Grapheme/README.md
+++ b/src/Intl/Grapheme/README.md
@@ -22,7 +22,7 @@ This component provides a partial, native PHP implementation of the
   the first occurrence of needle to the end of haystack
 - [`grapheme_substr`](http://php.net/grapheme_substr): Return part of a string
 
-More information can be found in the 
+More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
 
 License

--- a/src/Intl/Icu/README.md
+++ b/src/Intl/Icu/README.md
@@ -14,7 +14,7 @@ This component maps a collection of functions/classes using the
 - [`Locale`](http://php.net/Locale)
 - [`IntlDateFormatter`](http://php.net/IntlDateFormatter)
 
-More information can be found in the 
+More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
 
 License

--- a/src/Intl/Normalizer/README.md
+++ b/src/Intl/Normalizer/README.md
@@ -5,7 +5,7 @@ This component provides a fallback implementation for the
 [`Normalizer`](http://php.net/manual/en/class.normalizer.php) class provided
 by the [Intl](http://php.net/intl) extension.
 
-More information can be found in the 
+More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
 
 License

--- a/src/Mbstring/README.md
+++ b/src/Mbstring/README.md
@@ -4,7 +4,7 @@ Symfony Polyfill / Mbstring
 This component provides a partial, native PHP implementation for the
 [Mbstring](http://php.net/mbstring) extension.
 
-More information can be found in the 
+More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
 
 License

--- a/src/Php54/README.md
+++ b/src/Php54/README.md
@@ -8,7 +8,7 @@ This component provides functions unavailable in releases prior to PHP 5.4:
 - [`hex2bin`](http://php.net/hex2bin)
 - [`session_register_shutdown`](http://php.net/session_register_shutdown)
 
-More information can be found in the 
+More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
 
 License

--- a/src/Php55/README.md
+++ b/src/Php55/README.md
@@ -9,7 +9,7 @@ This component provides functions unavailable in releases prior to PHP 5.5:
 - [`hash_pbkdf2`](http://php.net/hash_pbkdf2)
 - `password_*` functions (from [ircmaxell/password_compat](https://github.com/ircmaxell/password_compat))
 
-More information can be found in the 
+More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
 
 License

--- a/src/Php56/README.md
+++ b/src/Php56/README.md
@@ -6,7 +6,7 @@ This component provides functions unavailable in releases prior to PHP 5.6:
 - [`hash_equals`](http://php.net/hash_equals)  (part of [hash](http://php.net/hash) extension)
 - [`ldap_escape`](http://php.net/ldap_escape) (part of [ldap](http://php.net/ldap) extension)
 
-More information can be found in the 
+More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
 
 License

--- a/src/Php70/README.md
+++ b/src/Php70/README.md
@@ -9,7 +9,7 @@ This component provides functions unavailable in releases prior to PHP 7.0:
 - `random_bytes` and `random_int` (from [paragonie/random_compat](https://github.com/paragonie/random_compat))
 - [`*Error` throwable classes](http://php.net/Error)
 
-More information can be found in the 
+More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
 
 License

--- a/src/Xml/README.md
+++ b/src/Xml/README.md
@@ -1,13 +1,13 @@
 Symfony Polyfill / XML
 ======================
 
-This component provides a fallback implementation for the following functions in the 
+This component provides a fallback implementation for the following functions in the
 abscense of the [XML](http://php.net/xml) extension:
 
 - [`utf8_encode`](https://php.net/utf8_encode)
 - [`utf8_decode`](https://php.net/utf8_decode)
 
-More information can be found in the 
+More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
 
 License

--- a/tests/Apcu/ApcuTest.php
+++ b/tests/Apcu/ApcuTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Apcu;
+
+/**
+ * @requires extension apc
+ */
+class ApcuTest extends \PHPUnit_Framework_TestCase
+{
+    public function testApcu()
+    {
+        apcu_delete(__CLASS__);
+
+        $this->assertFalse(apcu_exists(__CLASS__));
+        $this->assertTrue(apcu_add(__CLASS__, 123));
+        $this->assertTrue(apcu_exists(__CLASS__));
+        $this->assertSame(array(__CLASS__ => -1), apcu_add(array(__CLASS__ => 123)));
+        $this->assertSame(123, apcu_fetch(__CLASS__));
+        $this->assertTrue(apcu_store(__CLASS__, 124));
+        $this->assertSame(124, apcu_fetch(__CLASS__));
+        $this->assertSame(125, apcu_inc(__CLASS__));
+        $this->assertSame(124, apcu_dec(__CLASS__));
+        $this->assertTrue(apcu_cas(__CLASS__, 124, 123));
+        $this->assertFalse(apcu_cas(__CLASS__, 124, 123));
+        $this->assertTrue(apcu_delete(__CLASS__));
+        $this->assertFalse(apcu_delete(__CLASS__));
+        $this->assertArrayHasKey('cache_list', apcu_cache_info());
+    }
+
+    public function testAPCUIterator()
+    {
+        $this->assertTrue(apcu_store(__CLASS__, 456));
+
+        $entries = iterator_to_array(new \APCUIterator('/^'.preg_quote(__CLASS__, '/').'$/'));
+
+        $this->assertSame(array(__CLASS__), array_keys($entries));
+        $this->assertSame(__CLASS__, $entries[__CLASS__]['key']);
+        $this->assertSame(456, $entries[__CLASS__]['value']);
+    }
+
+    public function testApcuEntry()
+    {
+        apcu_delete(__CLASS__);
+
+        $gen = function ($key) use (&$ok) {
+            $ok = null === $ok && __CLASS__ === $key;
+
+            return 789;
+        };
+
+        $this->assertSame(789, apcu_entry(__CLASS__, $gen));
+        $this->assertTrue($ok);
+    }
+}


### PR DESCRIPTION
Now that we know that `apc_*` functions are legacy and `apcu_*` is the only way in PHP7, I propose to move forward with this polyfill. Let's replace all usages of `apc_*` in Symfony and elsewhere by their `apcu_*` equivalent and add a deps on this new polyfill to cope with legacy `apc` users.