### PR TITLE
Add polyfill for PHP 8's str_starts_with() and str_ends_with() functions

### DIFF
--- a/src/Php80/Php80.php
+++ b/src/Php80/Php80.php
@@ -83,4 +83,14 @@ final class Php80
     {
         return '' === $needle || false !== strpos($haystack, $needle);
     }
+
+    public static function str_starts_with(string $haystack, string $needle): bool
+    {
+        return 0 === \strncmp($haystack, $needle, \strlen($needle));
+    }
+
+    public static function str_ends_with(string $haystack, string $needle): bool
+    {
+        return '' === $needle || $needle === \substr($haystack, -\strlen($needle));
+    }
 }

--- a/src/Php80/bootstrap.php
+++ b/src/Php80/bootstrap.php
@@ -24,6 +24,14 @@ if (PHP_VERSION_ID < 80000) {
         function str_contains(string $haystack, string $needle): bool { return p\Php80::str_contains($haystack, $needle); }
     }
 
+    if (!function_exists('str_starts_with')) {
+        function str_starts_with(string $haystack, string $needle): bool { return p\Php80::str_starts_with($haystack, $needle); }
+    }
+
+    if (!function_exists('str_ends_with')) {
+        function str_ends_with(string $haystack, string $needle): bool { return p\Php80::str_ends_with($haystack, $needle); }
+    }
+
     if (!defined('FILTER_VALIDATE_BOOL') && defined('FILTER_VALIDATE_BOOLEAN')) {
         define('FILTER_VALIDATE_BOOL', FILTER_VALIDATE_BOOLEAN);
     }

--- a/tests/Php80/Php80Test.php
+++ b/tests/Php80/Php80Test.php
@@ -105,6 +105,80 @@ class Php80Test extends TestCase
         $this->assertFalse(str_contains('a', 'à'));
     }
 
+    /**
+     * @covers \Symfony\Polyfill\Php80\Php80::str_starts_with
+     */
+    public function testStrStartsWith()
+    {
+        $testStr = 'beginningMiddleEnd';
+
+        $this->assertTrue(str_starts_with($testStr, "beginning"));
+        $this->assertTrue(str_starts_with($testStr, $testStr));
+        $this->assertTrue(str_starts_with($testStr, ''));
+        $this->assertTrue(str_starts_with("", ""));
+        $this->assertTrue(str_starts_with("\x00", ""));
+        $this->assertTrue(str_starts_with("\x00", "\x00"));
+        $this->assertTrue(str_starts_with("\x00a", "\x00"));
+        $this->assertTrue(str_starts_with("a\x00bc", "a\x00b"));
+
+        $this->assertFalse(str_starts_with($testStr, "Beginning"));
+        $this->assertFalse(str_starts_with($testStr, "eginning"));
+        $this->assertFalse(str_starts_with($testStr, $testStr.$testStr));
+        $this->assertFalse(str_starts_with("", " "));
+        $this->assertFalse(str_starts_with($testStr, "\x00"));
+        $this->assertFalse(str_starts_with("a\x00b", "a\x00d"));
+        $this->assertFalse(str_starts_with("a\x00b", "z\x00b"));
+        $this->assertFalse(str_starts_with("a", "a\x00"));
+        $this->assertFalse(str_starts_with("a", "\x00a"));
+
+        // අයේෂ් = අ + ය + "ේ" + ෂ + ්
+        // අයේෂ් = (0xe0 0xb6 0x85) + (0xe0 0xb6 0xba) + (0xe0 0xb7 0x9a) + (0xe0 0xb7 0x82) + (0xe0 0xb7 0x8a)
+        $testMultiByte = 'අයේෂ්'; // 0xe0 0xb6 0x85 0xe0 0xb6 0xba 0xe0 0xb7 0x9a 0xe0 0xb7 0x82 0xe0 0xb7 0x8a
+        $this->assertTrue(str_starts_with($testMultiByte, "අයේ")); // 0xe0 0xb6 0x85 0xe0 0xb6 0xba 0xe0 0xb7 0x9a
+        $this->assertTrue(str_starts_with($testMultiByte, "අය")); // 0xe0 0xb6 0x85 0xe0 0xb6 0xba
+        $this->assertFalse(str_starts_with($testMultiByte, "ය")); // 0xe0 0xb6 0xba
+        $this->assertFalse(str_starts_with($testMultiByte, "අේ")); // 0xe0 0xb6 0x85 0xe0 0xb7 0x9a
+
+        $testEmoji = '🙌🎉✨🚀'; // 0xf0 0x9f 0x99 0x8c 0xf0 0x9f 0x8e 0x89 0xe2 0x9c 0xa8 0xf0 0x9f 0x9a 0x80
+        $this->assertTrue(str_starts_with($testEmoji, "🙌")); // 0xf0 0x9f 0x99 0x8c
+        $this->assertFalse(str_starts_with($testEmoji, "✨")); // 0xe2 0x9c 0xa8
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php80\Php80::str_ends_with
+     */
+    public function testStrEndsWith()
+    {
+        $testStr = 'beginningMiddleEnd';
+
+        $this->assertTrue(str_ends_with($testStr, "End"));
+        $this->assertFalse(str_ends_with($testStr, "end"));
+        $this->assertFalse(str_ends_with($testStr, "en"));
+        $this->assertTrue(str_ends_with($testStr, $testStr));
+        $this->assertFalse(str_ends_with($testStr, $testStr.$testStr));
+        $this->assertTrue(str_ends_with($testStr, ""));
+        $this->assertTrue(str_ends_with("", ""));
+        $this->assertFalse(str_ends_with("", " "));
+        $this->assertFalse(str_ends_with($testStr, "\x00"));
+        $this->assertTrue(str_ends_with("\x00", ""));
+        $this->assertTrue(str_ends_with("\x00", "\x00"));
+        $this->assertTrue(str_ends_with("a\x00", "\x00"));
+        $this->assertTrue(str_ends_with("ab\x00c", "b\x00c"));
+        $this->assertFalse(str_ends_with("a\x00b", "d\x00b"));
+        $this->assertFalse(str_ends_with("a\x00b", "a\x00z"));
+        $this->assertFalse(str_ends_with("a", "\x00a"));
+        $this->assertFalse(str_ends_with("a", "a\x00"));
+
+        $testMultiByte = 'අයේෂ්'; // 0xe0 0xb6 0x85 0xe0 0xb6 0xba 0xe0 0xb7 0x9a 0xe0 0xb7 0x82 0xe0 0xb7 0x8a
+        $this->assertTrue(str_ends_with($testMultiByte, "ෂ්")); // 0xe0 0xb7 0x82 0xe0 0xb7 0x8a
+        $this->assertTrue(str_ends_with($testMultiByte, "්")); // 0xe0 0xb7 0x8a
+        $this->assertFalse(str_ends_with($testMultiByte, "ෂ")); // 0xe0 0xb7 0x82
+
+        $testEmoji = '🙌🎉✨🚀'; // 0xf0 0x9f 0x99 0x8c 0xf0 0x9f 0x8e 0x89 0xe2 0x9c 0xa8 0xf0 0x9f 0x9a 0x80
+        $this->assertTrue(str_ends_with($testEmoji, "🚀")); // 0xf0 0x9f 0x9a 0x80
+        $this->assertFalse(str_ends_with($testEmoji, "✨")); // 0xe2 0x9c 0xa8
+    }
+
     public function fdivProvider()
     {
         return array(


### PR DESCRIPTION
Adds polyfills for str_starts_with() and str_ends_with() functions added in PHP 8.0.
RFC: https://wiki.php.net/rfc/add_str_starts_with_and_ends_with_functions
Tests from PHP source:
 - ext/standard/tests/strings/str_starts_with.phpt
 - ext/standard/tests/strings/str_ends_with.phpt

Sample implementation: https://php.watch/versions/8.0/str_starts_with-str_ends_with

*Marking this PR draft because the RFC voting has yet to be closed (on May 4)*