### PR TITLE
[WIP] Fixes for mbstring with PHP 8 throwing exceptions instead of raising warnings

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -77,6 +77,25 @@ final class Mbstring
         array('μ', 's', 'ι',        'σ', 'β',        'θ',        'φ',        'π',        'κ',        'ρ',        'ε',        "\xE1\xB9\xA1", 'ι'),
     );
 
+    /**
+     * A helper method to either trigger an error, or throw an exception in PHP 8.
+     *
+     * @param string $error_msg  the error message to be used in the error or exception
+     * @param int    $error_type Type of the error. Not used when an exception is thrown.
+     * @param null   $exception  in case an exception must be thrown in PHP 8,
+     *                           the fully-qualified name of the exception
+     */
+    private static function triggerErrorOrException(
+      $error_msg,
+      $error_type = E_USER_NOTICE,
+      $exception = null
+    ) {
+        if (null !== $exception && PHP_VERSION_ID >= 80000) {
+            throw new $exception($error_msg);
+        }
+        trigger_error($error_msg, $error_type);
+    }
+
     public static function mb_convert_encoding($s, $toEncoding, $fromEncoding = null)
     {
         if (\is_array($fromEncoding) || false !== strpos($fromEncoding, ',')) {
@@ -136,13 +155,13 @@ final class Mbstring
 
     public static function mb_encode_mimeheader($s, $charset = null, $transferEncoding = null, $linefeed = null, $indent = null)
     {
-        trigger_error('mb_encode_mimeheader() is bugged. Please use iconv_mime_encode() instead', E_USER_WARNING);
+        self::triggerErrorOrException('mb_encode_mimeheader() is bugged. Please use iconv_mime_encode() instead', E_USER_WARNING, '\TypeError');
     }
 
     public static function mb_decode_numericentity($s, $convmap, $encoding = null)
     {
         if (null !== $s && !\is_scalar($s) && !(\is_object($s) && \method_exists($s, '__toString'))) {
-            trigger_error('mb_decode_numericentity() expects parameter 1 to be string, '.\gettype($s).' given', E_USER_WARNING);
+            self::triggerErrorOrException('mb_decode_numericentity() expects parameter 1 to be string, '.\gettype($s).' given', E_USER_WARNING, '\TypeError');
 
             return null;
         }
@@ -152,7 +171,7 @@ final class Mbstring
         }
 
         if (null !== $encoding && !\is_scalar($encoding)) {
-            trigger_error('mb_decode_numericentity() expects parameter 3 to be string, '.\gettype($s).' given', E_USER_WARNING);
+            self::triggerErrorOrException('mb_decode_numericentity() expects parameter 3 to be string, '.\gettype($s).' given', E_USER_WARNING, '\TypeError');
 
             return '';  // Instead of null (cf. mb_encode_numericentity).
         }
@@ -202,7 +221,7 @@ final class Mbstring
     public static function mb_encode_numericentity($s, $convmap, $encoding = null, $is_hex = false)
     {
         if (null !== $s && !\is_scalar($s) && !(\is_object($s) && \method_exists($s, '__toString'))) {
-            trigger_error('mb_encode_numericentity() expects parameter 1 to be string, '.\gettype($s).' given', E_USER_WARNING);
+            self::triggerErrorOrException('mb_encode_numericentity() expects parameter 1 to be string, '.\gettype($s).' given', E_USER_WARNING, '\TypeError');
 
             return null;
         }
@@ -212,13 +231,13 @@ final class Mbstring
         }
 
         if (null !== $encoding && !\is_scalar($encoding)) {
-            trigger_error('mb_encode_numericentity() expects parameter 3 to be string, '.\gettype($s).' given', E_USER_WARNING);
+            self::triggerErrorOrException('mb_encode_numericentity() expects parameter 3 to be string, '.\gettype($s).' given', E_USER_WARNING, '\TypeError');
 
             return null;  // Instead of '' (cf. mb_decode_numericentity).
         }
 
         if (null !== $is_hex && !\is_scalar($is_hex)) {
-            trigger_error('mb_encode_numericentity() expects parameter 4 to be boolean, '.\gettype($s).' given', E_USER_WARNING);
+            self::triggerErrorOrException('mb_encode_numericentity() expects parameter 4 to be boolean, '.\gettype($s).' given', E_USER_WARNING, '\TypeError');
 
             return null;
         }
@@ -493,7 +512,7 @@ final class Mbstring
 
         $needle = (string) $needle;
         if ('' === $needle) {
-            trigger_error(__METHOD__.': Empty delimiter', E_USER_WARNING);
+            self::triggerErrorOrException(__METHOD__.': Empty delimiter', E_USER_WARNING, '\TypeError');
 
             return false;
         }
@@ -529,13 +548,13 @@ final class Mbstring
     public static function mb_str_split($string, $split_length = 1, $encoding = null)
     {
         if (null !== $string && !\is_scalar($string) && !(\is_object($string) && \method_exists($string, '__toString'))) {
-            trigger_error('mb_str_split() expects parameter 1 to be string, '.\gettype($string).' given', E_USER_WARNING);
+            self::triggerErrorOrException('mb_str_split() expects parameter 1 to be string, '.\gettype($string).' given', E_USER_WARNING, '\TypeError');
 
             return null;
         }
 
         if (1 > $split_length = (int) $split_length) {
-            trigger_error('The length of each segment must be greater than zero', E_USER_WARNING);
+            self::triggerErrorOrException('The length of each segment must be greater than zero', E_USER_WARNING, '\TypeError');
 
             return false;
         }

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -101,7 +101,7 @@ class MbstringTest extends TestCase
      */
     public function testDecodeNumericEntityWarnsOnInvalidInputType()
     {
-        $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'expects parameter 1 to be string');
+        $this->setExpectedExceptionVersionDependent('PHPUnit\Framework\Error\Warning', 'expects parameter 1 to be string', null, '\TypeError');
         mb_decode_numericentity(new \stdClass(), array(0x0, 0x10ffff, 0x0, 0x1fffff), 'UTF-8');
     }
 
@@ -110,7 +110,7 @@ class MbstringTest extends TestCase
      */
     public function testDecodeNumericEntityWarnsOnInvalidEncodingType()
     {
-        $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'expects parameter 3 to be string');
+        $this->setExpectedExceptionVersionDependent('PHPUnit\Framework\Error\Warning', 'expects parameter 3 to be string', null, '\TypeError');
         mb_decode_numericentity('déjà', array(0x0, 0x10ffff, 0x0, 0x1fffff), new \stdClass());
     }
 
@@ -157,7 +157,7 @@ class MbstringTest extends TestCase
      */
     public function testEncodeNumericEntityWarnsOnInvalidInputType()
     {
-        $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'expects parameter 1 to be string');
+        $this->setExpectedExceptionVersionDependent('PHPUnit\Framework\Error\Warning', 'expects parameter 1 to be string', null, '\TypeError');
         mb_encode_numericentity(new \stdClass(), array(0x0, 0x10ffff, 0x0, 0x1fffff), 'UTF-8');
     }
 
@@ -166,7 +166,7 @@ class MbstringTest extends TestCase
      */
     public function testEncodeNumericEntityWarnsOnInvalidEncodingType()
     {
-        $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'expects parameter 3 to be string');
+        $this->setExpectedExceptionVersionDependent('PHPUnit\Framework\Error\Warning', 'expects parameter 3 to be string', null, '\TypeError');
         mb_encode_numericentity('déjà', array(0x0, 0x10ffff, 0x0, 0x1fffff), new \stdClass());
     }
 
@@ -176,7 +176,7 @@ class MbstringTest extends TestCase
      */
     public function testEncodeNumericEntityWarnsOnInvalidIsHexType()
     {
-        $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'expects parameter 4 to be bool');
+        $this->setExpectedExceptionVersionDependent('PHPUnit\Framework\Error\Warning', 'expects parameter 4 to be bool', null, '\TypeError');
         mb_encode_numericentity('déjà', array(0x0, 0x10ffff, 0x0, 0x1fffff), 'UTF-8', new \stdClass());
     }
 
@@ -295,7 +295,7 @@ class MbstringTest extends TestCase
     public function testStrposEmptyDelimiter()
     {
         mb_strpos('abc', 'a');
-        $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'Empty delimiter');
+        $this->setExpectedExceptionVersionDependent('PHPUnit\Framework\Error\Warning', 'Empty delimiter', null, '\TypeError');
         mb_strpos('abc', '');
     }
 
@@ -308,7 +308,7 @@ class MbstringTest extends TestCase
         if (\PHP_VERSION_ID >= 70100) {
             $this->assertFalse(mb_strpos('abc', 'a', -1));
         } else {
-            $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'Offset not contained in string');
+            $this->setExpectedExceptionVersionDependent('PHPUnit\Framework\Error\Warning', 'Offset not contained in string', null, '\TypeError');
             mb_strpos('abc', 'a', -1);
         }
     }
@@ -330,7 +330,7 @@ class MbstringTest extends TestCase
         $this->assertFalse(@mb_str_split('победа', 0));
         $this->assertNull(@mb_str_split(array(), 0));
 
-        $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'The length of each segment must be greater than zero');
+        $this->setExpectedExceptionVersionDependent('PHPUnit\Framework\Error\Warning', 'The length of each segment must be greater than zero', null, '\TypeError');
         mb_str_split('победа', 0);
     }
 
@@ -458,6 +458,27 @@ class MbstringTest extends TestCase
             $this->expectExceptionMessage($message);
         } else {
             parent::setExpectedException($exception, $message, $code);
+        }
+    }
+
+    /**
+     * Version-dependent exception handling. From PHP 8.0 and later, PHP throws
+     *   \TypeError and \ValueError exceptions on errors. If the tests are being
+     *   run in PHP 8.0 or later, set it to expect the exception passed to
+     *   $php8_exception. Expect the first exception in versions prior to PHP 8.
+     *
+     * @param string      $exception      PHP 5.x and 7.x exception
+     * @param string      $message        Message for the exception
+     * @param int|null    $code           Exception error code
+     * @param string|null $php8_exception in case $exception is different in
+     *                                    PHP 8, the name of the exception
+     */
+    public function setExpectedExceptionVersionDependent($exception, $message, $code = null, $php8_exception = null)
+    {
+        if (null !== $php8_exception && PHP_VERSION_ID >= 80000) {
+            $this->setExpectedException($php8_exception, $message, $code);
+        } else {
+            $this->setExpectedException($exception, $message, $code);
         }
     }
 }

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -295,7 +295,11 @@ class MbstringTest extends TestCase
     public function testStrposEmptyDelimiter()
     {
         mb_strpos('abc', 'a');
-        $this->setExpectedExceptionVersionDependent('PHPUnit\Framework\Error\Warning', 'Empty delimiter', null, '\TypeError');
+        if (\PHP_VERSION_ID >= 80000) { // PHP 8 always returns this.
+            $this->assertSame(0, mb_strpos('abc', ''));
+        }
+        $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'Empty delimiter');
+        // todo: fix polyfill to consider every string contains empty strings now.
         mb_strpos('abc', '');
     }
 
@@ -308,7 +312,7 @@ class MbstringTest extends TestCase
         if (\PHP_VERSION_ID >= 70100) {
             $this->assertFalse(mb_strpos('abc', 'a', -1));
         } else {
-            $this->setExpectedExceptionVersionDependent('PHPUnit\Framework\Error\Warning', 'Offset not contained in string', null, '\TypeError');
+            $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'Offset not contained in string');
             mb_strpos('abc', 'a', -1);
         }
     }
@@ -330,7 +334,8 @@ class MbstringTest extends TestCase
         $this->assertFalse(@mb_str_split('победа', 0));
         $this->assertNull(@mb_str_split(array(), 0));
 
-        $this->setExpectedExceptionVersionDependent('PHPUnit\Framework\Error\Warning', 'The length of each segment must be greater than zero', null, '\TypeError');
+        // This is not converted to an exception yet.
+        $this->setExpectedException('PHPUnit\Framework\Error\Warning', 'The length of each segment must be greater than zero');
         mb_str_split('победа', 0);
     }
 
@@ -468,7 +473,7 @@ class MbstringTest extends TestCase
      *   $php8_exception. Expect the first exception in versions prior to PHP 8.
      *
      * @param string      $exception      PHP 5.x and 7.x exception
-     * @param string      $message        Message for the exception
+     * @param string      $message        text for the warning, or message for the exception
      * @param int|null    $code           Exception error code
      * @param string|null $php8_exception in case $exception is different in
      *                                    PHP 8, the name of the exception


### PR DESCRIPTION
Related #218.

This is an attempt to workaround the PHP 8's behavior of throwing `\TypeError` and [`\ValueError`](https://php.watch/versions/8.0/ValueError) exceptions on internal functions[1]. This is a rather massive change, so we will be taking a look at in bite-sizes. 

Both `Mbstring` and its test classes get two new helper methods. They check the PHP version, and if the PHP version is 8.0 or later, it will throw an exception from the polyfill class, and the complementing helper method will expect the same type of error. Both helper methods accept the name of the new exception class as the last parameter. We currently use `\TypeError`, but we will need to manually review each test to make sure the type of errors they throw. In most cases, this will be a `\ValueError` to follow the semantics of the error message. 

This PR is to get some feedback on if others would agree if this approach indeed makes sense. #219 already adds the new `\ValueError` class.

I considered to make the conditional expect/trigger helper methods into a trait, but traits are only available in PHP 5.4, but the polyfill needs to support PHP 5.3. However, because we need to split the repo to separate packages, this trait wouldn't be as handy as I thought it would be, so the helper methods are baked into the test and polyfill themselves. 