### PR TITLE
PHP 8.0 - add fdiv() function polyfill

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - php: 7.2
         - php: 7.3
           env: SYMFONY_PHPUNIT_VERSION=7.2
-        - php: 7.4snapshot
+        - php: 7.4
           env: SYMFONY_PHPUNIT_VERSION=7.2
         - php: nightly
           env: SYMFONY_PHPUNIT_VERSION=7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* v1.14.0
+
+ * added PHP 8.0 polyfill
+
 * v1.13.2
 
  * use correct block size for SHA1 in `hash_pbkdf2()` polyfill

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Polyfills are provided for:
 - the `JsonException` class introduced in PHP 7.3;
 - the `get_mangled_object_vars`, `mb_str_split` and `password_algos` functions
   introduced in PHP 7.4;
+- the `fdiv` function introduced in PHP 8.0;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no
@@ -71,6 +72,7 @@ should **not** `require` the `symfony/polyfill` package, but the standalone ones
 - `symfony/polyfill-php72` for using the PHP 7.2 functions,
 - `symfony/polyfill-php73` for using the PHP 7.3 functions,
 - `symfony/polyfill-php74` for using the PHP 7.4 functions,
+- `symfony/polyfill-php80` for using the PHP 8.0 functions,
 - `symfony/polyfill-iconv` for using the iconv functions,
 - `symfony/polyfill-intl-grapheme` for using the `grapheme_*` functions,
 - `symfony/polyfill-intl-idn` for using the `idn_to_ascii` and `idn_to_utf8` functions,

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "symfony/polyfill-php72": "self.version",
         "symfony/polyfill-php73": "self.version",
         "symfony/polyfill-php74": "self.version",
+        "symfony/polyfill-php80": "self.version",
         "symfony/polyfill-iconv": "self.version",
         "symfony/polyfill-intl-grapheme": "self.version",
         "symfony/polyfill-intl-icu": "self.version",
@@ -59,6 +60,7 @@
             "src/Php72/bootstrap.php",
             "src/Php73/bootstrap.php",
             "src/Php74/bootstrap.php",
+            "src/Php80/bootstrap.php",
             "src/Uuid/bootstrap.php",
             "src/Iconv/bootstrap.php",
             "src/Intl/Grapheme/bootstrap.php",
@@ -79,7 +81,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Apcu/composer.json
+++ b/src/Apcu/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Ctype/composer.json
+++ b/src/Ctype/composer.json
@@ -28,7 +28,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Iconv/composer.json
+++ b/src/Iconv/composer.json
@@ -28,7 +28,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Intl/Grapheme/composer.json
+++ b/src/Intl/Grapheme/composer.json
@@ -28,7 +28,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Intl/Icu/composer.json
+++ b/src/Intl/Icu/composer.json
@@ -28,7 +28,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Intl/Idn/composer.json
+++ b/src/Intl/Idn/composer.json
@@ -30,7 +30,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Intl/MessageFormatter/composer.json
+++ b/src/Intl/MessageFormatter/composer.json
@@ -29,7 +29,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Intl/Normalizer/composer.json
+++ b/src/Intl/Normalizer/composer.json
@@ -29,7 +29,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Mbstring/composer.json
+++ b/src/Mbstring/composer.json
@@ -28,7 +28,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Php54/composer.json
+++ b/src/Php54/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Php55/composer.json
+++ b/src/Php55/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Php56/composer.json
+++ b/src/Php56/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Php70/composer.json
+++ b/src/Php70/composer.json
@@ -27,7 +27,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Php72/composer.json
+++ b/src/Php72/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Php73/composer.json
+++ b/src/Php73/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Php74/composer.json
+++ b/src/Php74/composer.json
@@ -29,7 +29,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Php80/LICENSE
+++ b/src/Php80/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Php80/Php80.php
+++ b/src/Php80/Php80.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Php80;
+
+/**
+ * @author Ion Bazan <ion.bazan@gmail.com>
+ *
+ * @internal
+ */
+final class Php80
+{
+    public static function fdiv($dividend, $divisor)
+    {
+        $dividend = self::floatArg($dividend, __FUNCTION__, 1);
+        $divisor = self::floatArg($divisor, __FUNCTION__, 2);
+
+        return (float) @($dividend / $divisor);
+    }
+
+    private static function floatArg($value, $caller, $pos)
+    {
+        if (\is_float($value)) {
+            return $value;
+        }
+
+        if (!\is_numeric($value)) {
+            throw new \TypeError(sprintf('%s() expects parameter %d to be float, %s given', $caller, $pos, \gettype($value)));
+        }
+
+        return (float) $value;
+    }
+}

--- a/src/Php80/README.md
+++ b/src/Php80/README.md
@@ -1,0 +1,14 @@
+Symfony Polyfill / Php80
+========================
+
+This component provides functions added to PHP 8.0 core:
+
+- [`fdiv`](https://php.net/fdiv) (only for PHP 7.0+)
+
+More information can be found in the
+[main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
+
+License
+=======
+
+This library is released under the [MIT license](LICENSE).

--- a/src/Php80/bootstrap.php
+++ b/src/Php80/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\Php80 as p;
+
+if (PHP_VERSION_ID < 80000 && PHP_VERSION_ID >= 70000) {
+    if (!function_exists('fdiv')) {
+        function fdiv($dividend, $divisor) { return p\Php80::fdiv($dividend, $divisor); }
+    }
+}

--- a/src/Php80/composer.json
+++ b/src/Php80/composer.json
@@ -1,11 +1,15 @@
 {
-    "name": "symfony/polyfill-php71",
+    "name": "symfony/polyfill-php80",
     "type": "library",
-    "description": "Symfony polyfill backporting some PHP 7.1+ features to lower PHP versions",
+    "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
     "keywords": ["polyfill", "shim", "compatibility", "portable"],
     "homepage": "https://symfony.com",
     "license": "MIT",
     "authors": [
+        {
+            "name": "Ion Bazan",
+            "email": "ion.bazan@gmail.com"
+        },
         {
             "name": "Nicolas Grekas",
             "email": "p@tchwork.com"
@@ -16,10 +20,10 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.0.8"
     },
     "autoload": {
-        "psr-4": { "Symfony\\Polyfill\\Php71\\": "" },
+        "psr-4": { "Symfony\\Polyfill\\Php80\\": "" },
         "files": [ "bootstrap.php" ]
     },
     "minimum-stability": "dev",

--- a/src/Util/composer.json
+++ b/src/Util/composer.json
@@ -24,7 +24,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Uuid/composer.json
+++ b/src/Uuid/composer.json
@@ -29,7 +29,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/src/Xml/composer.json
+++ b/src/Xml/composer.json
@@ -23,7 +23,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.13-dev"
+            "dev-master": "1.14-dev"
         }
     }
 }

--- a/tests/Php80/Php80Test.php
+++ b/tests/Php80/Php80Test.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Php80;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Ion Bazan <ion.bazan@gmail.com>
+ */
+class Php80Test extends TestCase
+{
+    /**
+     * @requires PHP 7.0
+     * @covers \Symfony\Polyfill\Php80\Php80::fdiv
+     * @dataProvider fdivProvider
+     */
+    public function testFdiv($expected, $divident, $divisor)
+    {
+        $result = fdiv($divident, $divisor);
+        $this->assertSame($expected, $result);
+        // Cast to string to detect negative zero "-0"
+        $this->assertSame((string) $expected, (string) $result);
+    }
+
+    /**
+     * @requires PHP 7.0
+     * @covers \Symfony\Polyfill\Php80\Php80::fdiv
+     * @dataProvider nanFdivProvider
+     */
+    public function testFdivNan($divident, $divisor)
+    {
+        $this->assertTrue(is_nan(fdiv($divident, $divisor)));
+    }
+
+    /**
+     * @requires PHP 7.0
+     * @covers \Symfony\Polyfill\Php80\Php80::fdiv
+     * @dataProvider invalidFloatProvider
+     */
+    public function testFdivTypeError($divident, $divisor)
+    {
+        $this->setExpectedException('\TypeError');
+        fdiv($divident, $divisor);
+    }
+
+    public function fdivProvider()
+    {
+        return array(
+            array(3.3333333333333, '10', '3'),
+            array(3.3333333333333, 10.0, 3.0),
+            array(-4.0, -10.0, 2.5),
+            array(-4.0, 10.0, -2.5),
+            array(INF, 10.0, 0.0),
+            array(-INF, 10.0, -0.0),
+            array(-INF, -10.0, 0.0),
+            array(INF, -10.0, -0.0),
+            array(INF, INF, 0.0),
+            array(-INF, INF, -0.0),
+            array(-INF, -INF, 0.0),
+            array(INF, -INF, -0.0),
+            array(0.0, 0.0, INF),
+            array(-0.0, 0.0, -INF),
+            array(-0.0, -0.0, INF),
+            array(0.0, -0.0, -INF),
+        );
+    }
+
+    public function nanFdivProvider()
+    {
+        return array(
+            array(0.0, 0.0),
+            array(0.0, -0.0),
+            array(-0.0, 0.0),
+            array(-0.0, -0.0),
+            array(INF, INF),
+            array(INF, -INF),
+            array(-INF, INF),
+            array(-INF, -INF),
+            array(NAN, NAN),
+            array(INF, NAN),
+            array(-0.0, NAN),
+            array(NAN, INF),
+            array(NAN, 0.0),
+        );
+    }
+
+    public function invalidFloatProvider()
+    {
+        return array(
+            array('invalid', 1.0),
+            array('invalid', 'invalid'),
+            array(1.0, 'invalid'),
+            array(1.0, false),
+            array(1.0, true),
+        );
+    }
+
+    public function setExpectedException($exception, $message = '', $code = null)
+    {
+        if (!class_exists('PHPUnit\Framework\Error\Notice')) {
+            $exception = str_replace('PHPUnit\\Framework\\Error\\', 'PHPUnit_Framework_Error_', $exception);
+        }
+        if (method_exists($this, 'expectException')) {
+            $this->expectException($exception);
+            if (!empty($message)) {
+                $this->expectExceptionMessage($message);
+            }
+        } else {
+            parent::setExpectedException($exception, $message, $code);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds simple `fdiv()` implementation by suppressing warnings on the division, just like in original implementation: https://github.com/php/php-src/commit/e35bdb49121ac451384b6c443850ce67e7c5be63

This feature works only on PHP 7+ because suppressing warnings does not produce valid results and casting to string does not detect negative zero on older versions. 
Full logic implementation is available at https://github.com/IonBazan/polyfill/blob/php8-php5/src/Php80/Php80.php but lacks negative-zero detection for PHP 5. If anyone figures out how to detect it, we can simply replace `LogicException` with it.