### PR TITLE
PHP 7.2 - boost bootstrap

### DIFF
--- a/src/Php72/bootstrap.php
+++ b/src/Php72/bootstrap.php
@@ -11,13 +11,15 @@
 
 use Symfony\Polyfill\Php72 as p;
 
-if ('\\' === DIRECTORY_SEPARATOR && !function_exists('sapi_windows_vt100_support')) {
-    function sapi_windows_vt100_support() { return false; }
-}
-if (!function_exists('stream_isatty')) {
-    function stream_isatty($stream) { return function_exists('posix_isatty') && @posix_isatty($stream); }
-}
-if (!function_exists('utf8_encode')) {
-    function utf8_encode($s) { return p\Php72::utf8_encode($s); }
-    function utf8_decode($s) { return p\Php72::utf8_decode($s); }
+if (PHP_VERSION_ID < 70200) {
+    if ('\\' === DIRECTORY_SEPARATOR && !function_exists('sapi_windows_vt100_support')) {
+        function sapi_windows_vt100_support() { return false; }
+    }
+    if (!function_exists('stream_isatty')) {
+        function stream_isatty($stream) { return function_exists('posix_isatty') && @posix_isatty($stream); }
+    }
+    if (!function_exists('utf8_encode')) {
+        function utf8_encode($s) { return p\Php72::utf8_encode($s); }
+        function utf8_decode($s) { return p\Php72::utf8_decode($s); }
+    }
 }


### PR DESCRIPTION
all polyfills bootstrap checks PHP ver itself before trying to register polyfills, for 7.2 it;s missing