### PR TITLE
Redefine INTL_IDN_VARIANT_* constants on the Idn class

### DIFF
--- a/src/Intl/Idn/Idn.php
+++ b/src/Intl/Idn/Idn.php
@@ -43,6 +43,9 @@ namespace Symfony\Polyfill\Intl\Idn;
  */
 final class Idn
 {
+    const INTL_IDNA_VARIANT_2003 = 0;
+    const INTL_IDNA_VARIANT_UTS46 = 1;
+
     private static $encodeTable = array(
         'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
         'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
@@ -60,11 +63,11 @@ final class Idn
 
     public static function idn_to_ascii($domain, $options, $variant, &$idna_info = array())
     {
-        if (\PHP_VERSION_ID >= 70200 && INTL_IDNA_VARIANT_2003 === $variant) {
+        if (\PHP_VERSION_ID >= 70200 && self::INTL_IDNA_VARIANT_2003 === $variant) {
             @trigger_error('idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated', E_USER_DEPRECATED);
         }
 
-        if (INTL_IDNA_VARIANT_UTS46 === $variant) {
+        if (self::INTL_IDNA_VARIANT_UTS46 === $variant) {
             $domain = mb_strtolower($domain, 'utf-8');
         }
 
@@ -92,7 +95,7 @@ final class Idn
 
     public static function idn_to_utf8($domain, $options, $variant, &$idna_info = array())
     {
-        if (\PHP_VERSION_ID >= 70200 && INTL_IDNA_VARIANT_2003 === $variant) {
+        if (\PHP_VERSION_ID >= 70200 && self::INTL_IDNA_VARIANT_2003 === $variant) {
             @trigger_error('idn_to_utf8(): INTL_IDNA_VARIANT_2003 is deprecated', E_USER_DEPRECATED);
         }
 


### PR DESCRIPTION
I'm currently working on a project where we have to deploy the application to servers with a strange configuration. The servers run php 5.6, but instead of the bundled `ext-intl` the very outdated version 1.1 of `pecl/intl` is installed.

If I install the polyfill there, the `bootstrap.php` scrit will find an already defined `idn_to_ascii` function and do nothing. This is why I'd like to force the usage of the polyfill code here.

The problem that I have is that the old `pecl/intl` does not define all constants. To be more precise, `INTL_IDNA_VARIANT_UTS46` is missing because version 1.1 did not yet support the `$variant` parameter.

In order to solve this problem for me, I have redefined all constants on the `Idn` class.