### PR TITLE
PHP 7.3: Add hrtime() function

### DIFF
--- a/src/Php73/Php73.php
+++ b/src/Php73/Php73.php
@@ -3,12 +3,20 @@
 namespace Symfony\Polyfill\Php73;
 
 /**
+ * @author Gabriel Caruso <carusogabriel34@gmail.com>
+ * @author Ion Bazan <ion.bazan@gmail.com>
+ *
  * @internal
  */
 final class Php73
 {
     const NANO_IN_SEC = 1000000000.0;
 
+    /**
+     * @param mixed $var
+     *
+     * @return bool
+     */
     public static function is_countable($var)
     {
         return is_array($var)
@@ -17,6 +25,11 @@ final class Php73
             || $var instanceof \SimpleXmlElement;
     }
 
+    /**
+     * @param bool $as_num
+     *
+     * @return array|float
+     */
     public static function hrtime($as_num = false)
     {
         if ($as_num) {

--- a/src/Php73/Php73.php
+++ b/src/Php73/Php73.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Polyfill\Php73;
+
+/**
+ * @internal
+ */
+final class Php73
+{
+    const NANO_IN_SEC = 1000000000.0;
+
+    public static function is_countable($var)
+    {
+        return is_array($var)
+            || $var instanceof \Countable
+            || $var instanceof \ResourceBundle
+            || $var instanceof \SimpleXmlElement;
+    }
+
+    public static function hrtime($as_num = false)
+    {
+        if ($as_num) {
+            return microtime(true) * self::NANO_IN_SEC;
+        }
+
+        $time = explode(' ', microtime());
+
+        return array((int) $time[1], (int) ($time[0] * self::NANO_IN_SEC));
+    }
+}

--- a/src/Php73/Php73.php
+++ b/src/Php73/Php73.php
@@ -26,13 +26,13 @@ final class Php73
     }
 
     /**
-     * @param bool $as_num
+     * @param bool $asNum
      *
      * @return array|float
      */
-    public static function hrtime($as_num = false)
+    public static function hrtime($asNum = false)
     {
-        if ($as_num) {
+        if ($asNum) {
             return microtime(true) * self::NANO_IN_SEC;
         }
 

--- a/src/Php73/bootstrap.php
+++ b/src/Php73/bootstrap.php
@@ -17,6 +17,6 @@ if (PHP_VERSION_ID < 70300) {
     }
 
     if (!function_exists('hrtime')) {
-        function hrtime($as_num = false) { return p\Php73::hrtime($as_num); }
+        function hrtime($asNum = false) { return p\Php73::hrtime($asNum); }
     }
 }

--- a/src/Php73/bootstrap.php
+++ b/src/Php73/bootstrap.php
@@ -9,8 +9,14 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\Polyfill\Php73 as p;
+
 if (PHP_VERSION_ID < 70300) {
     if (!function_exists('is_countable')) {
-        function is_countable($var) { return is_array($var) || $var instanceof Countable || $var instanceof ResourceBundle || $var instanceof SimpleXmlElement; }
+        function is_countable($var) { return p\Php73::is_countable($var); }
+    }
+
+    if (!function_exists('hrtime')) {
+        function hrtime($as_num = false) { return p\Php73::hrtime($as_num); }
     }
 }

--- a/tests/Php73/Php73Test.php
+++ b/tests/Php73/Php73Test.php
@@ -33,8 +33,32 @@ class Php73Test extends TestCase
      */
     public function testIsCountableForGenerator()
     {
-        require 'generator.php';
+        require_once 'generator.php';
 
         $this->assertFalse(is_countable(genOneToTen()));
+    }
+
+    public function testHardwareTimeAsNum()
+    {
+        $microtime = microtime(true);
+        $hrtime = hrtime(true);
+        usleep(1000);
+        $d0 = (microtime(true) - $microtime) * 1000000000;
+        $d1 = hrtime(true) - $hrtime;
+
+        $this->assertEquals(10000000, $d1, '', 9e6);
+        $this->assertLessThan(0.05, abs($d0 - $d1) / $d1);
+    }
+
+    public function testHardwareTimeAsArray()
+    {
+        $microtime = microtime(true);
+        $hrtime = hrtime();
+        usleep(1000);
+        $microDelta = (microtime(true) - $microtime) * 1000000000;
+        $hrtime2 = hrtime();
+
+        $this->assertSame(0, $hrtime2[0] - $hrtime[0]);
+        $this->assertEquals($microDelta, $hrtime2[1] - $hrtime[1], '', 1e5);
     }
 }


### PR DESCRIPTION
Fixes #122 
This PR adds `hrtime()` function introduced in PHP 7.3. This implementation is based on `microtime` and is far from being precise. However, results should remain similar to actual `hrtime()` implementation.