### PR TITLE
Use the old precise environment for PHP 5.3 jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 matrix:
     include:
         - php: 5.3
+          dist: precise
         - php: 5.4
         - php: 5.5
         - php: 5.6


### PR DESCRIPTION
Travis does not provide PHP 5.3 anymore on Trusty.