### PR TITLE
Add JSON errors which supported by php55

### DIFF
--- a/src/Php55/Php55.php
+++ b/src/Php55/Php55.php
@@ -30,6 +30,9 @@ final class Php55
             case JSON_ERROR_CTRL_CHAR: return 'Control character error, possibly incorrectly encoded';
             case JSON_ERROR_SYNTAX: return 'Syntax error';
             case JSON_ERROR_UTF8: return 'Malformed UTF-8 characters, possibly incorrectly encoded';
+            case JSON_ERROR_RECURSION: return 'One or more recursive references in the value to be encoded';
+            case JSON_ERROR_INF_OR_NAN: return 'One or more NAN or INF values in the value to be encoded';
+            case JSON_ERROR_UNSUPPORTED_TYPE: return 'A value of a type that cannot be encoded was given';
             default: return 'Unknown error';
         }
     }

--- a/src/Php55/Php55.php
+++ b/src/Php55/Php55.php
@@ -30,9 +30,9 @@ final class Php55
             case JSON_ERROR_CTRL_CHAR: return 'Control character error, possibly incorrectly encoded';
             case JSON_ERROR_SYNTAX: return 'Syntax error';
             case JSON_ERROR_UTF8: return 'Malformed UTF-8 characters, possibly incorrectly encoded';
-            case JSON_ERROR_RECURSION: return 'One or more recursive references in the value to be encoded';
-            case JSON_ERROR_INF_OR_NAN: return 'One or more NAN or INF values in the value to be encoded';
-            case JSON_ERROR_UNSUPPORTED_TYPE: return 'A value of a type that cannot be encoded was given';
+            case JSON_ERROR_RECURSION: return 'Recursion detected';
+            case JSON_ERROR_INF_OR_NAN: return 'Inf and NaN cannot be JSON encoded';
+            case JSON_ERROR_UNSUPPORTED_TYPE: return 'Type is not supported';
             default: return 'Unknown error';
         }
     }


### PR DESCRIPTION
According to PHP documentation for [json_last_error](http://php.net/manual/en/function.json-last-error.php)

- JSON_ERROR_RECURSION
- JSON_ERROR_INF_OR_NAN
- JSON_ERROR_UNSUPPORTED_TYPE

JSON error codes available since PHP 5.5.0 