### PR TITLE
Add support of JSON_THROW_ON_ERROR global constant

### DIFF
--- a/src/Php73/bootstrap.php
+++ b/src/Php73/bootstrap.php
@@ -28,4 +28,8 @@ if (PHP_VERSION_ID < 70300) {
     if (!function_exists('array_key_last')) {
         function array_key_last(array $array) { end($array); return key($array); }
     }
+    
+    if (!defined('JSON_THROW_ON_ERROR')) {
+        define('JSON_THROW_ON_ERROR', 4194304);
+    }
 }


### PR DESCRIPTION
Added support of the `JSON_THROW_ON_ERROR` constant which was added in PHP 7.3

https://secure.php.net/manual/en/json.constants.php#constant.json-throw-on-error