### PR TITLE
Duplicate mb_ord/mb_chr/mb_scrub in PHP 7.2  polyfill

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -704,6 +704,10 @@ final class Mbstring
             $s = mb_convert_encoding($s, 'UTF-8', $encoding);
         }
 
+        if (1 === \strlen($s)) {
+            return \ord($s);
+        }
+
         $code = ($s = unpack('C*', substr($s, 0, 4))) ? $s[1] : 0;
         if (0xF0 <= $code) {
             return (($code - 0xF0) << 18) + (($s[2] - 0x80) << 12) + (($s[3] - 0x80) << 6) + $s[4] - 0x80;

--- a/src/Php72/Php72.php
+++ b/src/Php72/Php72.php
@@ -162,4 +162,49 @@ final class Php72
 
         self::$hashMask ^= hexdec(substr(spl_object_hash($obj), 16 - \PHP_INT_SIZE, \PHP_INT_SIZE));
     }
+
+    public static function mb_chr($code, $encoding = null)
+    {
+        if (0x80 > $code %= 0x200000) {
+            $s = \chr($code);
+        } elseif (0x800 > $code) {
+            $s = \chr(0xC0 | $code >> 6).\chr(0x80 | $code & 0x3F);
+        } elseif (0x10000 > $code) {
+            $s = \chr(0xE0 | $code >> 12).\chr(0x80 | $code >> 6 & 0x3F).\chr(0x80 | $code & 0x3F);
+        } else {
+            $s = \chr(0xF0 | $code >> 18).\chr(0x80 | $code >> 12 & 0x3F).\chr(0x80 | $code >> 6 & 0x3F).\chr(0x80 | $code & 0x3F);
+        }
+
+        if ('UTF-8' !== $encoding) {
+            $s = mb_convert_encoding($s, $encoding, 'UTF-8');
+        }
+
+        return $s;
+    }
+
+    public static function mb_ord($s, $encoding = null)
+    {
+        if (null == $encoding) {
+            $s = mb_convert_encoding($s, 'UTF-8');
+        } elseif ('UTF-8' !== $encoding) {
+            $s = mb_convert_encoding($s, 'UTF-8', $encoding);
+        }
+
+        if (1 === \strlen($s)) {
+            return \ord($s);
+        }
+
+        $code = ($s = unpack('C*', substr($s, 0, 4))) ? $s[1] : 0;
+        if (0xF0 <= $code) {
+            return (($code - 0xF0) << 18) + (($s[2] - 0x80) << 12) + (($s[3] - 0x80) << 6) + $s[4] - 0x80;
+        }
+        if (0xE0 <= $code) {
+            return (($code - 0xE0) << 12) + (($s[2] - 0x80) << 6) + $s[3] - 0x80;
+        }
+        if (0xC0 <= $code) {
+            return (($code - 0xC0) << 6) + $s[2] - 0x80;
+        }
+
+        return $code;
+    }
 }

--- a/src/Php72/bootstrap.php
+++ b/src/Php72/bootstrap.php
@@ -28,4 +28,9 @@ if (PHP_VERSION_ID < 70200) {
     if (!defined('PHP_OS_FAMILY')) {
         define('PHP_OS_FAMILY', p\Php72::php_os_family());
     }
+    if (!function_exists('mb_chr')) {
+        function mb_ord($s, $enc = null) { return p\Php72::mb_ord($s, $enc); }
+        function mb_chr($code, $enc = null) { return p\Php72::mb_chr($code, $enc); }
+        function mb_scrub($s, $enc = null) { $enc = null === $enc ? mb_internal_encoding() : $enc; return mb_convert_encoding($s, $enc, $enc); }
+    }
 }

--- a/tests/Php72/Php72Test.php
+++ b/tests/Php72/Php72Test.php
@@ -135,4 +135,30 @@ class Php72Test extends TestCase
             parent::setExpectedException($exception, $message, $code);
         }
     }
+
+    /**
+     * @covers Symfony\Polyfill\Php72\Php72::mb_chr
+     */
+    public function testChr()
+    {
+        $this->assertSame("\xF0\xA0\xAE\xB7", mb_chr(0x20BB7));
+        $this->assertSame("\xE9", mb_chr(0xE9, 'CP1252'));
+    }
+
+    /**
+     * @covers Symfony\Polyfill\Php72\Php72::mb_ord
+     */
+    public function testOrd()
+    {
+        $this->assertSame(0x20BB7, mb_ord("\xF0\xA0\xAE\xB7"));
+        $this->assertSame(0xE9, mb_ord("\xE9", 'CP1252'));
+    }
+
+    public function testScrub()
+    {
+        $subst = \mb_substitute_character();
+        \mb_substitute_character('none');
+        $this->assertSame('ab', mb_scrub("a\xE9b"));
+        \mb_substitute_character($subst);
+    }
 }


### PR DESCRIPTION
When our skeleton "replace" polyfill-mbstring but PHP 7.1 is used, it means these functions are *not* polyfilled (since they've been introduced in PHP 7.2).

Let's duplicate them in the 7.2 polyfill.