### PR TITLE
[PHP8.0] add ValueError and FILTER_VALIDATE_BOOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Polyfills are provided for:
 - the `get_mangled_object_vars`, `mb_str_split` and `password_algos` functions
   introduced in PHP 7.4;
 - the `fdiv` function introduced in PHP 8.0;
+- the `ValueError` class introduced in PHP 8.0;
+- the `FILTER_VALIDATE_BOOL` constant introduced in PHP 8.0;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
         "classmap": [
             "src/Intl/MessageFormatter/Resources/stubs",
             "src/Intl/Normalizer/Resources/stubs",
+            "src/Php80/Resources/stubs",
             "src/Php73/Resources/stubs",
             "src/Php70/Resources/stubs",
             "src/Php54/Resources/stubs"

--- a/src/Php80/README.md
+++ b/src/Php80/README.md
@@ -4,6 +4,8 @@ Symfony Polyfill / Php80
 This component provides functions added to PHP 8.0 core:
 
 - [`fdiv`](https://php.net/fdiv) (only for PHP 7.0+)
+- `ValueError` class
+- `FILTER_VALIDATE_BOOL` constant
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).

--- a/src/Php80/Resources/stubs/ValueError.php
+++ b/src/Php80/Resources/stubs/ValueError.php
@@ -1,0 +1,5 @@
+<?php
+
+class ValueError extends Error
+{
+}

--- a/src/Php80/bootstrap.php
+++ b/src/Php80/bootstrap.php
@@ -15,4 +15,8 @@ if (PHP_VERSION_ID < 80000 && PHP_VERSION_ID >= 70000) {
     if (!function_exists('fdiv')) {
         function fdiv($dividend, $divisor) { return p\Php80::fdiv($dividend, $divisor); }
     }
+
+    if (!defined('FILTER_VALIDATE_BOOL')) {
+        define('FILTER_VALIDATE_BOOL', FILTER_VALIDATE_BOOLEAN);
+    }
 }

--- a/src/Php80/composer.json
+++ b/src/Php80/composer.json
@@ -24,7 +24,8 @@
     },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Php80\\": "" },
-        "files": [ "bootstrap.php" ]
+        "files": [ "bootstrap.php" ],
+        "classmap": [ "Resources/stubs" ]
     },
     "minimum-stability": "dev",
     "extra": {

--- a/tests/Php80/Php80Test.php
+++ b/tests/Php80/Php80Test.php
@@ -52,6 +52,15 @@ class Php80Test extends TestCase
         fdiv($divident, $divisor);
     }
 
+    /**
+     * @requires PHP 7.0
+     */
+    public function testFilterValidateBool()
+    {
+        $this->assertTrue(\defined('FILTER_VALIDATE_BOOL'));
+        $this->assertSame(FILTER_VALIDATE_BOOLEAN, FILTER_VALIDATE_BOOL);
+    }
+
     public function fdivProvider()
     {
         return array(


### PR DESCRIPTION
This change adds support for new PHP 8.0 features:

- [x] `ValueError` class
- [x] `FILTER_VALIDATE_BOOL` constant