### PR TITLE
Use correct block size for SHA1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* v1.13.2
+
+ * use correct block size for SHA1 in `hash_pbkdf2()` polyfill
+
 * v1.13.1
 
  * fixed issues with the uuid polyfill

--- a/src/Php55/Php55.php
+++ b/src/Php55/Php55.php
@@ -43,6 +43,7 @@ final class Php55
         // Pre-hash for optimization if password length > hash length
         $hashLength = \strlen(hash($algorithm, '', true));
         switch ($algorithm) {
+            case 'sha1':
             case 'sha224':
             case 'sha256':
                 $blockSize = 64;

--- a/tests/Php55/Php55Test.php
+++ b/tests/Php55/Php55Test.php
@@ -50,4 +50,9 @@ class Php55Test extends TestCase
 
         return $values;
     }
+
+    public function testtestHashPbkdf2Sha1()
+    {
+        $this->assertSame('3d2eec4fe41c849b80c8d8366', hash_pbkdf2('sha1', 'passwordPASSWORDpassword', 'saltSALTsaltSALTsaltSALTsaltSALTsalt', 4096, 25));
+    }
 }


### PR DESCRIPTION
SHA1 has a 64 byte (512 bit) block size, not a 20 byte (160 bit) block size like you would expect.

Closes https://github.com/symfony/polyfill-php55/pull/3