### PR TITLE
Revert "bug #187 Ensure hrtime is monotonic (GrahamCampbell)"

### DIFF
--- a/src/Php73/Php73.php
+++ b/src/Php73/Php73.php
@@ -21,8 +21,6 @@ final class Php73
 {
     public static $startAt = 1533462603;
 
-    private static $previousValue = '0';
-
     /**
      * @param bool $asNum
      *
@@ -30,19 +28,9 @@ final class Php73
      */
     public static function hrtime($asNum = false)
     {
-        $microtime = microtime(false);
-        $current = 1E9 * (float) $microtime;
-        $previous = 1E9 * (float) self::$previousValue;
-
-        if ($current >= $previous) {
-            $ns = $current;
-            self::$previousValue = $microtime;
-        } else {
-            $ns = $previous;
-            $microtime = self::$previousValue;
-        }
-
-        $s = substr($microtime, 11) - self::$startAt;
+        $ns = microtime(false);
+        $s = substr($ns, 11) - self::$startAt;
+        $ns = 1E9 * (float) $ns;
 
         if ($asNum) {
             $ns += $s * 1E9;


### PR DESCRIPTION
This reverts commit 64d2d7d5b4595443c1ad0c667597ea4f5ae1e7a5, reversing
changes made to b501e55fbc45de6bc4112efeb7cb5f4b6a283d7b.

/cc @GrahamCampbell FYI I just realized the implementation doesn't work:
microtime(false) return something like `0.00018200 1574780469`
casting this to float and comparing with the previous checks only the sub-seconds part. But it should account for seconds too.
That's why tests fail transiently on the CI.

Maybe we don't care about monotonicity eventually, do we?