### PR TITLE
add phpunit 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
         - php: 7.1
         - php: 7.2
         - php: 7.3
+          env: SYMFONY_PHPUNIT_VERSION=7.2
         - php: nightly
     allow_failures:
         - php: nightly

--- a/src/Util/TestListener.php
+++ b/src/Util/TestListener.php
@@ -11,92 +11,18 @@
 
 namespace Symfony\Polyfill\Util;
 
-use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\Test;
-use PHPUnit\Framework\TestListener as TestListenerInterface;
-use PHPUnit\Framework\TestSuite;
-use PHPUnit\Framework\Warning;
-use PHPUnit\Framework\WarningTestCase;
-
 if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '6.0.0', '<')) {
-    class_alias('Symfony\Polyfill\Util\LegacyTestListener', 'Symfony\Polyfill\Util\TestListener');
+    class_alias('Symfony\Polyfill\Util\TestListenerForV5', 'Symfony\Polyfill\Util\TestListener');
 // Using an early return instead of a else does not work when using the PHPUnit phar due to some weird PHP behavior (the class
 // gets defined without executing the code before it and so the definition is not properly conditional)
+} elseif (version_compare(\PHPUnit\Runner\Version::id(), '7.0.0', '<')) {
+    class_alias('Symfony\Polyfill\Util\TestListenerForV6', 'Symfony\Polyfill\Util\TestListener');
 } else {
-    /**
-     * @author Nicolas Grekas <p@tchwork.com>
-     */
-    class TestListener extends TestSuite implements TestListenerInterface
+    class_alias('Symfony\Polyfill\Util\TestListenerForV7', 'Symfony\Polyfill\Util\TestListener');
+}
+
+if (false) {
+    class TestListener
     {
-        private $suite;
-        private $trait;
-
-        public function __construct(TestSuite $suite = null)
-        {
-            if ($suite) {
-                $this->suite = $suite;
-                $this->setName($suite->getName().' with polyfills enabled');
-                $this->addTest($suite);
-            }
-            $this->trait = new TestListenerTrait();
-        }
-
-        public function startTestSuite(TestSuite $suite)
-        {
-            $this->trait->startTestSuite($suite);
-        }
-
-        protected function setUp()
-        {
-            TestListenerTrait::$enabledPolyfills = $this->suite->getName();
-        }
-
-        protected function tearDown()
-        {
-            TestListenerTrait::$enabledPolyfills = false;
-        }
-
-        public function addError(Test $test, \Exception $e, $time)
-        {
-            $this->trait->addError($test, $e, $time);
-        }
-
-        public function addWarning(Test $test, Warning $e, $time)
-        {
-        }
-
-        public function addFailure(Test $test, AssertionFailedError $e, $time)
-        {
-            $this->trait->addError($test, $e, $time);
-        }
-
-        public function addIncompleteTest(Test $test, \Exception $e, $time)
-        {
-        }
-
-        public function addRiskyTest(Test $test, \Exception $e, $time)
-        {
-        }
-
-        public function addSkippedTest(Test $test, \Exception $e, $time)
-        {
-        }
-
-        public function endTestSuite(TestSuite $suite)
-        {
-        }
-
-        public function startTest(Test $test)
-        {
-        }
-
-        public function endTest(Test $test, $time)
-        {
-        }
-
-        public static function warning($message)
-        {
-            return parent::warning($message);
-        }
     }
 }

--- a/src/Util/TestListenerForV5.php
+++ b/src/Util/TestListenerForV5.php
@@ -14,7 +14,7 @@ namespace Symfony\Polyfill\Util;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class LegacyTestListener extends \PHPUnit_Framework_TestSuite implements \PHPUnit_Framework_TestListener
+class TestListenerForV5 extends \PHPUnit_Framework_TestSuite implements \PHPUnit_Framework_TestListener
 {
     private $suite;
     private $trait;
@@ -32,16 +32,6 @@ class LegacyTestListener extends \PHPUnit_Framework_TestSuite implements \PHPUni
     public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
     {
         $this->trait->startTestSuite($suite);
-    }
-
-    protected function setUp()
-    {
-        TestListenerTrait::$enabledPolyfills = $this->suite->getName();
-    }
-
-    protected function tearDown()
-    {
-        TestListenerTrait::$enabledPolyfills = false;
     }
 
     public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)
@@ -85,5 +75,15 @@ class LegacyTestListener extends \PHPUnit_Framework_TestSuite implements \PHPUni
     public static function warning($message)
     {
         return parent::warning($message);
+    }
+
+    protected function setUp()
+    {
+        TestListenerTrait::$enabledPolyfills = $this->suite->getName();
+    }
+
+    protected function tearDown()
+    {
+        TestListenerTrait::$enabledPolyfills = false;
     }
 }

--- a/src/Util/TestListenerForV6.php
+++ b/src/Util/TestListenerForV6.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Util;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestListener as TestListenerInterface;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Warning;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class TestListenerForV6 extends TestSuite implements TestListenerInterface
+{
+    private $suite;
+    private $trait;
+
+    public function __construct(TestSuite $suite = null)
+    {
+        if ($suite) {
+            $this->suite = $suite;
+            $this->setName($suite->getName().' with polyfills enabled');
+            $this->addTest($suite);
+        }
+        $this->trait = new TestListenerTrait();
+    }
+
+    public function startTestSuite(TestSuite $suite)
+    {
+        $this->trait->startTestSuite($suite);
+    }
+
+    public function addError(Test $test, \Exception $e, $time)
+    {
+        $this->trait->addError($test, $e, $time);
+    }
+
+    public function addWarning(Test $test, Warning $e, $time)
+    {
+    }
+
+    public function addFailure(Test $test, AssertionFailedError $e, $time)
+    {
+        $this->trait->addError($test, $e, $time);
+    }
+
+    public function addIncompleteTest(Test $test, \Exception $e, $time)
+    {
+    }
+
+    public function addRiskyTest(Test $test, \Exception $e, $time)
+    {
+    }
+
+    public function addSkippedTest(Test $test, \Exception $e, $time)
+    {
+    }
+
+    public function endTestSuite(TestSuite $suite)
+    {
+    }
+
+    public function startTest(Test $test)
+    {
+    }
+
+    public function endTest(Test $test, $time)
+    {
+    }
+
+    public static function warning($message)
+    {
+        return parent::warning($message);
+    }
+
+    protected function setUp()
+    {
+        TestListenerTrait::$enabledPolyfills = $this->suite->getName();
+    }
+
+    protected function tearDown()
+    {
+        TestListenerTrait::$enabledPolyfills = false;
+    }
+}

--- a/src/Util/TestListenerForV7.php
+++ b/src/Util/TestListenerForV7.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Util;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestListener as TestListenerInterface;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Warning;
+use PHPUnit\Framework\WarningTestCase;
+
+/**
+ * @author Ion Bazan <ion.bazan@gmail.com>
+ */
+class TestListenerForV7 extends TestSuite implements TestListenerInterface
+{
+    private $suite;
+    private $trait;
+
+    public function __construct(TestSuite $suite = null)
+    {
+        if ($suite) {
+            $this->suite = $suite;
+            $this->setName($suite->getName().' with polyfills enabled');
+            $this->addTest($suite);
+        }
+        $this->trait = new TestListenerTrait();
+    }
+
+    public function startTestSuite(TestSuite $suite): void
+    {
+        $this->trait->startTestSuite($suite);
+    }
+
+    public function addError(Test $test, \Throwable $t, float $time): void
+    {
+        $this->trait->addError($test, $e, $time);
+    }
+
+    public function addWarning(Test $test, Warning $e, float $time): void
+    {
+    }
+
+    public function addFailure(Test $test, AssertionFailedError $e, float $time): void
+    {
+        $this->trait->addError($test, $e, $time);
+    }
+
+    public function addIncompleteTest(Test $test, \Throwable $t, float $time): void
+    {
+    }
+
+    public function addRiskyTest(Test $test, \Throwable $t, float $time): void
+    {
+    }
+
+    public function addSkippedTest(Test $test, \Throwable $t, float $time): void
+    {
+    }
+
+    public function endTestSuite(TestSuite $suite): void
+    {
+    }
+
+    public function startTest(Test $test): void
+    {
+    }
+
+    public function endTest(Test $test, float $time): void
+    {
+    }
+
+    public static function warning($message): WarningTestCase
+    {
+        return parent::warning($message);
+    }
+
+    protected function setUp(): void
+    {
+        TestListenerTrait::$enabledPolyfills = $this->suite->getName();
+    }
+
+    protected function tearDown(): void
+    {
+        TestListenerTrait::$enabledPolyfills = false;
+    }
+}

--- a/src/Util/TestListenerForV7.php
+++ b/src/Util/TestListenerForV7.php
@@ -43,7 +43,7 @@ class TestListenerForV7 extends TestSuite implements TestListenerInterface
 
     public function addError(Test $test, \Throwable $t, float $time): void
     {
-        $this->trait->addError($test, $e, $time);
+        $this->trait->addError($test, $t, $time);
     }
 
     public function addWarning(Test $test, Warning $e, float $time): void

--- a/src/Util/TestListenerTrait.php
+++ b/src/Util/TestListenerTrait.php
@@ -25,7 +25,6 @@ class TestListenerTrait
         }
         self::$enabledPolyfills = false;
         $SkippedTestError = class_exists('PHPUnit\Framework\SkippedTestError') ? 'PHPUnit\Framework\SkippedTestError' : 'PHPUnit_Framework_SkippedTestError';
-        $TestListener = class_exists('Symfony\Polyfill\Util\TestListener', false) ? 'Symfony\Polyfill\Util\TestListener' : 'Symfony\Polyfill\Util\LegacyTestListener';
 
         foreach ($mainSuite->tests() as $suite) {
             $testClass = $suite->getName();
@@ -33,7 +32,7 @@ class TestListenerTrait
                 continue;
             }
             if (!preg_match('/^(.+)\\\\Tests(\\\\.*)Test$/', $testClass, $m)) {
-                $mainSuite->addTest($TestListener::warning('Unknown naming convention for '.$testClass));
+                $mainSuite->addTest(TestListener::warning('Unknown naming convention for '.$testClass));
                 continue;
             }
             if (!class_exists($m[1].$m[2])) {
@@ -53,9 +52,9 @@ class TestListenerTrait
                 try {
                     eval($defLine);
                 } catch (\PHPUnit_Framework_Exception $ex){
-                    $warnings[] = $TestListener::warning($ex->getMessage());
+                    $warnings[] = TestListener::warning($ex->getMessage());
                 } catch (\PHPUnit\Framework\Exception $ex) {
-                    $warnings[] = $TestListener::warning($ex->getMessage());
+                    $warnings[] = TestListener::warning($ex->getMessage());
                 }
             }
 
@@ -63,7 +62,7 @@ class TestListenerTrait
 
             foreach (new \RegexIterator($bootstrap, '/return p\\\\'.$testedClass->getShortName().'::/') as $defLine) {
                 if (!preg_match('/^\s*function (?P<name>[^\(]++)(?P<signature>\(.*\)) \{ (?<return>return p\\\\'.$testedClass->getShortName().'::[^\(]++)(?P<args>\([^\)]*+\)); \}$/', $defLine, $f)) {
-                    $warnings[] = $TestListener::warning('Invalid line in bootstrap.php: '.trim($defLine));
+                    $warnings[] = TestListener::warning('Invalid line in bootstrap.php: '.trim($defLine));
                     continue;
                 }
                 $testNamespace = substr($testClass, 0, strrpos($testClass, '\\'));
@@ -107,7 +106,7 @@ EOPHP
             if (!$warnings && null === $defLine) {
                 $warnings[] = new $SkippedTestError('No Polyfills found in bootstrap.php for '.$testClass);
             } else {
-                $mainSuite->addTest(new $TestListener($suite));
+                $mainSuite->addTest(new TestListener($suite));
             }
         }
         foreach ($warnings as $w) {


### PR DESCRIPTION
This PR fixes support for PHPUnit 7.2 by adding a separate `TestListener` for each major PHPUnit version.

It should fix #144 and is based on #133.