### PR TITLE
Exclude dev/test files from releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+.gitattributes   export-ignore
+.gitignore       export-ignore
+.travis.yml      export-ignore
+appveyor.yml     export-ignore
+phpunit.xml.dist export-ignore
+tests            export-ignore


### PR DESCRIPTION
Users of the package (as opposed to developers) do not need the test/dev files.

Exclude these from releases.