### PR TITLE
fix infinite loop in `iconv()` polyfill when using translit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  * added polyfill for `hrtime()`
  * added polyfills for `array_key_first()` and `array_key_last()`
+ * fixed infinite loop in `iconv()` polyfill when using translit mode
 
 * v1.8.0
 

--- a/src/Iconv/Iconv.php
+++ b/src/Iconv/Iconv.php
@@ -695,6 +695,10 @@ final class Iconv
                     } else {
                         return false;
                     }
+                } elseif ($ignore) {
+                    continue;
+                } else {
+                    return false;
                 }
 
                 $str = $uchr.substr($str, $i);

--- a/tests/Iconv/IconvTest.php
+++ b/tests/Iconv/IconvTest.php
@@ -37,6 +37,7 @@ class IconvTest extends TestCase
         $this->assertSame('deja noeud', p::iconv('UTF-8//ignore//IGNORE', 'US-ASCII//TRANSLIT//IGNORE//translit', 'déjà nœud'));
 
         $this->assertSame('4', iconv('UTF-8', 'UTF-8', 4));
+        $this->assertSame('aa', p::iconv('UTF-8', "ASCII//TRANSLIT//IGNORE", "a\xC2\x96a"));
     }
 
     /**


### PR DESCRIPTION
Fixes #136