### PR TITLE
Silence iconv_strlen() in mb_strlen() polyfill

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -339,7 +339,7 @@ final class Mbstring
                 return strlen($s);
         }
 
-        return iconv_strlen($s, $encoding);
+        return @iconv_strlen($s, $encoding);
     }
 
     public static function mb_strpos($haystack, $needle, $offset = 0, $encoding = null)


### PR DESCRIPTION
Polyfilling the behavior in erroneous situation is going to be too much work for today,
yet, by silencing, we at least prevent custom error handlers from throwing exceptions here (like phpunit's when running tests).