### PR TITLE
Php70: do not expose intArg

### DIFF
--- a/src/Php70/Php70.php
+++ b/src/Php70/Php70.php
@@ -60,7 +60,7 @@ final class Php70
         restore_error_handler();
     }
 
-    public static function intArg($value, $caller, $pos)
+    private static function intArg($value, $caller, $pos)
     {
         if (is_int($value)) {
             return $value;


### PR DESCRIPTION
`Php70::intArg` is used from `Php70` class only. make it private.

project search result: https://github.com/symfony/polyfill/search?q=intArg&type=Code