### PR TITLE
array_key_last: improving performance

### DIFF
--- a/src/Php73/bootstrap.php
+++ b/src/Php73/bootstrap.php
@@ -26,6 +26,6 @@ if (PHP_VERSION_ID < 70300) {
     }
 
     if (!function_exists('array_key_last')) {
-        function array_key_last(array $array) { $key = null; foreach ($array as $key => $value); return $key; }
+        function array_key_last(array $array) { end($array); return key($array); }
     }
 }


### PR DESCRIPTION
First PR is [here](https://github.com/symfony/polyfill-php73/pull/1), where was discussion.

Q: The issue is that this mutates the internal pointer.
A: created [benchmark](https://github.com/symfony/polyfill-php73/pull/1#issuecomment-424145092) and implementation does not change internal pointer.

Q: about performance for small vs big arrays
A: look like implementation is [every time faster](https://github.com/symfony/polyfill-php73/pull/1#issuecomment-424217955)


This implementation is approx twice faster than cycle foreach.

Benchmark is [on my gist](https://gist.github.com/h4kuna/6353ce99bd45b9c5fcdf49ef6d0e3da8). 

Results on my machine.

```
array_key_last_symfony
0.1387140750885

array_key_last
0.055586814880371
```