### PR TITLE
Allow paragonie/random_compat 2 in the php 7 subpackage as well

### DIFF
--- a/src/Php70/composer.json
+++ b/src/Php70/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "paragonie/random_compat": "~1.0"
+        "paragonie/random_compat": "~1.0|~2.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Php70\\": "" },


### PR DESCRIPTION
Greetings from the Symfony Live Cologne Hackday. :-)

This is a followup to the merged PR #44. I have added `"paragonie/random_compat": "~1.0|~2.0"` to the composer.json file of the `Php70` subpackage. Currently, only the full polyfill package allows version 2 of that library while the subpackage sill indicated compatibility with version 1 only.