### PR TITLE
[Mbstring] weird behaviour with mb_substr on PHP5 versions

### DIFF
--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -245,6 +245,9 @@ class MbstringTest extends TestCase
         $c = 'déjà';
 
         $this->assertSame('jà', mb_substr($c, 2));
+        $this->assertSame('à', mb_substr($c, 3));
+        $this->assertSame('', mb_substr($c, 4));
+        $this->assertSame('', mb_substr($c, 5));
         $this->assertSame('jà', mb_substr($c, -2));
         $this->assertSame('jà', mb_substr($c, -2, 3));
         $this->assertSame('', mb_substr($c, -1, 0));


### PR DESCRIPTION
While working on #183 I observed weird differences between polyfill's mb_substr and native mb_substr on PHP5 versions

This time, the issue was with UTF-8 encoding.

Here is the 3v4l.org link with the results I had:
https://3v4l.org/RQIL6


In this range of versions (5.4.0 - 5.4.45), there is an error which says that the iconv_substr() does not exists (??) but maybe it's a bug in 3v4l.
In this range of versions (5.0.0 - 5.3.29, 5.5.0 - 5.5.38), none of the tests give the same results. One of the test even truncate a UTF-8 character in half.

If I'm not mistaken, we should see that in the CI tests too.

I don't know what to do with that... Any advice?

EDIT: The truncated character was returned by the native mb_substr. Either I'm missing something or there is a serious issue here...
