### PR TITLE
[7.2] Add missing validation to sapi_windows_vt100_support()

### DIFF
--- a/src/Php72/Php72.php
+++ b/src/Php72/Php72.php
@@ -97,13 +97,25 @@ final class Php72
 
     public static function sapi_windows_vt100_support($stream, $enable = null)
     {
+        if (!is_resource($stream)) {
+            trigger_error('sapi_windows_vt100_support() expects parameter 1 to be resource, '.gettype($stream).' given', E_USER_WARNING);
+            return false;
+        }
+
+        $meta = stream_get_meta_data($stream);
+
+        if ('STDIO' !== $meta['stream_type']) {
+            trigger_error('sapi_windows_vt100_support() was not able to analyze the specified stream', E_USER_WARNING);
+            return false;
+        }
+
         // We cannot actually disable vt100 support if it is set
         if (false === $enable || !self::stream_isatty($stream)) {
             return false;
         }
 
         // The native function does not apply to stdin
-        $meta = array_map('strtolower', stream_get_meta_data($stream));
+        $meta = array_map('strtolower', $meta);
         $stdin = 'php://stdin' === $meta['uri'] || 'php://fd/0' === $meta['uri'];
 
         return !$stdin
@@ -114,6 +126,11 @@ final class Php72
 
     public static function stream_isatty($stream)
     {
+        if (!is_resource($stream)) {
+            trigger_error('stream_isatty() expects parameter 1 to be resource, '.gettype($stream).' given', E_USER_WARNING);
+            return false;
+        }
+
         if ('\\' === DIRECTORY_SEPARATOR) {
             $stat = @fstat($stream);
             // Check if formatted mode is S_IFCHR

--- a/tests/Php72/Php72Test.php
+++ b/tests/Php72/Php72Test.php
@@ -79,6 +79,32 @@ class Php72Test extends TestCase
     }
 
     /**
+     * @covers Symfony\Polyfill\Php72\Php72::sapi_windows_vt100_support
+     */
+    public function testSapiWindowsVt100SupportWarnsOnInvalidInputType()
+    {
+        if ('\\' !== DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Windows only test');
+        }
+
+        $this->setExpectedException('PHPUnit_Framework_Error_Warning', 'expects parameter 1 to be resource');
+        sapi_windows_vt100_support('foo', true);
+    }
+
+    /**
+     * @covers Symfony\Polyfill\Php72\Php72::sapi_windows_vt100_support
+     */
+    public function testSapiWindowsVt100SupportWarnsOnInvalidStream()
+    {
+        if ('\\' !== DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Windows only test');
+        }
+
+        $this->setExpectedException('PHPUnit_Framework_Error_Warning', 'was not able to analyze the specified stream');
+        sapi_windows_vt100_support(fopen('php://memory', 'wb'), true);
+    }
+
+    /**
      * @covers Symfony\Polyfill\Php72\Php72::stream_isatty
      */
     public function testStreamIsatty()
@@ -86,5 +112,14 @@ class Php72Test extends TestCase
         $fp = fopen('php://temp', 'r+');
         $this->assertFalse(stream_isatty($fp));
         fclose($fp);
+    }
+
+    /**
+     * @covers Symfony\Polyfill\Php72\Php72::stream_isatty
+     */
+    public function testStreamIsattyWarnsOnInvalidInputType()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error_Warning', 'expects parameter 1 to be resource');
+        stream_isatty('foo');
     }
 }


### PR DESCRIPTION
While investigating [this issue](https://github.com/symfony/symfony/issues/26210), I've noticed that polyfill implementation of `sapi_windows_vt100_support()` is simplified.

As per PHP source code, native function:

- requires the first argument to be a resource, emits a warning otherwise,
- requires the stream to be a file descriptor, emits an unanalyzable stream warning otherwise,
- checks whether the stream is a TTY after validations above.

This PR aligns the polyfill with the native function by:

- validating `$stream` argument to be a resource,
- checking if the stream type is a `STDIO`, returns `FALSE` otherwise,
- if stream is not `STDIO`, attempts to call `stream_select()` and emits the _unanalyzable stream_ warning when a `FALSE` gets returned in advance,
- performing validations above before `$enable` check and detections (including TTY).

I've compared the behavior with output tests ([test](https://github.com/php/php-src/blob/33301d5bae4964f74fd1fc8c4fc485abfde0378e/tests/output/sapi_windows_vt100_support.inc), [output](https://github.com/php/php-src/blob/f9959ee7c2004919675d9cdc7c82f886f099f15f/tests/output/sapi_windows_vt100_support_winko_err.phpt)) used in PHP source and enhanced unit tests accordingly.