### PR TITLE
Fix the readme content

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Polyfills are provided for:
 - the `*Error` classes, the `error_clear_last`, `preg_replace_callback_array` and
   `intdiv` functions introduced in PHP 7.0;
 - the `random_bytes` and `random_int` functions introduced in PHP 7.0,
+  provided by the `paragonie/random_compat` package;
 - the `PHP_INT_MIN` constant introduced in PHP 7.0,
 - the `is_iterable` function introduced in PHP 7.1;
-  provided by the `paragonie/random_compat` package;
 - a `Binary` utility class to be used when compatibility with
   `mbstring.func_overload` is required;
 - the `stream_isatty` function introduced in PHP 7.2;


### PR DESCRIPTION
#89 reordered some lines, but it did not keep both lines about `random_bytes` together