### PR TITLE
Fix hex2bin return null

### DIFF
--- a/src/Php54/Php54.php
+++ b/src/Php54/Php54.php
@@ -33,10 +33,6 @@ final class Php54
 
         $data = pack('H*', $data);
 
-        if (false !== strpos($data, "\0")) {
-            return false;
-        }
-
         return $data;
     }
 }

--- a/src/Php54/Php54.php
+++ b/src/Php54/Php54.php
@@ -31,8 +31,6 @@ final class Php54
             return false;
         }
 
-        $data = pack('H*', $data);
-
-        return $data;
+        return pack('H*', $data);
     }
 }

--- a/tests/Php54/Php54Test.php
+++ b/tests/Php54/Php54Test.php
@@ -35,13 +35,15 @@ class Php54Test extends \PHPUnit_Framework_TestCase
         $this->assertFalse(@class_uses('NotDefined'));
     }
 
-    public function testHexDecode()
+    public function testHexToBinValid()
     {
-        $php54 = new \Symfony\Polyfill\Php54\Php54;
-        // issue #48: hex2bin() returns false if nul byte present
-        $this->assertEquals(
-            "\x61\x62\x00\x63\x64",
-            $php54->hex2bin("6162006364")
-		);
+        $this->assertEquals("\x61\x62\x00\x63\x64", hex2bin("6162006364")); // With null byte, see #48
+        $this->assertEquals("\x61\x62\x63\x64", hex2bin("61626364"));
+    }
+
+    public function testHexToBinInvalid()
+    {
+        $this->assertNull(@hex2bin(array())); // Invalid type 
+        $this->assertFalse(@hex2bin("123")); // Invalid string length
     }
 }

--- a/tests/Php54/Php54Test.php
+++ b/tests/Php54/Php54Test.php
@@ -37,7 +37,7 @@ class Php54Test extends \PHPUnit_Framework_TestCase
 
     public function testHexToBinValid()
     {
-        $this->assertEquals("\x61\x62\x00\x63\x64", hex2bin("6162006364")); // With null byte, see #48
+        $this->assertEquals("\x61\x62\x00\x63\x64", hex2bin("6162006364")); // With null byte
         $this->assertEquals("\x61\x62\x63\x64", hex2bin("61626364"));
     }
 

--- a/tests/Php54/Php54Test.php
+++ b/tests/Php54/Php54Test.php
@@ -34,4 +34,14 @@ class Php54Test extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse(@class_uses('NotDefined'));
     }
+
+    public function testHexDecode()
+    {
+        $php54 = new \Symfony\Polyfill\Php54\Php54;
+        // issue #48: hex2bin() returns false if nul byte present
+        $this->assertEquals(
+            "\x61\x62\x00\x63\x64",
+            $php54->hex2bin("6162006364")
+		);
+    }
 }


### PR DESCRIPTION
Fixes the hex2bin implementation as per #47/#48.
This supersedes https://github.com/symfony/polyfill/pull/48.