### PR TITLE
Fix the polyfill for spl_object_id()

### DIFF
--- a/src/Php72/Php72.php
+++ b/src/Php72/Php72.php
@@ -95,7 +95,8 @@ final class Php72
             return;
         }
 
-        return self::$hashMask ^ hexdec(substr($hash, 16 - \PHP_INT_SIZE, \PHP_INT_SIZE));
+        // On 32-bit systems, PHP_INT_SIZE is 4,
+        return self::$hashMask ^ hexdec(substr($hash, 16 - (\PHP_INT_SIZE * 2 - 1), (\PHP_INT_SIZE * 2 - 1)));
     }
 
     public static function sapi_windows_vt100_support($stream, $enable = null)
@@ -166,7 +167,7 @@ final class Php72
             self::$hashMask = (int) substr(ob_get_clean(), 17);
         }
 
-        self::$hashMask ^= hexdec(substr(spl_object_hash($obj), 16 - \PHP_INT_SIZE, \PHP_INT_SIZE));
+        self::$hashMask ^= hexdec(substr(spl_object_hash($obj), 16 - (\PHP_INT_SIZE * 2 - 1), (\PHP_INT_SIZE * 2 - 1)));
     }
 
     public static function mb_chr($code, $encoding = null)

--- a/tests/Php72/Php72Test.php
+++ b/tests/Php72/Php72Test.php
@@ -67,6 +67,20 @@ class Php72Test extends TestCase
     }
 
     /**
+     * @covers \Symfony\Polyfill\Php72\Php72::spl_object_id
+     */
+    public function testSplObjectIdUniqueValues()
+    {
+        // Should be able to represent more than 2**16 ids on 32-bit systems.
+        $result = array();
+        for ($i = 0; $i < 70000; $i++) {
+            $obj = new \stdClass();
+            $result[spl_object_id($obj)] = $obj;
+        }
+        $this->assertSame(70000, count($result));
+    }
+
+    /**
      * @covers \Symfony\Polyfill\Php72\Php72::sapi_windows_vt100_support
      */
     public function testSapiWindowsVt100Support()


### PR DESCRIPTION
spl_object_hash will be a string such as
`000000001b19a247000000004e677fa5`.
The first half is 8 to 16 zero-padded **hex digits** of
data (PHP_INT_SIZE=4 **bytes** on 32-bit systems, 8 on 64-bit systems)

This meant that this polyfill for spl_object_id previously couldn't accurately
represent values that were greater than 65536 (`16**4`) on 32-bit systems,
~~or 4294967296 (`16**8`) on 64-bit systems.~~

This was noticed because 32-bit tests failed for Phan in php 7.1.
(https://github.com/phan/phan/blob/master/src/spl_object_id.php had no
issues before the dependency on symfony/polyfill-72 was added for a
different function)

- Aside: The object handle of `struct _zend_object` was a uint32_t in php 7.1,
  so it's always 8 hex digits for official php builds.
