### PR TITLE
Normalizer::decompose() should reorder "recursive" combining chars

### DIFF
--- a/src/Intl/Normalizer/Normalizer.php
+++ b/src/Intl/Normalizer/Normalizer.php
@@ -223,26 +223,10 @@ class Normalizer
             $uchr = substr($s, $i, $ulen);
             $i += $ulen;
 
-            if (isset($combClass[$uchr])) {
-                // Combining chars, for sorting
-
-                if (!isset($c[$combClass[$uchr]])) {
-                    $c[$combClass[$uchr]] = '';
-                }
-                $c[$combClass[$uchr]] .= isset($compatMap[$uchr]) ? $compatMap[$uchr] : (isset($decompMap[$uchr]) ? $decompMap[$uchr] : $uchr);
-                continue;
-            }
-            if ($c) {
-                ksort($c);
-                $result .= implode('', $c);
-                $c = array();
-            }
             if ($uchr < "\xEA\xB0\x80" || "\xED\x9E\xA3" < $uchr) {
                 // Table lookup
 
-                $j = isset($compatMap[$uchr]) ? $compatMap[$uchr] : (isset($decompMap[$uchr]) ? $decompMap[$uchr] : $uchr);
-
-                if ($uchr != $j) {
+                if ($uchr !== $j = isset($compatMap[$uchr]) ? $compatMap[$uchr] : (isset($decompMap[$uchr]) ? $decompMap[$uchr] : $uchr)) {
                     $uchr = $j;
 
                     $j = strlen($uchr);
@@ -267,6 +251,15 @@ class Normalizer
                         $uchr = substr($uchr, 0, $ulen);
                     }
                 }
+                if (isset($combClass[$uchr])) {
+                    // Combining chars, for sorting
+
+                    if (!isset($c[$combClass[$uchr]])) {
+                        $c[$combClass[$uchr]] = '';
+                    }
+                    $c[$combClass[$uchr]] .= $uchr;
+                    continue;
+                }
             } else {
                 // Hangul chars
 
@@ -281,6 +274,11 @@ class Normalizer
                         ? ("\xE1\x86".chr(0xA7 + $j))
                         : ("\xE1\x87".chr(0x67 + $j));
                 }
+            }
+            if ($c) {
+                ksort($c);
+                $result .= implode('', $c);
+                $c = array();
             }
 
             $result .= $uchr;

--- a/tests/Intl/Normalizer/NormalizerTest.php
+++ b/tests/Intl/Normalizer/NormalizerTest.php
@@ -83,6 +83,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(normalizer_normalize("\xFF"));
 
         $this->assertSame("\xcc\x83\xc3\x92\xd5\x9b", normalizer_normalize("\xcc\x83\xc3\x92\xd5\x9b"));
+        $this->assertSame("\xe0\xbe\xb2\xe0\xbd\xb1\xe0\xbe\x80\xe0\xbe\x80", normalizer_normalize("\xe0\xbd\xb6\xe0\xbe\x81", pn::NFD));
     }
 
     /**


### PR DESCRIPTION
Fix #56