### PR TITLE
ensure Php73 class is loaded for bootstrap

### DIFF
--- a/src/Php73/bootstrap.php
+++ b/src/Php73/bootstrap.php
@@ -17,6 +17,7 @@ if (PHP_VERSION_ID < 70300) {
     }
 
     if (!function_exists('hrtime')) {
+        require_once __DIR__.'/Php73.php';
         p\Php73::$startAt = (int) microtime(true);
         function hrtime($asNum = false) { return p\Php73::hrtime($asNum); }
     }


### PR DESCRIPTION
Some composer plugins (like monorepo) will cause files to be loaded before the autoloader is fully registered, so class files must be manually loaded