### PR TITLE
Add proper provides rules for mbstring and iconv polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,10 @@
         "paragonie/random_compat": "~1.0|~2.0",
         "symfony/intl": "~2.3|~3.0"
     },
+    "provide": {
+        "ext-iconv": "7",
+        "ext-mbstring": "7"
+    },
     "replace": {
         "symfony/polyfill-apcu": "self.version",
         "symfony/polyfill-php54": "self.version",

--- a/src/Iconv/composer.json
+++ b/src/Iconv/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "provide": {
+        "ext-iconv": "7"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Iconv\\": "" },
         "files": [ "bootstrap.php" ]

--- a/src/Mbstring/composer.json
+++ b/src/Mbstring/composer.json
@@ -16,7 +16,11 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "ext-iconv": "*"
+    },
+    "provide": {
+        "ext-mbstring": "7"
     },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Mbstring\\": "" },


### PR DESCRIPTION
Once https://github.com/composer/composer/issues/5030 is resolved, this will allow to install `symfony/polyfill-mbstring` in a project and having it fulfill a ext-mbstring requirement set by another library not aware of the polyfill.
Without the bug fix, things work already when installing the polyfill from a VCS repo rather than from Packagist or when the polyfill was already installed locally (the bug is on Packagist side when loading metadata).
This would avoid having to do things like https://github.com/beberlei/assert/pull/149 which forces any project using the library to install the polyfill even if they expect to always run with ext-mbstring available (the library could just continue to require ext-mbstring and projects may then choose to require the polyfill to fulfill the dependency)
