### PR TITLE
[PHP 8.0] Add preg_last_error_msg function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.15.0
+
+  * added `preg_last_error_msg()` to the PHP 8 polyfill
+
 # 1.14.0
 
   * added PHP 8.0 polyfill

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Polyfills are provided for:
 - the `get_mangled_object_vars`, `mb_str_split` and `password_algos` functions
   introduced in PHP 7.4;
 - the `fdiv` function introduced in PHP 8.0;
+- the `preg_last_error_msg` function introduced in PHP 8.0;
 - the `ValueError` class introduced in PHP 8.0;
 - the `FILTER_VALIDATE_BOOL` constant introduced in PHP 8.0;
 

--- a/src/Php80/Php80.php
+++ b/src/Php80/Php80.php
@@ -13,6 +13,7 @@ namespace Symfony\Polyfill\Php80;
 
 /**
  * @author Ion Bazan <ion.bazan@gmail.com>
+ * @author Nico Oelgart <nicoswd@gmail.com>
  *
  * @internal
  */
@@ -24,6 +25,28 @@ final class Php80
         $divisor = self::floatArg($divisor, __FUNCTION__, 2);
 
         return (float) @($dividend / $divisor);
+    }
+
+    public static function pregLastErrorMsg()
+    {
+        switch (preg_last_error()) {
+            case PREG_INTERNAL_ERROR:
+                return 'Internal error';
+            case PREG_BAD_UTF8_ERROR:
+                return 'Malformed UTF-8 characters, possibly incorrectly encoded';
+            case PREG_BAD_UTF8_OFFSET_ERROR:
+                return 'The offset did not correspond to the beginning of a valid UTF-8 code point';
+            case PREG_BACKTRACK_LIMIT_ERROR:
+                return 'Backtrack limit exhausted';
+            case PREG_RECURSION_LIMIT_ERROR:
+                return 'Recursion limit exhausted';
+            case PREG_JIT_STACKLIMIT_ERROR:
+                return 'JIT stack limit exhausted';
+            case PREG_NO_ERROR:
+                return 'No error';
+            default:
+                return 'Unknown error';
+        }
     }
 
     private static function floatArg($value, $caller, $pos)

--- a/src/Php80/README.md
+++ b/src/Php80/README.md
@@ -6,6 +6,7 @@ This component provides functions added to PHP 8.0 core:
 - [`fdiv`](https://php.net/fdiv) (only for PHP 7.0+)
 - `ValueError` class
 - `FILTER_VALIDATE_BOOL` constant
+- [`preg_last_error_msg`](https://php.net/preg_last_error_msg)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).

--- a/src/Php80/bootstrap.php
+++ b/src/Php80/bootstrap.php
@@ -16,6 +16,10 @@ if (PHP_VERSION_ID < 80000 && PHP_VERSION_ID >= 70000) {
         function fdiv($dividend, $divisor) { return p\Php80::fdiv($dividend, $divisor); }
     }
 
+    if (!function_exists('preg_last_error_msg')) {
+        function preg_last_error_msg() { return p\Php80::pregLastErrorMsg(); }
+    }
+
     if (!defined('FILTER_VALIDATE_BOOL') && defined('FILTER_VALIDATE_BOOLEAN')) {
         define('FILTER_VALIDATE_BOOL', FILTER_VALIDATE_BOOLEAN);
     }

--- a/tests/Php80/Php80Test.php
+++ b/tests/Php80/Php80Test.php
@@ -14,12 +14,14 @@ namespace Symfony\Polyfill\Tests\Php80;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * @requires PHP 7.0
+ *
  * @author Ion Bazan <ion.bazan@gmail.com>
+ * @author Nico Oelgart <nicoswd@gmail.com>
  */
 class Php80Test extends TestCase
 {
     /**
-     * @requires PHP 7.0
      * @covers \Symfony\Polyfill\Php80\Php80::fdiv
      * @dataProvider fdivProvider
      */
@@ -32,7 +34,6 @@ class Php80Test extends TestCase
     }
 
     /**
-     * @requires PHP 7.0
      * @covers \Symfony\Polyfill\Php80\Php80::fdiv
      * @dataProvider nanFdivProvider
      */
@@ -42,7 +43,6 @@ class Php80Test extends TestCase
     }
 
     /**
-     * @requires PHP 7.0
      * @covers \Symfony\Polyfill\Php80\Php80::fdiv
      * @dataProvider invalidFloatProvider
      */
@@ -53,12 +53,40 @@ class Php80Test extends TestCase
     }
 
     /**
-     * @requires PHP 7.0
      */
     public function testFilterValidateBool()
     {
         $this->assertTrue(\defined('FILTER_VALIDATE_BOOL'));
         $this->assertSame(FILTER_VALIDATE_BOOLEAN, FILTER_VALIDATE_BOOL);
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php80\Php80::pregLastErrorMsg
+     */
+    public function testPregNoError()
+    {
+        $this->assertSame('No error', preg_last_error_msg());
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php80\Php80::pregLastErrorMsg
+     */
+    public function testPregMalformedUtfError()
+    {
+        @preg_split('/a/u', "a\xff");
+        $this->assertSame('Malformed UTF-8 characters, possibly incorrectly encoded', preg_last_error_msg());
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php80\Php80::pregLastErrorMsg
+     */
+    public function testPregMalformedUtf8Offset()
+    {
+        @preg_match('/a/u', "\xE3\x82\xA2", $m, 0, 1);
+        $this->assertSame(
+            'The offset did not correspond to the beginning of a valid UTF-8 code point',
+            preg_last_error_msg()
+        );
     }
 
     public function fdivProvider()


### PR DESCRIPTION
This PR adds the function `preg_last_error_msg` added in [php-src/pull/5185](https://github.com/php/php-src/pull/5185)

_Note_: I only tested the cases that don't require special `.ini` settings as I didn't want to set them dynamically in the test suite.