### PR TITLE
Fix class_uses polyfill

### DIFF
--- a/src/Php54/bootstrap.php
+++ b/src/Php54/bootstrap.php
@@ -16,7 +16,14 @@ if (PHP_VERSION_ID < 50400) {
         function trait_exists($class, $autoload = true) { return $autoload && class_exists($class, $autoload) && false; }
     }
     if (!function_exists('class_uses')) {
-        function class_uses($class, $autoload = true) { return $autoload && class_exists($class, $autoload) && false; }
+        function class_uses($class, $autoload = true)
+        {
+            if (is_object($class) || class_exists($class, $autoload) || interface_exists($class, false)) {
+                return array();
+            }
+
+            return false;
+        }
     }
     if (!function_exists('hex2bin')) {
         function hex2bin($data) { return p\Php54::hex2bin($data); }

--- a/tests/Php54/Php54Test.php
+++ b/tests/Php54/Php54Test.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Php54;
+
+class Php54Test extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideClassUsesValid
+     */
+    public function testClassUsesValid($classOrObject)
+    {
+        $this->assertSame(array(), class_uses($classOrObject));
+    }
+
+    public function provideClassUsesValid()
+    {
+        return array(
+            array('stdClass'),
+            array(new \stdClass()),
+            array('Iterator'),
+        );
+    }
+
+    public function testClassUsesInvalid()
+    {
+        $this->assertFalse(@class_uses('NotDefined'));
+    }
+}


### PR DESCRIPTION
`class_uses` accepts both the class name and object instance as first argument, `class_exists` only accepts a class name. If an object instance is giving, the class is already autoloaded, so the other logic can be skipped.