### PR TITLE
Add polyfill for Intl\MessageFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Polyfills are provided for:
 - the `apcu` extension when the legacy `apc` extension is installed;
 - the `ctype` extension when PHP is compiled without ctype;
 - the `mbstring` and `iconv` extensions;
+- the `MessageFormatter` class and the `msgfmt_format_message` functions;
 - the `Normalizer` class and the `grapheme_*` functions;
 - the `utf8_encode` and `utf8_decode` functions from the `xml` extension or PHP-7.2 core;
 - the `Collator`, `NumberFormatter`, `Locale` and `IntlDateFormatter` classes;
@@ -65,6 +66,7 @@ should **not** `require` the `symfony/polyfill` package, but the standalone ones
 - `symfony/polyfill-iconv` for using the iconv functions,
 - `symfony/polyfill-intl-grapheme` for using the `grapheme_*` functions,
 - `symfony/polyfill-intl-icu` for using the intl functions and classes,
+- `symfony/polyfill-intl-messageformatter` for using the intl messageformatter,
 - `symfony/polyfill-intl-normalizer` for using the intl normalizer,
 - `symfony/polyfill-mbstring` for using the mbstring functions,
 - `symfony/polyfill-util` for using the polyfill utility helpers.

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "symfony/polyfill-iconv": "self.version",
         "symfony/polyfill-intl-grapheme": "self.version",
         "symfony/polyfill-intl-icu": "self.version",
+        "symfony/polyfill-intl-messageformatter": "self.version",
         "symfony/polyfill-intl-normalizer": "self.version",
         "symfony/polyfill-mbstring": "self.version",
         "symfony/polyfill-util": "self.version",
@@ -57,10 +58,12 @@
             "src/Iconv/bootstrap.php",
             "src/Intl/Grapheme/bootstrap.php",
             "src/Intl/Icu/bootstrap.php",
+            "src/Intl/MessageFormatter/bootstrap.php",
             "src/Intl/Normalizer/bootstrap.php",
             "src/Mbstring/bootstrap.php"
         ],
         "classmap": [
+            "src/Intl/MessageFormatter/Resources/stubs",
             "src/Intl/Normalizer/Resources/stubs",
             "src/Php70/Resources/stubs",
             "src/Php54/Resources/stubs"

--- a/src/Intl/MessageFormatter/LICENSE
+++ b/src/Intl/MessageFormatter/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2018 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Intl/MessageFormatter/MessageFormatter.php
+++ b/src/Intl/MessageFormatter/MessageFormatter.php
@@ -1,0 +1,316 @@
+<?php
+
+/*
+ * Copyright © 2008 by Yii Software LLC (http://www.yiisoft.com)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  * Neither the name of Yii Software LLC nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Originally forked from
+ * https://github.com/yiisoft/yii2/blob/2.0.15/framework/i18n/MessageFormatter.php
+ */
+
+namespace Symfony\Polyfill\Intl\MessageFormatter;
+
+/**
+ * A polyfill implementation of the MessageFormatter class provided by the intl extension.
+ *
+ * It only supports the following message formats:
+ *  * plural formatting for english ('one' and 'other' selectors)
+ *  * select format
+ *  * simple parameters
+ *  * integer number parameters
+ *
+ * It does NOT support the ['apostrophe-friendly' syntax](http://www.php.net/manual/en/messageformatter.formatmessage.php).
+ * Also messages that are working with the fallback implementation are not necessarily compatible with the
+ * PHP intl MessageFormatter so do not rely on the fallback if you are able to install intl extension somehow.
+ *
+ * @author Alexander Makarov <sam@rmcreative.ru>
+ * @author Carsten Brandt <mail@cebe.cc>
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class MessageFormatter
+{
+    private $locale;
+    private $pattern;
+    private $tokens;
+    private $errorCode = 0;
+    private $errorMessage = '';
+
+    public static function create($locale, $pattern)
+    {
+        $formatter = new static($locale, '-');
+
+        return $formatter->setPattern($pattern) ? $formatter : null;
+    }
+
+    public static function formatMessage($locale, $pattern, array $args)
+    {
+        if (null === $formatter = self::create($locale, $pattern)) {
+            return false;
+        }
+
+        return $formatter->format($args);
+    }
+
+    public function __construct($locale, $pattern)
+    {
+        $this->locale = (string) $locale;
+
+        if (!$this->setPattern($pattern)) {
+            throw new \IntlException('Message pattern is invalid.');
+        }
+    }
+
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    public function getPattern()
+    {
+        return $this->pattern;
+    }
+
+    public function getErrorCode()
+    {
+        return $this->errorCode;
+    }
+
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
+    }
+
+    public function setPattern($pattern)
+    {
+        $pattern = (string) $pattern;
+        try {
+            $this->tokens = self::tokenizePattern($pattern);
+            $this->pattern = $pattern;
+        } catch (\DomainException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function format(array $args)
+    {
+        $this->errorCode = 0;
+        $this->errorMessage = '';
+
+        if (!$args) {
+            return $this->pattern;
+        }
+
+        try {
+            return self::parseTokens($this->tokens, $args, $this->locale);
+        } catch (\DomainException $e) {
+            $this->errorCode = -1;
+            $this->errorMessage = $e->getMessage();
+
+            return false;
+        }
+    }
+
+    public function parse($value)
+    {
+        $this->errorCode = -1;
+        $this->errorMessage = sprintf('The PHP intl extension is required to use "MessageFormatter::%s()".', __FUNCTION__);
+
+        return false;
+    }
+
+    private static function parseTokens(array $tokens, array $args, $locale)
+    {
+        foreach ($tokens as $i => $token) {
+            if (\is_array($token)) {
+                $tokens[$i] = self::parseToken($token, $args, $locale);
+            }
+        }
+
+        return implode('', $tokens);
+    }
+
+    private static function tokenizePattern($pattern)
+    {
+        if (false === $start = $pos = strpos($pattern, '{')) {
+            return array($pattern);
+        }
+
+        $depth = 1;
+        $tokens = array(substr($pattern, 0, $pos));
+
+        while (true) {
+            $open = strpos($pattern, '{', 1 + $pos);
+            $close = strpos($pattern, '}', 1 + $pos);
+
+            if (false === $open) {
+                if (false === $close) {
+                    break;
+                }
+                $open = \strlen($pattern);
+            }
+
+            if ($close > $open) {
+                ++$depth;
+                $pos = $open;
+            } else {
+                --$depth;
+                $pos = $close;
+            }
+
+            if (0 === $depth) {
+                $tokens[] = explode(',', substr($pattern, 1 + $start, $pos - $start - 1), 3);
+                $start = 1 + $pos;
+                $tokens[] = substr($pattern, $start, $open - $start);
+                $start = $open;
+            }
+
+            if (0 !== $depth && (false === $open || false === $close)) {
+                break;
+            }
+        }
+
+        if ($depth) {
+            throw new \DomainException('Message pattern is invalid.');
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Parses pattern based on ICU grammar.
+     *
+     * @see http://icu-project.org/apiref/icu4c/classMessageFormat.html#details
+     */
+    private static function parseToken(array $token, array $args, $locale)
+    {
+        if (!isset($args[$param = trim($token[0])])) {
+            return '{'.$param.'}';
+        }
+
+        $arg = $args[$param];
+        $type = isset($token[1]) ? trim($token[1]) : 'none';
+        switch ($type) {
+            case 'date': //XXX use DateFormatter?
+            case 'time':
+            case 'spellout':
+            case 'ordinal':
+            case 'duration':
+            case 'choice':
+            case 'selectordinal':
+                throw new \DomainException(sprintf('The PHP intl extension is required to use the "%s" message format.', $type));
+
+            case 'number':
+                $format = isset($token[2]) ? trim($token[2]) : null;
+                if (!is_numeric($arg) || (null !== $format && 'integer' !== $format)) {
+                    throw new \DomainException('The PHP intl extension is required to use the "number" message format with non-integer values.');
+                }
+
+                $number = number_format($arg); //XXX use NumberFormatter?
+                if (null === $format && false !== $pos = strpos($arg, '.')) {
+                    // add decimals with unknown length
+                    $number .= '.'.substr($arg, $pos + 1);
+                }
+
+                return $number;
+
+            case 'none':
+                return $arg;
+
+            case 'select':
+                /* http://icu-project.org/apiref/icu4c/classicu_1_1SelectFormat.html
+                selectStyle = (selector '{' message '}')+
+                */
+                if (!isset($token[2])) {
+                    throw new \DomainException('Message pattern is invalid.');
+                }
+                $select = self::tokenizePattern($token[2]);
+                $c = \count($select);
+                $message = false;
+                for ($i = 0; 1 + $i < $c; ++$i) {
+                    if (\is_array($select[$i]) || !\is_array($select[1 + $i])) {
+                        throw new \DomainException('Message pattern is invalid.');
+                    }
+                    $selector = trim($select[$i++]);
+                    if (false === $message && 'other' === $selector || $selector == $arg) {
+                        $message = implode(',', $select[$i]);
+                    }
+                }
+                if (false !== $message) {
+                    return self::parseTokens(self::tokenizePattern($message), $args, $locale);
+                }
+                break;
+
+            case 'plural': //TODO make it locale-dependent based on symfony/translation rules
+                /* http://icu-project.org/apiref/icu4c/classicu_1_1PluralFormat.html
+                pluralStyle = [offsetValue] (selector '{' message '}')+
+                offsetValue = "offset:" number
+                selector = explicitValue | keyword
+                explicitValue = '=' number  // adjacent, no white space in between
+                keyword = [^[[:Pattern_Syntax:][:Pattern_White_Space:]]]+
+                message: see MessageFormat
+                */
+                if (!isset($token[2])) {
+                    throw new \DomainException('Message pattern is invalid.');
+                }
+                $plural = self::tokenizePattern($token[2]);
+                $c = \count($plural);
+                $message = false;
+                $offset = 0;
+                for ($i = 0; 1 + $i < $c; ++$i) {
+                    if (\is_array($plural[$i]) || !\is_array($plural[1 + $i])) {
+                        throw new \DomainException('Message pattern is invalid.');
+                    }
+                    $selector = trim($plural[$i++]);
+
+                    if (1 === $i && 0 === strncmp($selector, 'offset:', 7)) {
+                        $pos = strpos(str_replace(array("\n", "\r", "\t"), ' ', $selector), ' ', 7);
+                        $offset = (int) trim(substr($selector, 7, $pos - 7));
+                        $selector = trim(substr($selector, 1 + $pos, \strlen($selector)));
+                    }
+                    if (false === $message && 'other' === $selector ||
+                        '=' === $selector[0] && (int) substr($selector, 1, \strlen($selector)) === $arg ||
+                        'one' === $selector && 1 == $arg - $offset
+                    ) {
+                        $message = implode(',', str_replace('#', $arg - $offset, $plural[$i]));
+                    }
+                }
+                if (false !== $message) {
+                    return self::parseTokens(self::tokenizePattern($message), $args, $locale);
+                }
+                break;
+        }
+
+        throw new \DomainException('Message pattern is invalid.');
+    }
+}

--- a/src/Intl/MessageFormatter/README.md
+++ b/src/Intl/MessageFormatter/README.md
@@ -1,0 +1,14 @@
+Symfony Polyfill / Intl: MessageFormatter
+=========================================
+
+This component provides a fallback implementation for the
+[`MessageFormatter`](http://php.net/manual/en/class.messageformatter.php) class provided
+by the [Intl](http://php.net/intl) extension.
+
+More information can be found in the
+[main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
+
+License
+=======
+
+This library is released under the [MIT license](LICENSE).

--- a/src/Intl/MessageFormatter/Resources/stubs/IntlException.php
+++ b/src/Intl/MessageFormatter/Resources/stubs/IntlException.php
@@ -1,0 +1,5 @@
+<?php
+
+class IntlException extends Exception
+{
+}

--- a/src/Intl/MessageFormatter/Resources/stubs/MessageFormatter.php
+++ b/src/Intl/MessageFormatter/Resources/stubs/MessageFormatter.php
@@ -1,0 +1,5 @@
+<?php
+
+class MessageFormatter extends Symfony\Polyfill\Intl\MessageFormatter\MessageFormatter
+{
+}

--- a/src/Intl/MessageFormatter/bootstrap.php
+++ b/src/Intl/MessageFormatter/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\Intl\MessageFormatter\MessageFormatter as p;
+
+if (!function_exists('msgfmt_format_message')) {
+    function msgfmt_format_message($locale, $pattern, array $args) { return p::formatMessage($locale, $pattern, $args); }
+}

--- a/src/Intl/MessageFormatter/composer.json
+++ b/src/Intl/MessageFormatter/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "symfony/polyfill-intl-normalizer",
+    "type": "library",
+    "description": "Symfony polyfill for intl's Normalizer class and related functions",
+    "keywords": ["polyfill", "shim", "compatibility", "portable", "intl", "normalizer"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Nicolas Grekas",
+            "email": "p@tchwork.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.3"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Polyfill\\Intl\\Normalizer\\": "" },
+        "files": [ "bootstrap.php" ],
+        "classmap": [ "Resources/stubs" ]
+    },
+    "suggest": {
+        "ext-intl": "For best performance"
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.9-dev"
+        }
+    }
+}

--- a/tests/Intl/MessageFormatter/MessageFormatterTest.php
+++ b/tests/Intl/MessageFormatter/MessageFormatterTest.php
@@ -1,0 +1,279 @@
+<?php
+
+/*
+ * Copyright © 2008 by Yii Software LLC (http://www.yiisoft.com)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  * Neither the name of Yii Software LLC nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Originally forked from
+ * https://github.com/yiisoft/yii2/blob/2.0.15/tests/framework/i18n/FallbackMessageFormatterTest.php
+ */
+
+namespace Symfony\Polyfill\Tests\Intl\MessageFormatter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Polyfill\Intl\MessageFormatter\MessageFormatter;
+
+/**
+ * @author Carsten Brandt <mail@cebe.cc>
+ */
+class MessageFormatterTest extends TestCase
+{
+    /**
+     * @dataProvider patterns
+     */
+    public function testNamedArguments($pattern, $expected, array $args)
+    {
+        $formatter = new MessageFormatter('en_US', $pattern);
+        $result = $formatter->format($args);
+        $this->assertEquals($expected, $result, $formatter->getErrorMessage());
+
+        if (\PHP_VERSION_ID < 50500) {
+            return;
+        }
+
+        $formatter = new \MessageFormatter('en_US', $pattern);
+        $result = $formatter->format($args);
+        $this->assertEquals($expected, $result, $formatter->getErrorMessage());
+    }
+
+    public function patterns()
+    {
+        $subject = 'Answer to the Ultimate Question of Life, the Universe, and Everything';
+
+        return array(
+            array(
+                '{сабж} is {n}', // pattern
+                $subject.' is 42', // expected
+                array( // params
+                    'n' => 42,
+                    'сабж' => $subject,
+                ),
+            ),
+
+            array(
+                '{сабж} is {n, number}', // pattern
+                $subject.' is 42', // expected
+                array( // params
+                    'n' => 42,
+                    'сабж' => $subject,
+                ),
+            ),
+
+            array(
+                '{сабж} is {n, number, integer}', // pattern
+                $subject.' is 42', // expected
+                array( // params
+                    'n' => 42,
+                    'сабж' => $subject,
+                ),
+            ),
+
+            array(
+                'Here is a big number: {f, number}', // pattern
+                'Here is a big number: 200,000,000', // expected
+                array( // params
+                    'f' => 2e+8,
+                ),
+            ),
+
+            array(
+                'Here is a big number: {f, number, integer}', // pattern
+                'Here is a big number: 200,000,000', // expected
+                array( // params
+                    'f' => 2e+8,
+                ),
+            ),
+
+            array(
+                'Here is a big number: {d, number}', // pattern
+                'Here is a big number: 200,000,000.101', // expected
+                array( // params
+                    'd' => 200000000.101,
+                ),
+            ),
+
+            array(
+                'Here is a big number: {d, number, integer}', // pattern
+                'Here is a big number: 200,000,000', // expected
+                array( // params
+                    'd' => 200000000.101,
+                ),
+            ),
+
+            // This one was provided by Aura.Intl. Thanks!
+            array(<<<'_MSG_'
+{gender_of_host, select,
+  female {{num_guests, plural, offset:1
+      =0 {{host} does not give a party.}
+      =1 {{host} invites {guest} to her party.}
+      =2 {{host} invites {guest} and one other person to her party.}
+     other {{host} invites {guest} and # other people to her party.}}}
+  male {{num_guests, plural, offset:1
+      =0 {{host} does not give a party.}
+      =1 {{host} invites {guest} to his party.}
+      =2 {{host} invites {guest} and one other person to his party.}
+     other {{host} invites {guest} and # other people to his party.}}}
+  other {{num_guests, plural, offset:1
+      =0 {{host} does not give a party.}
+      =1 {{host} invites {guest} to their party.}
+      =2 {{host} invites {guest} and one other person to their party.}
+      other {{host} invites {guest} and # other people to their party.}}}}
+_MSG_
+                ,
+                'ralph invites beep and 3 other people to his party.',
+                array(
+                    'gender_of_host' => 'male',
+                    'num_guests' => 4,
+                    'host' => 'ralph',
+                    'guest' => 'beep',
+                ),
+            ),
+
+            array(
+                '{name} is {gender} and {gender, select, female{she} male{he} other{it}} loves Yii!',
+                'Alexander is male and he loves Yii!',
+                array(
+                    'name' => 'Alexander',
+                    'gender' => 'male',
+                ),
+            ),
+
+            // verify pattern in select does not get replaced
+            array(
+                '{name} is {gender} and {gender, select, female{she} male{he} other{it}} loves Yii!',
+                'Alexander is male and he loves Yii!',
+                array(
+                    'name' => 'Alexander',
+                    'gender' => 'male',
+                    // following should not be replaced
+                    'he' => 'wtf',
+                    'she' => 'wtf',
+                    'it' => 'wtf',
+                ),
+            ),
+
+            // verify pattern in select message gets replaced
+            array(
+                '{name} is {gender} and {gender, select, female{she} male{{he}} other{it}} loves Yii!',
+                'Alexander is male and wtf loves Yii!',
+                array(
+                    'name' => 'Alexander',
+                    'gender' => 'male',
+                    'he' => 'wtf',
+                    'she' => 'wtf',
+                ),
+            ),
+
+            // formatting a message that contains params but they are not provided.
+            array(
+                'Incorrect password (length must be from { min, number } to { max, number } symbols).',
+                'Incorrect password (length must be from {min} to {max} symbols).',
+                array('attribute' => 'password'),
+            ),
+
+            // some parser specific verifications
+            array(
+                '{gender} and {gender, select, female{she} male{{he}} other{it}} loves {nr} is {gender}!',
+                'male and wtf loves 42 is male!',
+                array(
+                    'nr' => 42,
+                    'gender' => 'male',
+                    'he' => 'wtf',
+                    'she' => 'wtf',
+                ),
+            ),
+        );
+    }
+
+    public function testInsufficientArguments()
+    {
+        $pattern = '{сабж} is {n}';
+
+        $formatter = new MessageFormatter('en_US', $pattern);
+        $result = $formatter->format(array('n' => 42));
+        $this->assertEquals('{сабж} is 42', $result);
+
+        if (\PHP_VERSION_ID < 50500) {
+            return;
+        }
+
+        $formatter = new \MessageFormatter('en_US', $pattern);
+        $result = $formatter->format(array('n' => 42));
+        $this->assertEquals('{сабж} is 42', $result);
+    }
+
+    public function testNoParams()
+    {
+        $pattern = '{сабж} is {n}';
+
+        $formatter = new MessageFormatter('en_US', $pattern);
+        $result = $formatter->format(array());
+        $this->assertEquals($pattern, $result, $formatter->getErrorMessage());
+
+        if (\PHP_VERSION_ID < 50500) {
+            return;
+        }
+
+        $formatter = new \MessageFormatter('en_US', $pattern);
+        $result = $formatter->format(array());
+        $this->assertEquals($pattern, $result, $formatter->getErrorMessage());
+    }
+
+    public function testGridViewMessage()
+    {
+        $pattern = 'Showing <b>{begin, number}-{end, number}</b> of <b>{totalCount, number}</b> {totalCount, plural, one{item} other{items}}.';
+
+        $formatter = new MessageFormatter('en_US', $pattern);
+        $result = $formatter->format(array('begin' => 1, 'end' => 5, 'totalCount' => 10));
+        $this->assertEquals('Showing <b>1-5</b> of <b>10</b> items.', $result);
+
+        if (\PHP_VERSION_ID < 50500) {
+            return;
+        }
+
+        $formatter = new \MessageFormatter('en_US', $pattern);
+        $result = $formatter->format(array('begin' => 1, 'end' => 5, 'totalCount' => 10));
+        $this->assertEquals('Showing <b>1-5</b> of <b>10</b> items.', $result);
+    }
+
+    public function testUnsupportedPercentException()
+    {
+        $pattern = 'Number {n, number, percent}';
+        $formatter = new MessageFormatter('en-US', $pattern);
+        $this->assertFalse($formatter->format(array('n' => 42)));
+    }
+
+    public function testUnsupportedCurrencyException()
+    {
+        $pattern = 'Number {n, number, currency}';
+        $formatter = new MessageFormatter('en-US', $pattern);
+        $this->assertFalse($formatter->format(array('n' => 42)));
+    }
+}


### PR DESCRIPTION
This is a fork of Yii's [fallback MessageFormatter](https://github.com/yiisoft/yii2/blob/master/framework/i18n/MessageFormatter.php) implementation, ported as a polyfill of intl's MessageFormatter. I also reformatted the code to make it more in line with our practices and added some notes if we want to push the polyfill forward. The test suite compares both native and PHP variants, with similar results.
Kudos to them!

ping @cebe and @samdark FYI