### PR TITLE
Allow NOP version of paragonie/random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "ircmaxell/password-compat": "~1.0",
-        "paragonie/random_compat": "~1.0|~2.0",
+        "paragonie/random_compat": "~1.0|~2.0|~9.99",
         "symfony/intl": "~2.3|~3.0|~4.0"
     },
     "require-dev": {

--- a/src/Php70/composer.json
+++ b/src/Php70/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "paragonie/random_compat": "~1.0|~2.0"
+        "paragonie/random_compat": "~1.0|~2.0|~9.99"
     },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Php70\\": "" },


### PR DESCRIPTION
`paragonie/random_compat` ships a [special version 9.99.99](https://github.com/paragonie/random_compat#version-99999) which is only installable on PHP ≥7.0. It consists of an empty `composer.json` and adds no files to the autoloader. It might provide a minor perfomance improvement.