### PR TITLE
[7.2] Add polyfill for spl_object_id()

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Polyfills are provided for:
 - the `is_iterable` function introduced in PHP 7.1;
 - a `Binary` utility class to be used when compatibility with
   `mbstring.func_overload` is required;
-- the `stream_isatty` function introduced in PHP 7.2;
+- the `spl_object_id` and `stream_isatty` functions introduced in PHP 7.2;
 - the `sapi_windows_vt100_support` function (Windows only) introduced in PHP 7.2;
 - the `PHP_OS_FAMILY` constant introduced in PHP 7.2.
 

--- a/src/Php72/Php72.php
+++ b/src/Php72/Php72.php
@@ -19,6 +19,8 @@ namespace Symfony\Polyfill\Php72;
  */
 final class Php72
 {
+    private static $hashMask;
+
     public static function utf8_encode($s)
     {
         $s .= $s;
@@ -79,5 +81,39 @@ final class Php72
         );
 
         return isset($map[PHP_OS]) ? $map[PHP_OS] : 'Unknown';
+    }
+
+    public static function spl_object_id($object)
+    {
+        if (null === self::$hashMask) {
+            self::initHashMask();
+        }
+        if (null === $hash = spl_object_hash($object)) {
+            return;
+        }
+
+        return self::$hashMask ^ hexdec(substr($hash, 16 - \PHP_INT_SIZE, \PHP_INT_SIZE));
+    }
+
+    private static function initHashMask()
+    {
+        $obj = (object) array();
+        self::$hashMask = -1;
+
+        // check if we are nested in an output buffering handler to prevent a fatal error with ob_start() below
+        $obFuncs = array('ob_clean', 'ob_end_clean', 'ob_flush', 'ob_end_flush', 'ob_get_contents', 'ob_get_flush');
+        foreach (debug_backtrace(\PHP_VERSION_ID >= 50400 ? DEBUG_BACKTRACE_IGNORE_ARGS : false) as $frame) {
+            if (isset($frame['function'][0]) && !isset($frame['class']) && 'o' === $frame['function'][0] && in_array($frame['function'], $obFuncs)) {
+                $frame['line'] = 0;
+                break;
+            }
+        }
+        if (!empty($frame['line'])) {
+            ob_start();
+            debug_zval_dump($obj);
+            self::$hashMask = (int) substr(ob_get_clean(), 17);
+        }
+
+        self::$hashMask ^= hexdec(substr(spl_object_hash($obj), 16 - \PHP_INT_SIZE, \PHP_INT_SIZE));
     }
 }

--- a/src/Php72/README.md
+++ b/src/Php72/README.md
@@ -3,6 +3,7 @@ Symfony Polyfill / Php72
 
 This component provides functions added to PHP 7.2 core:
 
+- [`spl_object_id`](https://php.net/spl_object_id)
 - [`stream_isatty`](https://php.net/stream_isatty)
 
 On Windows only:

--- a/src/Php72/bootstrap.php
+++ b/src/Php72/bootstrap.php
@@ -22,6 +22,9 @@ if (PHP_VERSION_ID < 70200) {
         function utf8_encode($s) { return p\Php72::utf8_encode($s); }
         function utf8_decode($s) { return p\Php72::utf8_decode($s); }
     }
+    if (!function_exists('spl_object_id')) {
+        function spl_object_id($s) { return p\Php72::spl_object_id($s); }
+    }
     if (!defined('PHP_OS_FAMILY')) {
         define('PHP_OS_FAMILY', p\Php72::php_os_family());
     }

--- a/tests/Php72/Php72Test.php
+++ b/tests/Php72/Php72Test.php
@@ -48,4 +48,20 @@ class Php72Test extends \PHPUnit_Framework_TestCase
           $this->assertTrue(defined('PHP_OS_FAMILY'));
           $this->assertSame(PHP_OS_FAMILY, p::php_os_family());
     }
+
+    /**
+     * @covers Symfony\Polyfill\Php72\Php72::spl_object_id
+     */
+    public function testSplObjectId()
+    {
+        $obj = new \stdClass();
+        $id = spl_object_id($obj);
+        ob_start();
+        var_dump($obj);
+        $dump = ob_get_clean();
+
+        $this->assertStringStartsWith("object(stdClass)#$id ", $dump);
+
+        $this->assertNull(@spl_object_id(123));
+    }
 }


### PR DESCRIPTION
As [discussed on php-internals](https://externals.io/message/99751) and implemented in https://github.com/php/php-src/pull/2611.
Implementation [borrowed from VarDumper](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/VarDumper/Cloner/VarCloner.php#L300).