### PR TITLE
use phpseclib/mcrypt_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.3",
         "ircmaxell/password-compat": "~1.0",
         "paragonie/random_compat": "~1.0|~2.0",
+        "phpseclib/mcrypt_compat": "~1.0",
         "symfony/intl": "~2.3|~3.0"
     },
     "replace": {


### PR DESCRIPTION
The fact that mcrypt, as an extension, is becoming less and less common on hosts, there is also an accepted RFC to deprecate mcrypt on PHP 7.1 and to remove it all together in the next major release: https://wiki.php.net/rfc/mcrypt-viking-funeral .