### PR TITLE
Add the Throwable interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Compatibility notes
 
 To write portable code between PHP5 and PHP7, some care must be taken:
 - `\*Error` exceptions must by caught before `\Exception`;
+- The `\Throwable` interface is not implemented by `\Exception` in PHP5.
+- Both `\Error` and `\Exception` will fall through a `try {} catch (\Throwable $e) {}`
+  block in PHP5.
 - after calling `error_clear_last()`, the result of `$e = error_get_last()` must be
   verified using `isset($e['message'][0])` instead of `null === $e`.
 

--- a/src/Php70/Resources/stubs/Error.php
+++ b/src/Php70/Resources/stubs/Error.php
@@ -1,5 +1,5 @@
 <?php
 
-class Error extends Exception
+class Error extends Exception implements Throwable
 {
 }

--- a/src/Php70/Resources/stubs/Throwable.php
+++ b/src/Php70/Resources/stubs/Throwable.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Throwable interface for PHP 5.x
+ *
+ * Throwable is the base interface for any object that can be thrown via a throw statement in PHP 7,
+ * including {@see Error} and {@see Exception}.
+ *
+ * @see http://php.net/manual/en/class.throwable.php
+ */
+interface Throwable
+{
+    /**
+     * Gets the message
+     *
+     * Returns the message associated with the thrown object.
+     *
+     * @see http://php.net/manual/en/throwable.getmessage.php
+     *
+     * @return string
+     */
+    public function getMessage();
+
+    /**
+     * Gets the exception code
+     *
+     * Returns the error code associated with the thrown object.
+     *
+     * @see http://php.net/manual/en/throwable.getcode.php
+     *
+     * @return int
+     */
+    public function getCode();
+
+    /**
+     * Gets the file in which the exception occurred
+     *
+     * Returns the name of the file from which the object was thrown.
+     *
+     * @link http://php.net/manual/en/throwable.getfile.php
+     *
+     * @return string
+     */
+    public function getFile();
+
+    /**
+     * Gets the line on which the object was instantiated
+     *
+     * Returns the line number where the thrown object was instantiated.
+     *
+     * @see http://php.net/manual/en/throwable.getline.php
+     *
+     * @return int
+     */
+    public function getLine();
+
+    /**
+     * Gets the stack trace
+     *
+     * Returns the stack trace as an array.
+     *
+     * @see http://php.net/manual/en/throwable.gettrace.php
+     *
+     * @return array
+     */
+    public function getTrace();
+
+    /**
+     * Gets the stack trace as a string
+     *
+     * Returns the stack trace as a string.
+     *
+     * @see http://php.net/manual/en/throwable.gettraceasstring.php
+     *
+     * @return string
+     */
+    public function getTraceAsString();
+
+    /**
+     * Returns the previous Throwable
+     *
+     * Returns any previous Throwable (for example, one provided as the third parameter
+     * to {@see Exception::__construct())}.
+     *
+     * @see http://php.net/manual/en/throwable.getprevious.php
+     *
+     * @return Throwable|null
+     */
+    public function getPrevious();
+
+    /**
+     * Gets a string representation of the thrown object
+     *
+     * @see http://php.net/manual/en/throwable.tostring.php
+     *
+     * @return string
+     */
+    public function __toString();
+}

--- a/tests/Php70/Php70Test.php
+++ b/tests/Php70/Php70Test.php
@@ -63,4 +63,26 @@ class Php70Test extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(5, $count);
     }
+
+    public function testCatchExceptionBeforeThrowable()
+    {
+        try {
+            throw new \Error('Catch me, if you can');
+        } catch (\Exception $e) {
+            $this->assertTrue(PHP_VERSION_ID < 70000, 'This will only work in PHP5');
+        } catch (\Throwable $t) {
+            $this->assertTrue(PHP_VERSION_ID >= 70000, 'This will only work in PHP7');
+        }
+    }
+
+    public function testCatchThrowableBeforeException()
+    {
+        try {
+            throw new \Error('Catch me, if you can');
+        } catch (\Throwable $t) {
+            $this->assertTrue(PHP_VERSION_ID >= 70000, 'This will only work in PHP7');
+        } catch (\Exception $e) {
+            $this->assertTrue(PHP_VERSION_ID < 70000, 'This will only work in PHP5');
+        }
+    }
 }


### PR DESCRIPTION
This PR adds the `Throwable` interface to the PHP7 polyfill. This way, the interface can be used in type hints and `catch` statements.

Limitations in PHP 5.x:
* Regular exceptions won't implement the `Throwable` interface, only children of the polyfilled `Error` class.
* While a `catch (Throwable $t)` statement won't produce an error, it will not catch anything either.

The interface becomes interesting for writing `try`/`catch` blocks that should catch everything.

```php
try {
    do_something();
} catch (Throwable $t) {
    // Global exception/error handling for PHP >= 7
} catch (Exception $e) {
    // Legacy exception/error handling block for PHP 5.x
    // Can be deleted when PHP 5.x support is dropped.
}
```