### PR TITLE
add new PHP 7.4 functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,10 @@ matrix:
         - php: 7.2
         - php: 7.3
           env: SYMFONY_PHPUNIT_VERSION=7.2
+        - php: 7.4snapshot
+          env: SYMFONY_PHPUNIT_VERSION=7.2
         - php: nightly
+          env: SYMFONY_PHPUNIT_VERSION=7.2
     allow_failures:
         - php: nightly
     fast_finish: true
@@ -32,7 +35,7 @@ before_install:
     - phpenv config-rm xdebug.ini || echo "xdebug not available"
     - if [[ $TRAVIS_PHP_VERSION = 5.* ]]; then echo yes | pecl install -f apcu-4.0.11; fi
     - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then echo yes | pecl install -f apcu_bc-1.0.4; fi
-    - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then echo yes | pecl install -f apcu-5.1.11; fi
+    - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then echo yes | pecl install -f apcu-5.1.17; fi
     - php -i
 
 install:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Polyfills are provided for:
 - the `is_countable` function introduced in PHP 7.3;
 - the `array_key_first` and `array_key_last` functions introduced in PHP 7.3;
 - the `hrtime` function introduced in PHP 7.3;
-- the `JsonException` class introduced in PHP 7.3.
+- the `JsonException` class introduced in PHP 7.3;
+- the `get_mangled_object_vars`, `mb_str_split` and `password_algos` functions
+  introduced in PHP 7.4;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no
@@ -67,6 +69,7 @@ should **not** `require` the `symfony/polyfill` package, but the standalone ones
 - `symfony/polyfill-php71` for using the PHP 7.1 functions,
 - `symfony/polyfill-php72` for using the PHP 7.2 functions,
 - `symfony/polyfill-php73` for using the PHP 7.3 functions,
+- `symfony/polyfill-php74` for using the PHP 7.4 functions,
 - `symfony/polyfill-iconv` for using the iconv functions,
 - `symfony/polyfill-intl-grapheme` for using the `grapheme_*` functions,
 - `symfony/polyfill-intl-idn` for using the `idn_to_ascii` and `idn_to_utf8` functions,

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "symfony/polyfill-php71": "self.version",
         "symfony/polyfill-php72": "self.version",
         "symfony/polyfill-php73": "self.version",
+        "symfony/polyfill-php74": "self.version",
         "symfony/polyfill-iconv": "self.version",
         "symfony/polyfill-intl-grapheme": "self.version",
         "symfony/polyfill-intl-icu": "self.version",
@@ -56,6 +57,7 @@
             "src/Php71/bootstrap.php",
             "src/Php72/bootstrap.php",
             "src/Php73/bootstrap.php",
+            "src/Php74/bootstrap.php",
             "src/Iconv/bootstrap.php",
             "src/Intl/Grapheme/bootstrap.php",
             "src/Intl/Idn/bootstrap.php",
@@ -75,7 +77,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.11-dev"
+            "dev-master": "1.12-dev"
         }
     }
 }

--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -35,6 +35,7 @@ namespace Symfony\Polyfill\Mbstring;
  * - mb_strlen               - Get string length
  * - mb_strpos               - Find position of first occurrence of string in a string
  * - mb_strrpos              - Find position of last occurrence of a string in a string
+ * - mb_str_split            - Convert a string to an array
  * - mb_strtolower           - Make a string lowercase
  * - mb_strtoupper           - Make a string uppercase
  * - mb_substitute_character - Set/Get substitution character
@@ -521,6 +522,34 @@ final class Mbstring
         $pos = iconv_strrpos($haystack, $needle, $encoding);
 
         return false !== $pos ? $offset + $pos : false;
+    }
+
+    public static function mb_str_split($string, $split_length = 1, $encoding = null)
+    {
+        if (null !== $string && !\is_scalar($string) && !(\is_object($string) && \method_exists($string, '__toString'))) {
+            trigger_error('mb_str_split() expects parameter 1 to be string, '.\gettype($string).' given', E_USER_WARNING);
+
+            return null;
+        }
+
+        if ($split_length < 1) {
+            trigger_error('The length of each segment must be greater than zero', E_USER_WARNING);
+
+            return false;
+        }
+
+        if (null === $encoding) {
+            $encoding = mb_internal_encoding();
+        }
+
+        $result = array();
+        $length = mb_strlen($string, $encoding);
+
+        for ($i = 0; $i < $length; $i += $split_length) {
+            $result[] = mb_substr($string, $i, $split_length, $encoding);
+        }
+
+        return $result;
     }
 
     public static function mb_strtolower($s, $encoding = null)

--- a/src/Mbstring/bootstrap.php
+++ b/src/Mbstring/bootstrap.php
@@ -56,3 +56,7 @@ if (!function_exists('mb_chr')) {
     function mb_chr($code, $enc = null) { return p\Mbstring::mb_chr($code, $enc); }
     function mb_scrub($s, $enc = null) { $enc = null === $enc ? mb_internal_encoding() : $enc; return mb_convert_encoding($s, $enc, $enc); }
 }
+
+if (!function_exists('mb_str_split')) {
+    function mb_str_split($string, $split_length = 1, $encoding = null) { return p\Mbstring::mb_str_split($string, $split_length, $encoding); }
+}

--- a/src/Php73/Php73.php
+++ b/src/Php73/Php73.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Polyfill\Php73;
 
 /**
@@ -19,8 +28,8 @@ final class Php73
      */
     public static function hrtime($asNum = false)
     {
-        $ns = \microtime(false);
-        $s = \substr($ns, 11) - self::$startAt;
+        $ns = microtime(false);
+        $s = substr($ns, 11) - self::$startAt;
         $ns = 1E9 * (float) $ns;
 
         if ($asNum) {

--- a/src/Php74/Php74.php
+++ b/src/Php74/Php74.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Php74;
+
+/**
+ * @author Ion Bazan <ion.bazan@gmail.com>
+ *
+ * @internal
+ */
+final class Php74
+{
+    public static function get_mangled_object_vars($obj)
+    {
+        if (!\is_object($obj)) {
+            trigger_error('get_mangled_object_vars() expects parameter 1 to be object, '.\gettype($obj).' given', E_USER_WARNING);
+
+            return null;
+        }
+
+        if ($obj instanceof \ArrayIterator || $obj instanceof \ArrayObject) {
+            $reflector = new \ReflectionClass($obj instanceof \ArrayIterator ? 'ArrayIterator' : 'ArrayObject');
+            $flags = $reflector->getMethod('getFlags')->invoke($obj);
+            $reflector = $reflector->getMethod('setFlags');
+
+            $reflector->invoke($obj, ($flags & \ArrayObject::STD_PROP_LIST) ? 0 : \ArrayObject::STD_PROP_LIST);
+            $arr = (array) $obj;
+            $reflector->invoke($obj, $flags);
+        } else {
+            $arr = (array) $obj;
+        }
+
+        return array_combine(array_keys($arr), array_values($arr));
+    }
+
+    public static function mb_str_split($string, $split_length = 1, $encoding = null)
+    {
+        if (null !== $string && !\is_scalar($string) && !(\is_object($string) && \method_exists($string, '__toString'))) {
+            trigger_error('mb_str_split() expects parameter 1 to be string, '.\gettype($string).' given', E_USER_WARNING);
+
+            return null;
+        }
+
+        if ($split_length < 1) {
+            trigger_error('The length of each segment must be greater than zero', E_USER_WARNING);
+
+            return false;
+        }
+
+        if (null === $encoding) {
+            $encoding = mb_internal_encoding();
+        }
+
+        $result = array();
+        $length = mb_strlen($string, $encoding);
+
+        for ($i = 0; $i < $length; $i += $split_length) {
+            $result[] = mb_substr($string, $i, $split_length, $encoding);
+        }
+
+        return $result;
+    }
+
+    public static function password_algos()
+    {
+        $algos = array();
+
+        if (\defined('PASSWORD_BCRYPT')) {
+            $algos[] = PASSWORD_BCRYPT;
+        }
+
+        if (\defined('PASSWORD_ARGON2I')) {
+            $algos[] = PASSWORD_ARGON2I;
+        }
+
+        if (\defined('PASSWORD_ARGON2ID')) {
+            $algos[] = PASSWORD_ARGON2ID;
+        }
+
+        return $algos;
+    }
+}

--- a/src/Php74/README.md
+++ b/src/Php74/README.md
@@ -1,0 +1,16 @@
+Symfony Polyfill / Php74
+========================
+
+This component provides functions added to PHP 7.4 core:
+
+- [`get_mangled_object_vars`](https://php.net/get_mangled_object_vars)
+- [`mb_str_split`](https://php.net/mb_str_split)
+- [`password_algos`](https://php.net/password_algos)
+
+More information can be found in the
+[main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
+
+License
+=======
+
+This library is released under the [MIT license](LICENSE).

--- a/src/Php74/bootstrap.php
+++ b/src/Php74/bootstrap.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\Php74 as p;
+
+if (PHP_VERSION_ID < 70400) {
+    if (!function_exists('get_mangled_object_vars')) {
+        function get_mangled_object_vars($obj) { return p\Php74::get_mangled_object_vars($obj); }
+    }
+
+    if (!function_exists('mb_str_split') && function_exists('mb_substr')) {
+        function mb_str_split($string, $split_length = 1, $encoding = null) { return p\Php74::mb_str_split($string, $split_length, $encoding); }
+    }
+
+    if (!function_exists('password_algos')) {
+        function password_algos() { return p\Php74::password_algos(); }
+    }
+}

--- a/src/Php74/composer.json
+++ b/src/Php74/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "symfony/polyfill-php74",
+    "type": "library",
+    "description": "Symfony polyfill backporting some PHP 7.4+ features to lower PHP versions",
+    "keywords": ["polyfill", "shim", "compatibility", "portable"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Ion Bazan",
+            "email": "ion.bazan@gmail.com"
+        },
+        {
+            "name": "Nicolas Grekas",
+            "email": "p@tchwork.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.3"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Polyfill\\Php74\\": "" },
+        "files": [ "bootstrap.php" ]
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.12-dev"
+        }
+    }
+}

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -309,6 +309,23 @@ class MbstringTest extends TestCase
     }
 
     /**
+     * @covers \Symfony\Polyfill\Mbstring\Mbstring::mb_str_split
+     */
+    public function testStrSplit()
+    {
+        $this->assertSame(array('한', '국', '어'), mb_str_split('한국어'));
+        $this->assertSame(array('по', 'бе', 'да'), mb_str_split('победа', 2));
+        $this->assertSame(array('źre', 'bię'), mb_str_split('źrebię', 3));
+        $this->assertSame(array('źr', 'ebi', 'ę'), mb_str_split('źrebię', 3, 'ASCII'));
+        $this->assertSame(array('alpha', 'bet'), mb_str_split('alphabet', 5));
+        $this->assertFalse(@mb_str_split('победа', 0));
+        $this->assertNull(@mb_str_split(array(), 0));
+
+        $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'The length of each segment must be greater than zero');
+        mb_str_split('победа', 0);
+    }
+
+    /**
      * @covers \Symfony\Polyfill\Mbstring\Mbstring::mb_strstr
      * @covers \Symfony\Polyfill\Mbstring\Mbstring::mb_stristr
      * @covers \Symfony\Polyfill\Mbstring\Mbstring::mb_strrchr

--- a/tests/Php74/Php74Test.php
+++ b/tests/Php74/Php74Test.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Php74;
+
+use ArrayObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Ion Bazan <ion.bazan@gmail.com>
+ */
+class Php74Test extends TestCase
+{
+    /**
+     * @covers \Symfony\Polyfill\Php74\Php74::get_mangled_object_vars
+     */
+    public function testGetMangledObjectVarsOnObject()
+    {
+        $obj = new B();
+        $obj->dyn = 5;
+        $obj->{'6'} = 6;
+
+        $this->assertSame(array(
+            "\0".'Symfony\Polyfill\Tests\Php74\B'."\0".'priv' => 4,
+            'pub' => 1,
+            "\0".'*'."\0".'prot' => 2,
+            "\0".'Symfony\Polyfill\Tests\Php74\A'."\0".'priv' => 3,
+            'dyn' => 5,
+            6 => 6,
+        ), get_mangled_object_vars($obj));
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php74\Php74::get_mangled_object_vars
+     */
+    public function testGetMangledObjectVarsOnArrayObject()
+    {
+        $ao = new AO(array('x' => 'y'));
+        $ao->dyn = 2;
+
+        $this->assertSame(array(
+            "\0".'Symfony\Polyfill\Tests\Php74\AO'."\0".'priv' => 1,
+            'dyn' => 2,
+        ), get_mangled_object_vars($ao));
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php74\Php74::get_mangled_object_vars
+     */
+    public function testGetMangledObjectVarsOnNonObject()
+    {
+        $this->assertNull(@get_mangled_object_vars(0));
+        $this->assertNull(@get_mangled_object_vars(true));
+        $this->assertNull(@get_mangled_object_vars('string'));
+        $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'expects parameter 1 to be object');
+        get_mangled_object_vars(1);
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php74\Php74::password_algos
+     */
+    public function testPasswordAlgos()
+    {
+        $algos = password_algos();
+
+        if (\defined('PASSWORD_BCRYPT')) {
+            $this->assertContains(PASSWORD_BCRYPT, $algos);
+        }
+
+        if (\defined('PASSWORD_ARGON2I')) {
+            $this->assertContains(PASSWORD_ARGON2I, $algos);
+        }
+
+        if (\defined('PASSWORD_ARGON2ID')) {
+            $this->assertContains(PASSWORD_ARGON2ID, $algos);
+        }
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php74\Php74::mb_str_split
+     */
+    public function testStrSplit()
+    {
+        $this->assertSame(array('한', '국', '어'), mb_str_split('한국어'));
+        $this->assertSame(array('по', 'бе', 'да'), mb_str_split('победа', 2));
+        $this->assertSame(array('źre', 'bię'), mb_str_split('źrebię', 3));
+        $this->assertSame(array('źr', 'ebi', 'ę'), mb_str_split('źrebię', 3, 'ASCII'));
+        $this->assertSame(array('alpha', 'bet'), mb_str_split('alphabet', 5));
+        $this->assertFalse(@mb_str_split('победа', 0));
+        $this->assertNull(@mb_str_split(array(), 0));
+
+        $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'The length of each segment must be greater than zero');
+        mb_str_split('победа', 0);
+    }
+
+    public function setExpectedException($exception, $message = '', $code = null)
+    {
+        if (!class_exists('PHPUnit\Framework\Error\Notice')) {
+            $exception = str_replace('PHPUnit\\Framework\\Error\\', 'PHPUnit_Framework_Error_', $exception);
+        }
+        if (method_exists($this, 'expectException')) {
+            $this->expectException($exception);
+            $this->expectExceptionMessage($message);
+        } else {
+            parent::setExpectedException($exception, $message, $code);
+        }
+    }
+}
+
+class A
+{
+    public $pub = 1;
+    protected $prot = 2;
+    private $priv = 3;
+}
+
+class B extends A
+{
+    private $priv = 4;
+}
+
+class AO extends ArrayObject
+{
+    private $priv = 1;
+
+    public function getFlags()
+    {
+        return self::ARRAY_AS_PROPS | self::STD_PROP_LIST;
+    }
+}


### PR DESCRIPTION
This PR adds new PHP 7.4 functions:
- [x] `get_mangled_object_vars` (https://github.com/php/php-src/commit/eecd8961d94c50cc6cdc94ec80df8c1ce4881a76)
- [x] `mb_str_split` (https://wiki.php.net/rfc/mb_str_split)
- [x] `password_algos` (https://wiki.php.net/rfc/password_registry)

Closes #179 and replaces #178 