### PR TITLE
Added PHP_INT_MIN constant

### DIFF
--- a/src/Php70/bootstrap.php
+++ b/src/Php70/bootstrap.php
@@ -12,6 +12,7 @@
 use Symfony\Polyfill\Php70 as p;
 
 if (PHP_VERSION_ID < 70000) {
+    define('PHP_INT_MIN', ~PHP_INT_MAX);
     if (!function_exists('intdiv')) {
         function intdiv($dividend, $divisor) { return p\Php70::intdiv($dividend, $divisor); }
     }

--- a/src/Php70/bootstrap.php
+++ b/src/Php70/bootstrap.php
@@ -12,7 +12,9 @@
 use Symfony\Polyfill\Php70 as p;
 
 if (PHP_VERSION_ID < 70000) {
-    define('PHP_INT_MIN', ~PHP_INT_MAX);
+    if (!defined('PHP_INT_MIN')) {
+        define('PHP_INT_MIN', ~PHP_INT_MAX);
+    }
     if (!function_exists('intdiv')) {
         function intdiv($dividend, $divisor) { return p\Php70::intdiv($dividend, $divisor); }
     }

--- a/tests/Php70/Php70Test.php
+++ b/tests/Php70/Php70Test.php
@@ -16,6 +16,7 @@ class Php70Test extends \PHPUnit_Framework_TestCase
     public function testPhpIntMin()
     {
         $this->assertTrue(defined('PHP_INT_MIN'));
+        $this->assertSame(~PHP_INT_MAX, PHP_INT_MIN);
     }
 
     /**

--- a/tests/Php70/Php70Test.php
+++ b/tests/Php70/Php70Test.php
@@ -18,7 +18,6 @@ class Php70Test extends \PHPUnit_Framework_TestCase
         $this->assertTrue(defined('PHP_INT_MIN'));
     }
 
-
     /**
      * @dataProvider provideIntdiv
      */

--- a/tests/Php70/Php70Test.php
+++ b/tests/Php70/Php70Test.php
@@ -13,6 +13,12 @@ namespace Symfony\Polyfill\Tests\Php70;
 
 class Php70Test extends \PHPUnit_Framework_TestCase
 {
+    public function testPhpIntMin()
+    {
+        $this->assertTrue(defined('PHP_INT_MIN'));
+    }
+
+
     /**
      * @dataProvider provideIntdiv
      */


### PR DESCRIPTION
The `PHP_INT_MIN` constant is available in PHP 7.0.0 onwards but not in any previous release. Seems like an oversight since that value is constantly being created in the test cases. However, I did not change those since we should not rely on code that is being tested.