### PR TITLE
[Php70] Add random_bytes() and random_int()

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,8 @@ Polyfills are provided for:
 - the `password_hash` and `password_*` related functions introduced in PHP 5.5,
   provided by the `ircmaxell/password-compat` package;
 - the `hash_equals` and `ldap_escape` functions introduced in PHP 5.6;
-- the `*Error` classes, the `error_clear_last`, `preg_replace_callback_array` and
-  `intdiv` functions introduced in PHP 7.0;
-- the `random_bytes` and `random_int` functions introduced in PHP 7.0,
-  provided by the `paragonie/random_compat` package;
+- the `*Error` classes, the `error_clear_last`, `preg_replace_callback_array`,
+  `random_bytes`, `random_int` and `intdiv` functions introduced in PHP 7.0;
 - a `Binary` utility class to be used when compatibility with
   `mbstring.func_overload` is required.
 

--- a/src/Php70/Php70Random.php
+++ b/src/Php70/Php70Random.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Php70;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class Php70Random
+{
+    private static $rngSrc;
+    private static $rngHandle;
+
+    public static function random_bytes($length)
+    {
+        $length = Php70::intArg($length, __FUNCTION__, 1);
+
+        if (0 >= $length) {
+            throw new \Error('Length must be greater than 0');
+        }
+
+        if (null === self::$rngSrc) {
+            self::$rngSrc = '';
+            switch (true) {
+                case function_exists('mcrypt_create_iv') && (DIRECTORY_SEPARATOR !== '/' || PHP_VERSION_ID < 50610 || 50612 < PHP_VERSION_ID): self::$rngSrc = 'mcrypt'; break;
+                case function_exists('Sodium\randombytes_buf'): self::$rngSrc = 'sodium02'; break;
+                case method_exists('Sodium', 'randombytes_buf'): self::$rngSrc = 'sodium01'; break;
+                default:
+                    if ('\\' !== DIRECTORY_SEPARATOR && $h = @fopen('/dev/urandom', 'rb')) {
+                        $stat = fstat($h);
+                        if (020000 === ($stat['mode'] & 0170000)) {
+                            if (function_exists('stream_set_read_buffer')) {
+                                stream_set_read_buffer($h, 0);
+                            }
+                            self::$rngHandle = $h;
+                            self::$rngSrc = 'urandom';
+                        }
+                    }
+            }
+        }
+
+        switch (self::$rngSrc) {
+            case 'mcrypt': $bytes = @mcrypt_create_iv($length, MCRYPT_DEV_URANDOM); break;
+            case 'sodium02': $bytes = \Sodium\randombytes_buf($length); break;
+            case 'sodium01': $bytes = \Sodium::randombytes_buf($length); break;
+            case 'urandom': $bytes = fread(self::$rngHandle, $length); break;
+            default:
+                throw new \Exception('Cannot open source device');
+        }
+
+        if (!isset($bytes[$length - 1])) {
+            throw new \Exception('Could not gather sufficient random data');
+        }
+
+        return $bytes;
+    }
+
+    public static function random_int($min, $max)
+    {
+        $min = Php70::intArg($min, __FUNCTION__, 1);
+        $max = Php70::intArg($max, __FUNCTION__, 2);
+
+        if ($max < $min) {
+            throw new \Error('Minimum value must be less than or equal to the maximum value');
+        }
+        if ($min === $max) {
+            return $min;
+        }
+
+        if (is_float($range = $max - $min)) {
+            $bitmask = -1;
+            $offset = 0;
+        } else {
+            $bitmask = ~(-1 << strlen(decbin($range)));
+            $offset = $min;
+        }
+        $try = 128;
+
+        do {
+            $rand = self::random_bytes(PHP_INT_SIZE);
+            $result = ord($rand[0]);
+            for ($i = 1; $i < PHP_INT_SIZE; ++$i) {
+                $result = ($result << 8) | ord($rand[$i]);
+            }
+            $result &= $bitmask;
+            $result += $offset;
+        } while (($result > $max || $min > $result) && $try--);
+
+        if (!$try) {
+            throw new \Exception('Could not gather sufficient random data');
+        }
+
+        return $result;
+    }
+}

--- a/src/Php70/bootstrap.php
+++ b/src/Php70/bootstrap.php
@@ -21,4 +21,8 @@ if (PHP_VERSION_ID < 70000) {
     if (!function_exists('error_clear_last')) {
         function error_clear_last() { return p\Php70::error_clear_last(); }
     }
+    if (!function_exists('random_bytes')) {
+        function random_bytes($length) { return p\Php70Random::random_bytes($length); }
+        function random_int($min, $max) { return p\Php70Random::random_int($min, $max); }
+    }
 }

--- a/tests/Php70/Php70RandomTest.php
+++ b/tests/Php70/Php70RandomTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Paragon Initiative Enterprises
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.This file is part of the Symfony package.
+ *
+ */
+
+namespace Symfony\Polyfill\Tests\Php70;
+
+/**
+ * Test cases are borrowed from https://github.com/paragonie/random_compat
+ */
+class Php70RandomTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRandomBytesOutput()
+    {
+        $bytes = array(
+            random_bytes(12),
+            random_bytes(64),
+            random_bytes(64)
+        );
+
+        $this->assertTrue(strlen(bin2hex($bytes[0])) === 24);
+
+        // This should never generate identical byte strings
+        $this->assertFalse(
+            $bytes[1] === $bytes[2]
+        );
+    }
+
+    /**
+     * @requires function gzcompress
+     */
+    public function testRandomBytesCompressionRatios()
+    {
+        $bytes = random_bytes(65536);
+
+        $this->assertSame(65536, strlen($bytes));
+        $compressed = gzcompress($bytes, 9);
+        $length = strlen($compressed);
+
+        $this->assertTrue(65000 <= $length && $length <= 67000);
+    }
+
+    /**
+     * @expectedException TypeError
+     * @expectedExceptionMessage random_bytes() expects parameter 1 to be integer
+     */
+    public function testRandomBytesTypeError()
+    {
+        random_bytes(PHP_INT_MAX + 1);
+    }
+
+    /**
+     * @expectedException Error
+     * @expectedExceptionMessage Length must be greater than 0
+     */
+    public function testRandomBytesLengthError()
+    {
+        random_bytes(0);
+    }
+
+    /**
+     * All possible values should be > 30% but less than 170%
+     *
+     * This also catches 0 and 1000
+     */
+    public function testRandomIntDistribution()
+    {
+        $integers = array_fill(0, 100, 0);
+        for ($i = 0; $i < 10000; ++$i) {
+            ++$integers[random_int(0,99)];
+        }
+        for ($i = 0; $i < 100; ++$i) {
+            $this->assertFalse($integers[$i] < 30);
+            $this->assertFalse($integers[$i] > 170);
+        }
+    }
+
+    /**
+     * This should be between 55% and 75%, always
+     */
+    public function testRandomIntCoverage()
+    {
+        $integers = array_fill(0, 2000, 0);
+        for ($i = 0; $i < 2000; ++$i) {
+            ++$integers[random_int(0,1999)];
+        }
+        $coverage = 0;
+        for ($i = 0; $i < 2000; ++$i) {
+            if ($integers[$i] > 0) {
+                ++$coverage;
+            }
+        }
+        $this->assertTrue($coverage >= 1150);
+        $this->assertTrue($coverage <= 1350);
+    }
+
+    public function testRandomInt()
+    {
+        $half_neg_max = (~PHP_INT_MAX / 2);
+        $integers = array(
+            random_int(0, 1000),
+            random_int(1001,2000),
+            random_int(-100, -10),
+            random_int(-1000, 1000),
+            random_int(~PHP_INT_MAX, PHP_INT_MAX),
+            random_int("0", "1"),
+            random_int(0.11111, 0.99999),
+            random_int($half_neg_max, PHP_INT_MAX),
+            random_int(0.0, 255.0),
+            random_int(-4.5, -4.5),
+            random_int("1337e3","1337e3")
+        );
+
+        $this->assertFalse($integers[0] === $integers[1]);
+        $this->assertTrue($integers[0] >= 0 && $integers[0] <= 1000);
+        $this->assertTrue($integers[1] >= 1001 && $integers[1] <= 2000);
+        $this->assertTrue($integers[2] >= -100 && $integers[2] <= -10);
+        $this->assertTrue($integers[3] >= -1000 && $integers[3] <= 1000);
+        $this->assertTrue($integers[4] >= ~PHP_INT_MAX && $integers[4] <= PHP_INT_MAX);
+        $this->assertTrue($integers[5] >= 0 && $integers[5] <= 1);
+        $this->assertTrue($integers[6] === 0);
+        $this->assertTrue($integers[7] >= $half_neg_max && $integers[7] <= PHP_INT_MAX);
+        $this->assertTrue($integers[8] >= 0 && $integers[8] <= 255);
+        $this->assertTrue($integers[9] === -4);
+        $this->assertTrue($integers[10] === 1337000);
+    }
+
+    public function testRandomIntRange()
+    {
+        $try = 64;
+        $maxLen = strlen(~PHP_INT_MAX);
+        do {
+            $rand = random_int(~PHP_INT_MAX, PHP_INT_MAX);
+        } while (strlen($rand) !== $maxLen && $try--);
+
+        $this->assertGreaterThan(0, $try);
+    }
+
+    /**
+     * @expectedException Error
+     * @expectedExceptionMessage Minimum value must be less than or equal to the maximum value
+     */
+    public function testRandomIntSwappedError()
+    {
+        random_int("0", "-1");
+    }
+
+    /**
+     * @expectedException TypeError
+     * @expectedExceptionMessage random_int() expects parameter 2 to be integer, float given
+     */
+    public function provideRandomIntError()
+    {
+        random_int(~PHP_INT_MAX, ~PHP_INT_MAX + 0.0);
+    }
+}


### PR DESCRIPTION
This is for reference only so that one can see what it would be like to implement these function directly in our Php70 polyfill.
Looks much less convoluted than paragonie/random_compat (because of PHP 5.2 compat).
Yet, it's better to play nice with the community as a whole.