### PR TITLE
Add logic to new stream functions on Windows

### DIFF
--- a/src/Php72/Php72.php
+++ b/src/Php72/Php72.php
@@ -95,6 +95,35 @@ final class Php72
         return self::$hashMask ^ hexdec(substr($hash, 16 - \PHP_INT_SIZE, \PHP_INT_SIZE));
     }
 
+    public static function sapi_windows_vt100_support($stream, $enable = null)
+    {
+        // We cannot actually enable vt100 support
+        if (true === $enable || !self::stream_isatty($stream)) {
+            return false;
+        }
+
+        // The native function does not apply to stdin
+        $meta = array_map('strtolower', stream_get_meta_data($stream));
+        $stdin = 'php://stdin' === $meta['uri'] || 'php://fd/0' === $meta['uri'];
+
+        return !$stdin
+            && (false !== getenv('ANSICON')
+            || 'ON' === getenv('ConEmuANSI')
+            || 'xterm' === getenv('TERM')
+            || 'cygwin' === getenv('TERM'));
+    }
+
+    public static function stream_isatty($stream)
+    {
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $stat = @fstat($stream);
+            // Check if formatted mode is S_IFCHR
+            return $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
+        }
+
+        return function_exists('posix_isatty') && @posix_isatty($stream);
+    }
+
     private static function initHashMask()
     {
         $obj = (object) array();

--- a/src/Php72/Php72.php
+++ b/src/Php72/Php72.php
@@ -97,8 +97,8 @@ final class Php72
 
     public static function sapi_windows_vt100_support($stream, $enable = null)
     {
-        // We cannot actually enable vt100 support
-        if (true === $enable || !self::stream_isatty($stream)) {
+        // We cannot actually disable vt100 support if it is set
+        if (false === $enable || !self::stream_isatty($stream)) {
             return false;
         }
 

--- a/src/Php72/Php72.php
+++ b/src/Php72/Php72.php
@@ -109,8 +109,7 @@ final class Php72
         return !$stdin
             && (false !== getenv('ANSICON')
             || 'ON' === getenv('ConEmuANSI')
-            || 'xterm' === getenv('TERM')
-            || 'cygwin' === getenv('TERM'));
+            || 'xterm' === getenv('TERM'));
     }
 
     public static function stream_isatty($stream)

--- a/src/Php72/bootstrap.php
+++ b/src/Php72/bootstrap.php
@@ -13,10 +13,10 @@ use Symfony\Polyfill\Php72 as p;
 
 if (PHP_VERSION_ID < 70200) {
     if ('\\' === DIRECTORY_SEPARATOR && !function_exists('sapi_windows_vt100_support')) {
-        function sapi_windows_vt100_support() { return false; }
+        function sapi_windows_vt100_support($stream, $enable = null) { return p\Php72::sapi_windows_vt100_support($stream, $enable); }
     }
     if (!function_exists('stream_isatty')) {
-        function stream_isatty($stream) { return function_exists('posix_isatty') && @posix_isatty($stream); }
+        function stream_isatty($stream) { return p\Php72::stream_isatty($stream); }
     }
     if (!function_exists('utf8_encode')) {
         function utf8_encode($s) { return p\Php72::utf8_encode($s); }

--- a/tests/Php72/Php72Test.php
+++ b/tests/Php72/Php72Test.php
@@ -74,7 +74,7 @@ class Php72Test extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Windows only test');
         }
 
-        $this->assertFalse(p::sapi_windows_vt100_support(STDOUT, false));
+        $this->assertFalse(sapi_windows_vt100_support(STDIN, true));
     }
 
     /**
@@ -83,7 +83,7 @@ class Php72Test extends \PHPUnit_Framework_TestCase
     public function testStreamIsatty()
     {
         $fp = fopen('php://temp', 'r+');
-        $this->assertFalse(p::stream_isatty($fp));
+        $this->assertFalse(stream_isatty($fp));
         fclose($fp);
     }
 }

--- a/tests/Php72/Php72Test.php
+++ b/tests/Php72/Php72Test.php
@@ -74,7 +74,7 @@ class Php72Test extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Windows only test');
         }
 
-        $this->assertFalse(p::sapi_windows_vt100_support(STDOUT, true));
+        $this->assertFalse(p::sapi_windows_vt100_support(STDOUT, false));
     }
 
     /**

--- a/tests/Php72/Php72Test.php
+++ b/tests/Php72/Php72Test.php
@@ -64,4 +64,26 @@ class Php72Test extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(@spl_object_id(123));
     }
+
+    /**
+     * @covers Symfony\Polyfill\Php72\Php72::sapi_windows_vt100_support
+     */
+    public function testSapiWindowsVt100Support()
+    {
+        if ('\\' !== DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Windows only test');
+        }
+
+        $this->assertFalse(p::sapi_windows_vt100_support(STDOUT, true));
+    }
+
+    /**
+     * @covers Symfony\Polyfill\Php72\Php72::stream_isatty
+     */
+    public function testStreamIsatty()
+    {
+        $fp = fopen('php://temp', 'r+');
+        $this->assertFalse(p::stream_isatty($fp));
+        fclose($fp);
+    }
 }


### PR DESCRIPTION
The tests are pretty useless, but it is impossible to guarantee what the descriptors are pointing to in all test environments.