### PR TITLE
Feature/if exists

### DIFF
--- a/src/Intl/Icu/bootstrap.php
+++ b/src/Intl/Icu/bootstrap.php
@@ -12,8 +12,17 @@
 use Symfony\Component\Intl\Globals\IntlGlobals;
 
 if (!function_exists('intl_is_failure')) {
-    function intl_is_failure($errorCode) { return IntlGlobals::isFailure($errorCode); }
-    function intl_get_error_code() { return IntlGlobals::getErrorCode(); }
-    function intl_get_error_message() { return IntlGlobals::getErrorMessage(); }
-    function intl_error_name($errorCode) { return IntlGlobals::getErrorName($errorCode); }
+	function intl_is_failure($errorCode) { return IntlGlobals::isFailure($errorCode); }
+}
+
+if(!function_exists('intl_get_error_code')) {
+	function intl_get_error_code() { return IntlGlobals::getErrorCode(); }
+}
+
+if(!function_exists('intl_get_error_message')) {
+	function intl_get_error_message() { return IntlGlobals::getErrorMessage(); }
+}
+
+if(!function_exists('intl_error_name')) {
+	function intl_error_name($errorCode) { return IntlGlobals::getErrorName($errorCode); }
 }

--- a/src/Php70/Resources/stubs/ArithmeticError.php
+++ b/src/Php70/Resources/stubs/ArithmeticError.php
@@ -1,5 +1,7 @@
 <?php
 
-class ArithmeticError extends Error
-{
+if(!class_exists('ArithmeticError')) {
+	class ArithmeticError extends Error
+	{
+	}
 }

--- a/src/Php70/Resources/stubs/AssertionError.php
+++ b/src/Php70/Resources/stubs/AssertionError.php
@@ -1,5 +1,7 @@
 <?php
 
-class AssertionError extends Error
-{
+if(!class_exists('AssertionError')) {
+	class AssertionError extends Error
+	{
+	}
 }

--- a/src/Php70/Resources/stubs/DivisionByZeroError.php
+++ b/src/Php70/Resources/stubs/DivisionByZeroError.php
@@ -1,5 +1,7 @@
 <?php
 
-class DivisionByZeroError extends Error
-{
+if(!class_exists('DivisionByZeroError')) {
+	class DivisionByZeroError extends Error
+	{
+	}
 }

--- a/src/Php70/Resources/stubs/Error.php
+++ b/src/Php70/Resources/stubs/Error.php
@@ -1,5 +1,7 @@
 <?php
 
-class Error extends Exception
-{
+if(!class_exists('Error')) {
+	class Error extends Exception
+	{
+	}
 }

--- a/src/Php70/Resources/stubs/ParseError.php
+++ b/src/Php70/Resources/stubs/ParseError.php
@@ -1,5 +1,7 @@
 <?php
 
-class ParseError extends Error
-{
+if(!class_exists('ParseError')) {
+	class ParseError extends Error
+	{
+	}
 }

--- a/src/Php70/Resources/stubs/TypeError.php
+++ b/src/Php70/Resources/stubs/TypeError.php
@@ -1,5 +1,7 @@
 <?php
 
-class TypeError extends Error
-{
+if(!class_exists('TypeError')) {
+	class TypeError extends Error
+	{
+	}
 }


### PR DESCRIPTION
Hi.
Thank you for the great libraries and code first :) My pool request is a little tweak for this code.

I developing a WordPress plugin for wp.org which uses a lot of Symfony components. And I have a trouble when deploying my code into wp.org plugins directory. The problem appears every time when I commiting to wp-org. It simply not allows me to make a commit actually 😀 This happens because wp-org and their SVN repo run `php -l` command for each file in commit while you commiting. And since vendor folder contains files and classes like `ArithmeticError.php` — this triggering error. Just PHP 7 already have `ArithmeticError` class and there is no `if class exists` check for all of this classes and methods.

Please allow me deploying :) Right now I make this changes manually every time when I'm deploying.

And by the way. Here is plugin that I'm talking about: https://wordpress.org/plugins/setka-editor/
The source code with fixed stubs: https://plugins.trac.wordpress.org/browser/setka-editor/tags/1.7.9/vendor/symfony/polyfill-php70/Resources/stubs/