### PR TITLE
[Php70] Workaround https://bugs.php.net/63206

### DIFF
--- a/src/Php70/Php70.php
+++ b/src/Php70/Php70.php
@@ -51,7 +51,11 @@ final class Php70
 
     public static function error_clear_last()
     {
-        set_error_handler('var_dump', 0);
+        static $handler;
+        if (!$handler) {
+             $handler = function() { return false; };
+        }
+        set_error_handler($handler);
         @trigger_error('');
         restore_error_handler();
     }


### PR DESCRIPTION
This ensures we never create the conditions for https://bugs.php.net/63206
I.e. never use set_error_handler's second argument.