### PR TITLE
Optimization of mb_str_split

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -534,7 +534,7 @@ final class Mbstring
             return null;
         }
 
-        if ($split_length < 1) {
+        if (1 > $split_length = (int) $split_length) {
             trigger_error('The length of each segment must be greater than zero', E_USER_WARNING);
 
             return false;
@@ -542,6 +542,10 @@ final class Mbstring
 
         if (null === $encoding) {
             $encoding = mb_internal_encoding();
+        }
+
+        if ('UTF-8' === $encoding = self::getEncoding($encoding)) {
+            return preg_split("/(.{{$split_length}})/u", $string, null, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         }
 
         $result = array();
@@ -817,11 +821,16 @@ final class Mbstring
             return self::$internalEncoding;
         }
 
+        if ('UTF-8' === $encoding) {
+            return 'UTF-8';
+        }
+
         $encoding = strtoupper($encoding);
 
         if ('8BIT' === $encoding || 'BINARY' === $encoding) {
             return 'CP850';
         }
+
         if ('UTF8' === $encoding) {
             return 'UTF-8';
         }

--- a/src/Php74/Php74.php
+++ b/src/Php74/Php74.php
@@ -49,7 +49,7 @@ final class Php74
             return null;
         }
 
-        if ($split_length < 1) {
+        if (1 > $split_length = (int) $split_length) {
             trigger_error('The length of each segment must be greater than zero', E_USER_WARNING);
 
             return false;
@@ -57,6 +57,10 @@ final class Php74
 
         if (null === $encoding) {
             $encoding = mb_internal_encoding();
+        }
+
+        if ('UTF-8' === $encoding || \in_array(strtoupper($encoding), array('UTF-8', 'UTF8'), true)) {
+            return preg_split("/(.{{$split_length}})/u", $string, null, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         }
 
         $result = array();

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -323,6 +323,8 @@ class MbstringTest extends TestCase
         $this->assertSame(array('źre', 'bię'), mb_str_split('źrebię', 3));
         $this->assertSame(array('źr', 'ebi', 'ę'), mb_str_split('źrebię', 3, 'ASCII'));
         $this->assertSame(array('alpha', 'bet'), mb_str_split('alphabet', 5));
+        $this->assertSame(array('e', '́', '💩', '𐍈'), mb_str_split('é💩𐍈', 1, 'UTF-8'));
+        $this->assertSame(array(), mb_str_split('', 1, 'UTF-8'));
         $this->assertFalse(@mb_str_split('победа', 0));
         $this->assertNull(@mb_str_split(array(), 0));
 

--- a/tests/Php74/Php74Test.php
+++ b/tests/Php74/Php74Test.php
@@ -94,6 +94,8 @@ class Php74Test extends TestCase
         $this->assertSame(array('źre', 'bię'), mb_str_split('źrebię', 3));
         $this->assertSame(array('źr', 'ebi', 'ę'), mb_str_split('źrebię', 3, 'ASCII'));
         $this->assertSame(array('alpha', 'bet'), mb_str_split('alphabet', 5));
+        $this->assertSame(array('e', '́', '💩', '𐍈'), mb_str_split('é💩𐍈', 1, 'UTF-8'));
+        $this->assertSame(array(), mb_str_split('', 1, 'UTF-8'));
         $this->assertFalse(@mb_str_split('победа', 0));
         $this->assertNull(@mb_str_split(array(), 0));
 


### PR DESCRIPTION
`mb_strlen` + `mb_substr` can be very slow for large strings. In the common case of split length 1 and charset UTF=8 we can use `preg_split` instead.

Added an early exit to the function:

    if (1 === $split_length && 'UTF-8' === $encoding) {
        return preg_split('//u', $string, null, PREG_SPLIT_NO_EMPTY);
    }


See https://3v4l.org/U6PPf