### PR TITLE
Add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+* v1.1.1
+
+ * bug #40 [Apcu] Load APCUIterator only when APCIterator exists (nicolas-grekas)
+ * bug #37 [Iconv] Fix wrong use in bootstrap.php (tucksaun)
+ * bug #31 Fix class_uses polyfill (WouterJ)
+
+* v1.1.0
+
+ * feature #22 [APCu] A new polyfill for the legacy APC users (nicolas-grekas)
+ * bug #28 [Php70] Workaround https://bugs.php.net/63206 (nicolas-grekas)
+
+* v1.0.1
+
+ * bug #14 ldap_escape does not encode leading/trailing spaces. (ChadSikorra)
+ * bug #17 Fix #16 - gzopen() / gzopen64() - 32 bit builds of Ubuntu 14.04 (fisharebest)
+
+* v1.0.0
+
+ * Hello symfony/polyfill


### PR DESCRIPTION
Fixes #32 

* v1.1.1

 * bug #40 [Apcu] Load APCUIterator only when APCIterator exists (nicolas-grekas)
 * bug #37 [Iconv] Fix wrong use in bootstrap.php (tucksaun)
 * bug #31 Fix class_uses polyfill (WouterJ)

* v1.1.0

 * feature #22 [APCu] A new polyfill for the legacy APC users (nicolas-grekas)
 * bug #28 [Php70] Workaround https://bugs.php.net/63206 (nicolas-grekas)

* v1.0.1

 * bug #14 ldap_escape does not encode leading/trailing spaces. (ChadSikorra)
 * bug #17 Fix #16 - gzopen() / gzopen64() - 32 bit builds of Ubuntu 14.04 (fisharebest)

* v1.0.0

 * Hello symfony/polyfill