### PR TITLE
Compatibility fix for PHP 7 and higher for polyfill-php70 package

### DIFF
--- a/src/Php70/Resources/stubs/ArithmeticError.php
+++ b/src/Php70/Resources/stubs/ArithmeticError.php
@@ -1,5 +1,7 @@
 <?php
 
-class ArithmeticError extends Error
-{
+if (!class_exists('ArithmeticError')) {
+	class ArithmeticError extends Error
+	{
+	}
 }

--- a/src/Php70/Resources/stubs/AssertionError.php
+++ b/src/Php70/Resources/stubs/AssertionError.php
@@ -1,5 +1,7 @@
 <?php
 
-class AssertionError extends Error
-{
+if (!class_exists('AssertionError')) {
+	class AssertionError extends Error
+	{
+	}
 }

--- a/src/Php70/Resources/stubs/DivisionByZeroError.php
+++ b/src/Php70/Resources/stubs/DivisionByZeroError.php
@@ -1,5 +1,7 @@
 <?php
 
-class DivisionByZeroError extends Error
-{
+if (!class_exists('DivisionByZeroError')) {
+	class DivisionByZeroError extends Error
+	{
+	}
 }

--- a/src/Php70/Resources/stubs/Error.php
+++ b/src/Php70/Resources/stubs/Error.php
@@ -1,5 +1,7 @@
 <?php
 
-class Error extends Exception
-{
+if (!class_exists('Error')) {
+	class Error extends Exception
+	{
+	}
 }

--- a/src/Php70/Resources/stubs/ParseError.php
+++ b/src/Php70/Resources/stubs/ParseError.php
@@ -1,5 +1,7 @@
 <?php
 
-class ParseError extends Error
-{
+if (!class_exists('ParseError')) {
+	class ParseError extends Error
+	{
+	}
 }

--- a/src/Php70/Resources/stubs/SessionUpdateTimestampHandlerInterface.php
+++ b/src/Php70/Resources/stubs/SessionUpdateTimestampHandlerInterface.php
@@ -1,23 +1,25 @@
 <?php
 
-interface SessionUpdateTimestampHandlerInterface
-{
-    /**
-     * Checks if a session identifier already exists or not.
-     *
-     * @param string $key
-     *
-     * @return bool
-     */
-    public function validateId($key);
+if (!interface_exists('SessionUpdateTimestampHandlerInterface')) {
+    interface SessionUpdateTimestampHandlerInterface
+    {
+        /**
+         * Checks if a session identifier already exists or not.
+         *
+         * @param string $key
+         *
+         * @return bool
+         */
+        public function validateId($key);
 
-    /**
-     * Updates the timestamp of a session when its data didn't change.
-     *
-     * @param string $key
-     * @param string $val
-     *
-     * @return bool
-     */
-    public function updateTimestamp($key, $val);
+        /**
+         * Updates the timestamp of a session when its data didn't change.
+         *
+         * @param string $key
+         * @param string $val
+         *
+         * @return bool
+         */
+        public function updateTimestamp($key, $val);
+    }
 }

--- a/src/Php70/Resources/stubs/TypeError.php
+++ b/src/Php70/Resources/stubs/TypeError.php
@@ -1,5 +1,7 @@
 <?php
 
-class TypeError extends Error
-{
+if (!class_exists('TypeError')) {
+	class TypeError extends Error
+	{
+	}
 }


### PR DESCRIPTION
symfony/polyfill-php70 package, as composer.json says, requires PHP >=5.3.3 but on practice if my environment uses PHP >= 7.0.0, name conflict occurs. PR fixes this issue.