### PR TITLE
Check PHP version in stubs classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,8 @@ install:
     - if [[ $TRAVIS_BRANCH = master ]]; then export COMPOSER_ROOT_VERSION=dev-master; else export COMPOSER_ROOT_VERSION=$TRAVIS_BRANCH.x-dev; fi
     - composer --prefer-source install
 
+before_script:
+    - if find src -name "*.php" -print0 | xargs -0 -n 1 -P 8 php -l | grep -v "No syntax errors detected"; then exit 1; fi
+
 script:
     - ./vendor/bin/simple-phpunit

--- a/src/Php54/Resources/stubs/CallbackFilterIterator.php
+++ b/src/Php54/Resources/stubs/CallbackFilterIterator.php
@@ -9,20 +9,22 @@
  * file that was distributed with this source code.
  */
 
-class CallbackFilterIterator extends FilterIterator
-{
-    private $iterator;
-    private $callback;
-
-    public function __construct(Iterator $iterator, $callback)
+if (PHP_VERSION_ID < 50400) {
+    class CallbackFilterIterator extends FilterIterator
     {
-        $this->iterator = $iterator;
-        $this->callback = $callback;
-        parent::__construct($iterator);
-    }
+        private $iterator;
+        private $callback;
 
-    public function accept()
-    {
-        return call_user_func($this->callback, $this->current(), $this->key(), $this->iterator);
+        public function __construct(Iterator $iterator, $callback)
+        {
+            $this->iterator = $iterator;
+            $this->callback = $callback;
+            parent::__construct($iterator);
+        }
+
+        public function accept()
+        {
+            return call_user_func($this->callback, $this->current(), $this->key(), $this->iterator);
+        }
     }
 }

--- a/src/Php54/Resources/stubs/RecursiveCallbackFilterIterator.php
+++ b/src/Php54/Resources/stubs/RecursiveCallbackFilterIterator.php
@@ -9,25 +9,27 @@
  * file that was distributed with this source code.
  */
 
-class RecursiveCallbackFilterIterator extends CallbackFilterIterator implements RecursiveIterator
-{
-    private $iterator;
-    private $callback;
-
-    public function __construct(RecursiveIterator $iterator, $callback)
+if (PHP_VERSION_ID < 50400) {
+    class RecursiveCallbackFilterIterator extends CallbackFilterIterator implements RecursiveIterator
     {
-        $this->iterator = $iterator;
-        $this->callback = $callback;
-        parent::__construct($iterator, $callback);
-    }
+        private $iterator;
+        private $callback;
 
-    public function hasChildren()
-    {
-        return $this->iterator->hasChildren();
-    }
+        public function __construct(RecursiveIterator $iterator, $callback)
+        {
+            $this->iterator = $iterator;
+            $this->callback = $callback;
+            parent::__construct($iterator, $callback);
+        }
 
-    public function getChildren()
-    {
-        return new static($this->iterator->getChildren(), $this->callback);
+        public function hasChildren()
+        {
+            return $this->iterator->hasChildren();
+        }
+
+        public function getChildren()
+        {
+            return new static($this->iterator->getChildren(), $this->callback);
+        }
     }
 }

--- a/src/Php54/Resources/stubs/SessionHandlerInterface.php
+++ b/src/Php54/Resources/stubs/SessionHandlerInterface.php
@@ -29,74 +29,76 @@
  * @author Drak <drak@zikula.org>
  * @author Tobias Schultze <http://tobion.de>
  */
-interface SessionHandlerInterface
-{
-    /**
-     * Re-initializes existing session, or creates a new one.
-     *
-     * @see http://php.net/sessionhandlerinterface.open
-     *
-     * @param string $savePath    Save path
-     * @param string $sessionName Session name, see http://php.net/function.session-name.php
-     *
-     * @return bool true on success, false on failure
-     */
-    public function open($savePath, $sessionName);
+if (PHP_VERSION_ID < 50400) {
+    interface SessionHandlerInterface
+    {
+        /**
+         * Re-initializes existing session, or creates a new one.
+         *
+         * @see http://php.net/sessionhandlerinterface.open
+         *
+         * @param string $savePath    Save path
+         * @param string $sessionName Session name, see http://php.net/function.session-name.php
+         *
+         * @return bool true on success, false on failure
+         */
+        public function open($savePath, $sessionName);
 
-    /**
-     * Closes the current session.
-     *
-     * @see http://php.net/sessionhandlerinterface.close
-     *
-     * @return bool true on success, false on failure
-     */
-    public function close();
+        /**
+         * Closes the current session.
+         *
+         * @see http://php.net/sessionhandlerinterface.close
+         *
+         * @return bool true on success, false on failure
+         */
+        public function close();
 
-    /**
-     * Reads the session data.
-     *
-     * @see http://php.net/sessionhandlerinterface.read
-     *
-     * @param string $sessionId Session ID, see http://php.net/function.session-id
-     *
-     * @return string Same session data as passed in write() or empty string when non-existent or on failure
-     */
-    public function read($sessionId);
+        /**
+         * Reads the session data.
+         *
+         * @see http://php.net/sessionhandlerinterface.read
+         *
+         * @param string $sessionId Session ID, see http://php.net/function.session-id
+         *
+         * @return string Same session data as passed in write() or empty string when non-existent or on failure
+         */
+        public function read($sessionId);
 
-    /**
-     * Writes the session data to the storage.
-     *
-     * Care, the session ID passed to write() can be different from the one previously
-     * received in read() when the session ID changed due to session_regenerate_id().
-     *
-     * @see http://php.net/sessionhandlerinterface.write
-     *
-     * @param string $sessionId Session ID , see http://php.net/function.session-id
-     * @param string $data      Serialized session data to save
-     *
-     * @return bool true on success, false on failure
-     */
-    public function write($sessionId, $data);
+        /**
+         * Writes the session data to the storage.
+         *
+         * Care, the session ID passed to write() can be different from the one previously
+         * received in read() when the session ID changed due to session_regenerate_id().
+         *
+         * @see http://php.net/sessionhandlerinterface.write
+         *
+         * @param string $sessionId Session ID , see http://php.net/function.session-id
+         * @param string $data      Serialized session data to save
+         *
+         * @return bool true on success, false on failure
+         */
+        public function write($sessionId, $data);
 
-    /**
-     * Destroys a session.
-     *
-     * @see http://php.net/sessionhandlerinterface.destroy
-     *
-     * @param string $sessionId Session ID, see http://php.net/function.session-id
-     *
-     * @return bool true on success, false on failure
-     */
-    public function destroy($sessionId);
+        /**
+         * Destroys a session.
+         *
+         * @see http://php.net/sessionhandlerinterface.destroy
+         *
+         * @param string $sessionId Session ID, see http://php.net/function.session-id
+         *
+         * @return bool true on success, false on failure
+         */
+        public function destroy($sessionId);
 
-    /**
-     * Cleans up expired sessions (garbage collection).
-     *
-     * @see http://php.net/sessionhandlerinterface.gc
-     *
-     * @param string|int $maxlifetime Sessions that have not updated for the last maxlifetime seconds will be removed
-     *
-     * @return bool true on success, false on failure
-     */
-    public function gc($maxlifetime);
+        /**
+         * Cleans up expired sessions (garbage collection).
+         *
+         * @see http://php.net/sessionhandlerinterface.gc
+         *
+         * @param string|int $maxlifetime Sessions that have not updated for the last maxlifetime seconds will be removed
+         *
+         * @return bool true on success, false on failure
+         */
+        public function gc($maxlifetime);
+    }
 }

--- a/src/Php70/Resources/stubs/ArithmeticError.php
+++ b/src/Php70/Resources/stubs/ArithmeticError.php
@@ -1,5 +1,7 @@
 <?php
 
-class ArithmeticError extends Error
-{
+if (PHP_VERSION_ID < 70000) {
+    class ArithmeticError extends Error
+    {
+    }
 }

--- a/src/Php70/Resources/stubs/AssertionError.php
+++ b/src/Php70/Resources/stubs/AssertionError.php
@@ -1,5 +1,7 @@
 <?php
 
-class AssertionError extends Error
-{
+if (PHP_VERSION_ID < 70000) {
+    class AssertionError extends Error
+    {
+    }
 }

--- a/src/Php70/Resources/stubs/DivisionByZeroError.php
+++ b/src/Php70/Resources/stubs/DivisionByZeroError.php
@@ -1,5 +1,7 @@
 <?php
 
-class DivisionByZeroError extends Error
-{
+if (PHP_VERSION_ID < 70000) {
+    class DivisionByZeroError extends Error
+    {
+    }
 }

--- a/src/Php70/Resources/stubs/Error.php
+++ b/src/Php70/Resources/stubs/Error.php
@@ -1,5 +1,7 @@
 <?php
 
-class Error extends Exception
-{
+if (PHP_VERSION_ID < 70000) {
+    class Error extends Exception
+    {
+    }
 }

--- a/src/Php70/Resources/stubs/ParseError.php
+++ b/src/Php70/Resources/stubs/ParseError.php
@@ -1,5 +1,7 @@
 <?php
 
-class ParseError extends Error
-{
+if (PHP_VERSION_ID < 70000) {
+    class ParseError extends Error
+    {
+    }
 }

--- a/src/Php70/Resources/stubs/SessionUpdateTimestampHandlerInterface.php
+++ b/src/Php70/Resources/stubs/SessionUpdateTimestampHandlerInterface.php
@@ -1,23 +1,25 @@
 <?php
 
-interface SessionUpdateTimestampHandlerInterface
-{
-    /**
-     * Checks if a session identifier already exists or not.
-     *
-     * @param string $key
-     *
-     * @return bool
-     */
-    public function validateId($key);
+if (PHP_VERSION_ID < 70000) {
+    interface SessionUpdateTimestampHandlerInterface
+    {
+        /**
+         * Checks if a session identifier already exists or not.
+         *
+         * @param string $key
+         *
+         * @return bool
+         */
+        public function validateId($key);
 
-    /**
-     * Updates the timestamp of a session when its data didn't change.
-     *
-     * @param string $key
-     * @param string $val
-     *
-     * @return bool
-     */
-    public function updateTimestamp($key, $val);
+        /**
+         * Updates the timestamp of a session when its data didn't change.
+         *
+         * @param string $key
+         * @param string $val
+         *
+         * @return bool
+         */
+        public function updateTimestamp($key, $val);
+    }
 }

--- a/src/Php70/Resources/stubs/TypeError.php
+++ b/src/Php70/Resources/stubs/TypeError.php
@@ -1,5 +1,7 @@
 <?php
 
-class TypeError extends Error
-{
+if (PHP_VERSION_ID < 70000) {
+    class TypeError extends Error
+    {
+    }
 }


### PR DESCRIPTION
I added a test in stubs classes to prevent `php -l` to fail on polyfills (errors like `PHP Fatal error:  Cannot declare class ArithmeticError, because the name is already in use`)

* add test to lint polyfill files
* make lint test pass