### PR TITLE
Add separate checks for all polyfilled functions and constants

### DIFF
--- a/src/Apcu/bootstrap.php
+++ b/src/Apcu/bootstrap.php
@@ -15,25 +15,56 @@ if (!extension_loaded('apc') && !extension_loaded('apcu')) {
     return;
 }
 
-if (!function_exists('apcu_add')) {
-    if (extension_loaded('Zend Data Cache')) {
+if (extension_loaded('Zend Data Cache')) {
+    if (!function_exists('apcu_add')) {
         function apcu_add($key, $var = null, $ttl = 0) { return p\Apcu::apcu_add($key, $var, $ttl); }
+    }
+    if (!function_exists('apcu_delete')) {
         function apcu_delete($key) { return p\Apcu::apcu_delete($key); }
+    }
+    if (!function_exists('apcu_exists')) {
         function apcu_exists($keys) { return p\Apcu::apcu_exists($keys); }
+    }
+    if (!function_exists('apcu_fetch')) {
         function apcu_fetch($key, &$success = null) { return p\Apcu::apcu_fetch($key, $success); }
+    }
+    if (!function_exists('apcu_store')) {
         function apcu_store($key, $var = null, $ttl = 0) { return p\Apcu::apcu_store($key, $var, $ttl); }
-    } else {
+    }
+} else {
+    if (!function_exists('apcu_add')) {
         function apcu_add($key, $var = null, $ttl = 0) { return apc_add($key, $var, $ttl); }
+    }
+    if (!function_exists('apcu_delete')) {
         function apcu_delete($key) { return apc_delete($key); }
+    }
+    if (!function_exists('apcu_exists')) {
         function apcu_exists($keys) { return apc_exists($keys); }
+    }
+    if (!function_exists('apcu_fetch')) {
         function apcu_fetch($key, &$success = null) { return apc_fetch($key, $success); }
+    }
+    if (!function_exists('apcu_store')) {
         function apcu_store($key, $var = null, $ttl = 0) { return apc_store($key, $var, $ttl); }
     }
+}
+
+if (!function_exists('apcu_cache_info')) {
     function apcu_cache_info($limited = false) { return apc_cache_info('user', $limited); }
+}
+if (!function_exists('apcu_cas')) {
     function apcu_cas($key, $old, $new) { return apc_cas($key, $old, $new); }
+}
+if (!function_exists('apcu_clear_cache')) {
     function apcu_clear_cache() { return apc_clear_cache('user'); }
+}
+if (!function_exists('apcu_dec')) {
     function apcu_dec($key, $step = 1, &$success = false) { return apc_dec($key, $step, $success); }
+}
+if (!function_exists('apcu_inc')) {
     function apcu_inc($key, $step = 1, &$success = false) { return apc_inc($key, $step, $success); }
+}
+if (!function_exists('apcu_sma_info')) {
     function apcu_sma_info($limited = false) { return apc_sma_info($limited); }
 }
 

--- a/src/Ctype/bootstrap.php
+++ b/src/Ctype/bootstrap.php
@@ -13,14 +13,34 @@ use Symfony\Polyfill\Ctype as p;
 
 if (!function_exists('ctype_alnum')) {
     function ctype_alnum($text) { return p\Ctype::ctype_alnum($text); }
+}
+if (!function_exists('ctype_alpha')) {
     function ctype_alpha($text) { return p\Ctype::ctype_alpha($text); }
+}
+if (!function_exists('ctype_cntrl')) {
     function ctype_cntrl($text) { return p\Ctype::ctype_cntrl($text); }
+}
+if (!function_exists('ctype_digit')) {
     function ctype_digit($text) { return p\Ctype::ctype_digit($text); }
+}
+if (!function_exists('ctype_graph')) {
     function ctype_graph($text) { return p\Ctype::ctype_graph($text); }
+}
+if (!function_exists('ctype_lower')) {
     function ctype_lower($text) { return p\Ctype::ctype_lower($text); }
+}
+if (!function_exists('ctype_print')) {
     function ctype_print($text) { return p\Ctype::ctype_print($text); }
+}
+if (!function_exists('ctype_punct')) {
     function ctype_punct($text) { return p\Ctype::ctype_punct($text); }
+}
+if (!function_exists('ctype_space')) {
     function ctype_space($text) { return p\Ctype::ctype_space($text); }
+}
+if (!function_exists('ctype_upper')) {
     function ctype_upper($text) { return p\Ctype::ctype_upper($text); }
+}
+if (!function_exists('ctype_xdigit')) {
     function ctype_xdigit($text) { return p\Ctype::ctype_xdigit($text); }
 }

--- a/src/Iconv/bootstrap.php
+++ b/src/Iconv/bootstrap.php
@@ -13,34 +13,68 @@ use Symfony\Polyfill\Iconv as p;
 
 if (!defined('ICONV_IMPL')) {
     define('ICONV_IMPL', 'Symfony');
+}
+if (!defined('ICONV_VERSION')) {
     define('ICONV_VERSION', '1.0');
+}
+if (!defined('ICONV_MIME_DECODE_STRICT')) {
     define('ICONV_MIME_DECODE_STRICT', 1);
+}
+if (!defined('ICONV_MIME_DECODE_CONTINUE_ON_ERROR')) {
     define('ICONV_MIME_DECODE_CONTINUE_ON_ERROR', 2);
 }
 
 if (!function_exists('iconv')) {
     function iconv($from, $to, $s) { return p\Iconv::iconv($from, $to, $s); }
+}
+if (!function_exists('iconv_get_encoding')) {
     function iconv_get_encoding($type = 'all') { return p\Iconv::iconv_get_encoding($type); }
+}
+if (!function_exists('iconv_set_encoding')) {
     function iconv_set_encoding($type, $charset) { return p\Iconv::iconv_set_encoding($type, $charset); }
+}
+if (!function_exists('iconv_mime_encode')) {
     function iconv_mime_encode($name, $value, $pref = null) { return p\Iconv::iconv_mime_encode($name, $value, $pref); }
+}
+if (!function_exists('iconv_mime_decode_headers')) {
     function iconv_mime_decode_headers($encodedHeaders, $mode = 0, $enc = null) { return p\Iconv::iconv_mime_decode_headers($encodedHeaders, $mode, $enc); }
+}
 
-    if (extension_loaded('mbstring')) {
+if (extension_loaded('mbstring')) {
+    if (!function_exists('iconv_strlen')) {
         function iconv_strlen($s, $enc = null) { null === $enc and $enc = p\Iconv::$internalEncoding; return mb_strlen($s, $enc); }
+    }
+    if (!function_exists('iconv_strpos')) {
         function iconv_strpos($s, $needle, $offset = 0, $enc = null) { null === $enc and $enc = p\Iconv::$internalEncoding; return mb_strpos($s, $needle, $offset, $enc); }
+    }
+    if (!function_exists('iconv_strrpos')) {
         function iconv_strrpos($s, $needle, $enc = null) { null === $enc and $enc = p\Iconv::$internalEncoding; return mb_strrpos($s, $needle, 0, $enc); }
+    }
+    if (!function_exists('iconv_substr')) {
         function iconv_substr($s, $start, $length = 2147483647, $enc = null) { null === $enc and $enc = p\Iconv::$internalEncoding; return mb_substr($s, $start, $length, $enc); }
+    }
+    if (!function_exists('iconv_mime_decode')) {
         function iconv_mime_decode($encodedHeaders, $mode = 0, $enc = null) { null === $enc and $enc = p\Iconv::$internalEncoding; return mb_decode_mimeheader($encodedHeaders, $mode, $enc); }
-    } else {
+    }
+} else {
+    if (!function_exists('iconv_strlen')) {
         if (extension_loaded('xml')) {
             function iconv_strlen($s, $enc = null) { return p\Iconv::strlen1($s, $enc); }
         } else {
             function iconv_strlen($s, $enc = null) { return p\Iconv::strlen2($s, $enc); }
         }
+    }
 
+    if (!function_exists('iconv_strpos')) {
         function iconv_strpos($s, $needle, $offset = 0, $enc = null) { return p\Iconv::iconv_strpos($s, $needle, $offset, $enc); }
+    }
+    if (!function_exists('iconv_strrpos')) {
         function iconv_strrpos($s, $needle, $enc = null) { return p\Iconv::iconv_strrpos($s, $needle, $enc); }
+    }
+    if (!function_exists('iconv_substr')) {
         function iconv_substr($s, $start, $length = 2147483647, $enc = null) { return p\Iconv::iconv_substr($s, $start, $length, $enc); }
+    }
+    if (!function_exists('iconv_mime_decode')) {
         function iconv_mime_decode($encodedHeaders, $mode = 0, $enc = null) { return p\Iconv::iconv_mime_decode($encodedHeaders, $mode, $enc); }
     }
 }

--- a/src/Intl/Grapheme/bootstrap.php
+++ b/src/Intl/Grapheme/bootstrap.php
@@ -13,18 +13,38 @@ use Symfony\Polyfill\Intl\Grapheme as p;
 
 if (!defined('GRAPHEME_EXTR_COUNT')) {
     define('GRAPHEME_EXTR_COUNT', 0);
+}
+if (!defined('GRAPHEME_EXTR_MAXBYTES')) {
     define('GRAPHEME_EXTR_MAXBYTES', 1);
+}
+if (!defined('GRAPHEME_EXTR_MAXCHARS')) {
     define('GRAPHEME_EXTR_MAXCHARS', 2);
 }
 
-if (!function_exists('grapheme_strlen')) {
+if (!function_exists('grapheme_extract')) {
     function grapheme_extract($s, $size, $type = 0, $start = 0, &$next = 0) { return p\Grapheme::grapheme_extract($s, $size, $type, $start, $next); }
+}
+if (!function_exists('grapheme_stripos')) {
     function grapheme_stripos($s, $needle, $offset = 0) { return p\Grapheme::grapheme_stripos($s, $needle, $offset); }
+}
+if (!function_exists('grapheme_stristr')) {
     function grapheme_stristr($s, $needle, $beforeNeedle = false) { return p\Grapheme::grapheme_stristr($s, $needle, $beforeNeedle); }
+}
+if (!function_exists('grapheme_strlen')) {
     function grapheme_strlen($s) { return p\Grapheme::grapheme_strlen($s); }
+}
+if (!function_exists('grapheme_strpos')) {
     function grapheme_strpos($s, $needle, $offset = 0) { return p\Grapheme::grapheme_strpos($s, $needle, $offset); }
+}
+if (!function_exists('grapheme_strripos')) {
     function grapheme_strripos($s, $needle, $offset = 0) { return p\Grapheme::grapheme_strripos($s, $needle, $offset); }
+}
+if (!function_exists('grapheme_strrpos')) {
     function grapheme_strrpos($s, $needle, $offset = 0) { return p\Grapheme::grapheme_strrpos($s, $needle, $offset); }
+}
+if (!function_exists('grapheme_strstr')) {
     function grapheme_strstr($s, $needle, $beforeNeedle = false) { return p\Grapheme::grapheme_strstr($s, $needle, $beforeNeedle); }
+}
+if (!function_exists('grapheme_substr')) {
     function grapheme_substr($s, $start, $len = 2147483647) { return p\Grapheme::grapheme_substr($s, $start, $len); }
 }

--- a/src/Intl/Icu/bootstrap.php
+++ b/src/Intl/Icu/bootstrap.php
@@ -13,7 +13,13 @@ use Symfony\Component\Intl\Globals\IntlGlobals;
 
 if (!function_exists('intl_is_failure')) {
     function intl_is_failure($errorCode) { return IntlGlobals::isFailure($errorCode); }
+}
+if (!function_exists('intl_get_error_code')) {
     function intl_get_error_code() { return IntlGlobals::getErrorCode(); }
+}
+if (!function_exists('intl_get_error_message')) {
     function intl_get_error_message() { return IntlGlobals::getErrorMessage(); }
+}
+if (!function_exists('intl_error_name')) {
     function intl_error_name($errorCode) { return IntlGlobals::getErrorName($errorCode); }
 }

--- a/src/Intl/Idn/bootstrap.php
+++ b/src/Intl/Idn/bootstrap.php
@@ -11,51 +11,127 @@
 
 use Symfony\Polyfill\Intl\Idn as p;
 
-if (!defined('IDNA_DEFAULT')) {
+if (!defined('U_IDNA_PROHIBITED_ERROR')) {
     define('U_IDNA_PROHIBITED_ERROR', 66560);
+}
+if (!defined('U_IDNA_ERROR_START')) {
     define('U_IDNA_ERROR_START', 66560);
+}
+if (!defined('U_IDNA_UNASSIGNED_ERROR')) {
     define('U_IDNA_UNASSIGNED_ERROR', 66561);
+}
+if (!defined('U_IDNA_CHECK_BIDI_ERROR')) {
     define('U_IDNA_CHECK_BIDI_ERROR', 66562);
+}
+if (!defined('U_IDNA_STD3_ASCII_RULES_ERROR')) {
     define('U_IDNA_STD3_ASCII_RULES_ERROR', 66563);
+}
+if (!defined('U_IDNA_ACE_PREFIX_ERROR')) {
     define('U_IDNA_ACE_PREFIX_ERROR', 66564);
+}
+if (!defined('U_IDNA_VERIFICATION_ERROR')) {
     define('U_IDNA_VERIFICATION_ERROR', 66565);
+}
+if (!defined('U_IDNA_LABEL_TOO_LONG_ERROR')) {
     define('U_IDNA_LABEL_TOO_LONG_ERROR', 66566);
+}
+if (!defined('U_IDNA_ZERO_LENGTH_LABEL_ERROR')) {
     define('U_IDNA_ZERO_LENGTH_LABEL_ERROR', 66567);
+}
+if (!defined('U_IDNA_DOMAIN_NAME_TOO_LONG_ERROR')) {
     define('U_IDNA_DOMAIN_NAME_TOO_LONG_ERROR', 66568);
+}
+if (!defined('U_IDNA_ERROR_LIMIT')) {
     define('U_IDNA_ERROR_LIMIT', 66569);
+}
+if (!defined('U_STRINGPREP_PROHIBITED_ERROR')) {
     define('U_STRINGPREP_PROHIBITED_ERROR', 66560);
+}
+if (!defined('U_STRINGPREP_UNASSIGNED_ERROR')) {
     define('U_STRINGPREP_UNASSIGNED_ERROR', 66561);
+}
+if (!defined('U_STRINGPREP_CHECK_BIDI_ERROR')) {
     define('U_STRINGPREP_CHECK_BIDI_ERROR', 66562);
+}
+if (!defined('IDNA_DEFAULT')) {
     define('IDNA_DEFAULT', 0);
+}
+if (!defined('IDNA_ALLOW_UNASSIGNED')) {
     define('IDNA_ALLOW_UNASSIGNED', 1);
+}
+if (!defined('IDNA_USE_STD3_RULES')) {
     define('IDNA_USE_STD3_RULES', 2);
+}
+if (!defined('IDNA_CHECK_BIDI')) {
     define('IDNA_CHECK_BIDI', 4);
+}
+if (!defined('IDNA_CHECK_CONTEXTJ')) {
     define('IDNA_CHECK_CONTEXTJ', 8);
+}
+if (!defined('IDNA_NONTRANSITIONAL_TO_ASCII')) {
     define('IDNA_NONTRANSITIONAL_TO_ASCII', 16);
+}
+if (!defined('IDNA_NONTRANSITIONAL_TO_UNICODE')) {
     define('IDNA_NONTRANSITIONAL_TO_UNICODE', 32);
+}
+if (!defined('INTL_IDNA_VARIANT_2003')) {
     define('INTL_IDNA_VARIANT_2003', 0);
+}
+if (!defined('INTL_IDNA_VARIANT_UTS46')) {
     define('INTL_IDNA_VARIANT_UTS46', 1);
+}
+if (!defined('IDNA_ERROR_EMPTY_LABEL')) {
     define('IDNA_ERROR_EMPTY_LABEL', 1);
+}
+if (!defined('IDNA_ERROR_LABEL_TOO_LONG')) {
     define('IDNA_ERROR_LABEL_TOO_LONG', 2);
+}
+if (!defined('IDNA_ERROR_DOMAIN_NAME_TOO_LONG')) {
     define('IDNA_ERROR_DOMAIN_NAME_TOO_LONG', 4);
+}
+if (!defined('IDNA_ERROR_LEADING_HYPHEN')) {
     define('IDNA_ERROR_LEADING_HYPHEN', 8);
+}
+if (!defined('IDNA_ERROR_TRAILING_HYPHEN')) {
     define('IDNA_ERROR_TRAILING_HYPHEN', 16);
+}
+if (!defined('IDNA_ERROR_HYPHEN_3_4')) {
     define('IDNA_ERROR_HYPHEN_3_4', 32);
+}
+if (!defined('IDNA_ERROR_LEADING_COMBINING_MARK')) {
     define('IDNA_ERROR_LEADING_COMBINING_MARK', 64);
+}
+if (!defined('IDNA_ERROR_DISALLOWED')) {
     define('IDNA_ERROR_DISALLOWED', 128);
+}
+if (!defined('IDNA_ERROR_PUNYCODE')) {
     define('IDNA_ERROR_PUNYCODE', 256);
+}
+if (!defined('IDNA_ERROR_LABEL_HAS_DOT')) {
     define('IDNA_ERROR_LABEL_HAS_DOT', 512);
+}
+if (!defined('IDNA_ERROR_INVALID_ACE_LABEL')) {
     define('IDNA_ERROR_INVALID_ACE_LABEL', 1024);
+}
+if (!defined('IDNA_ERROR_BIDI')) {
     define('IDNA_ERROR_BIDI', 2048);
+}
+if (!defined('IDNA_ERROR_CONTEXTJ')) {
     define('IDNA_ERROR_CONTEXTJ', 4096);
 }
 
-if (!function_exists('idn_to_ascii')) {
-    if (PHP_VERSION_ID < 70400) {
+if (PHP_VERSION_ID < 70400) {
+    if (!function_exists('idn_to_ascii')) {
         function idn_to_ascii($domain, $options = IDNA_DEFAULT, $variant = INTL_IDNA_VARIANT_2003, &$idna_info = array()) { return p\Idn::idn_to_ascii($domain, $options, $variant, $idna_info); }
+    }
+    if (!function_exists('idn_to_utf8')) {
         function idn_to_utf8($domain, $options = IDNA_DEFAULT, $variant = INTL_IDNA_VARIANT_2003, &$idna_info = array()) { return p\Idn::idn_to_utf8($domain, $options, $variant, $idna_info); }
-    } else {
+    }
+} else {
+    if (!function_exists('idn_to_ascii')) {
         function idn_to_ascii($domain, $options = IDNA_DEFAULT, $variant = INTL_IDNA_VARIANT_UTS46, &$idna_info = array()) { return p\Idn::idn_to_ascii($domain, $options, $variant, $idna_info); }
+    }
+    if (!function_exists('idn_to_utf8')) {
         function idn_to_utf8($domain, $options = IDNA_DEFAULT, $variant = INTL_IDNA_VARIANT_UTS46, &$idna_info = array()) { return p\Idn::idn_to_utf8($domain, $options, $variant, $idna_info); }
     }
 }

--- a/src/Intl/Normalizer/bootstrap.php
+++ b/src/Intl/Normalizer/bootstrap.php
@@ -13,5 +13,7 @@ use Symfony\Polyfill\Intl\Normalizer as p;
 
 if (!function_exists('normalizer_is_normalized')) {
     function normalizer_is_normalized($s, $form = p\Normalizer::NFC) { return p\Normalizer::isNormalized($s, $form); }
+}
+if (!function_exists('normalizer_normalize')) {
     function normalizer_normalize($s, $form = p\Normalizer::NFC) { return p\Normalizer::normalize($s, $form); }
 }

--- a/src/Mbstring/bootstrap.php
+++ b/src/Mbstring/bootstrap.php
@@ -13,52 +13,125 @@ use Symfony\Polyfill\Mbstring as p;
 
 if (!defined('MB_CASE_UPPER')) {
     define('MB_CASE_UPPER', 0);
+}
+if (!defined('MB_CASE_LOWER')) {
     define('MB_CASE_LOWER', 1);
+}
+if (!defined('MB_CASE_TITLE')) {
     define('MB_CASE_TITLE', 2);
 }
 
-if (!function_exists('mb_strlen')) {
+if (!function_exists('mb_convert_encoding')) {
     function mb_convert_encoding($s, $to, $from = null) { return p\Mbstring::mb_convert_encoding($s, $to, $from); }
+}
+if (!function_exists('mb_decode_mimeheader')) {
     function mb_decode_mimeheader($s) { return p\Mbstring::mb_decode_mimeheader($s); }
+}
+if (!function_exists('mb_encode_mimeheader')) {
     function mb_encode_mimeheader($s, $charset = null, $transferEnc = null, $lf = null, $indent = null) { return p\Mbstring::mb_encode_mimeheader($s, $charset, $transferEnc, $lf, $indent); }
+}
+if (!function_exists('mb_decode_numericentity')) {
     function mb_decode_numericentity($s, $convmap, $enc = null) { return p\Mbstring::mb_decode_numericentity($s, $convmap, $enc); }
+}
+if (!function_exists('mb_encode_numericentity')) {
     function mb_encode_numericentity($s, $convmap, $enc = null, $is_hex = false) { return p\Mbstring::mb_encode_numericentity($s, $convmap, $enc, $is_hex); }
+}
+if (!function_exists('mb_convert_case')) {
     function mb_convert_case($s, $mode, $enc = null) { return p\Mbstring::mb_convert_case($s, $mode, $enc); }
+}
+if (!function_exists('mb_internal_encoding')) {
     function mb_internal_encoding($enc = null) { return p\Mbstring::mb_internal_encoding($enc); }
+}
+if (!function_exists('mb_language')) {
     function mb_language($lang = null) { return p\Mbstring::mb_language($lang); }
+}
+if (!function_exists('mb_list_encodings')) {
     function mb_list_encodings() { return p\Mbstring::mb_list_encodings(); }
+}
+if (!function_exists('mb_encoding_aliases')) {
     function mb_encoding_aliases($encoding) { return p\Mbstring::mb_encoding_aliases($encoding); }
+}
+if (!function_exists('mb_check_encoding')) {
     function mb_check_encoding($var = null, $encoding = null) { return p\Mbstring::mb_check_encoding($var, $encoding); }
+}
+if (!function_exists('mb_detect_encoding')) {
     function mb_detect_encoding($str, $encodingList = null, $strict = false) { return p\Mbstring::mb_detect_encoding($str, $encodingList, $strict); }
+}
+if (!function_exists('mb_detect_order')) {
     function mb_detect_order($encodingList = null) { return p\Mbstring::mb_detect_order($encodingList); }
+}
+if (!function_exists('mb_parse_str')) {
     function mb_parse_str($s, &$result = array()) { parse_str($s, $result); }
+}
+if (!function_exists('mb_strlen')) {
     function mb_strlen($s, $enc = null) { return p\Mbstring::mb_strlen($s, $enc); }
+}
+if (!function_exists('mb_strpos')) {
     function mb_strpos($s, $needle, $offset = 0, $enc = null) { return p\Mbstring::mb_strpos($s, $needle, $offset, $enc); }
+}
+if (!function_exists('mb_strtolower')) {
     function mb_strtolower($s, $enc = null) { return p\Mbstring::mb_strtolower($s, $enc); }
+}
+if (!function_exists('mb_strtoupper')) {
     function mb_strtoupper($s, $enc = null) { return p\Mbstring::mb_strtoupper($s, $enc); }
+}
+if (!function_exists('mb_substitute_character')) {
     function mb_substitute_character($char = null) { return p\Mbstring::mb_substitute_character($char); }
+}
+if (!function_exists('mb_substr')) {
     function mb_substr($s, $start, $length = 2147483647, $enc = null) { return p\Mbstring::mb_substr($s, $start, $length, $enc); }
+}
+if (!function_exists('mb_stripos')) {
     function mb_stripos($s, $needle, $offset = 0, $enc = null) { return p\Mbstring::mb_stripos($s, $needle, $offset, $enc); }
+}
+if (!function_exists('mb_stristr')) {
     function mb_stristr($s, $needle, $part = false, $enc = null) { return p\Mbstring::mb_stristr($s, $needle, $part, $enc); }
+}
+if (!function_exists('mb_strrchr')) {
     function mb_strrchr($s, $needle, $part = false, $enc = null) { return p\Mbstring::mb_strrchr($s, $needle, $part, $enc); }
+}
+if (!function_exists('mb_strrichr')) {
     function mb_strrichr($s, $needle, $part = false, $enc = null) { return p\Mbstring::mb_strrichr($s, $needle, $part, $enc); }
+}
+if (!function_exists('mb_strripos')) {
     function mb_strripos($s, $needle, $offset = 0, $enc = null) { return p\Mbstring::mb_strripos($s, $needle, $offset, $enc); }
+}
+if (!function_exists('mb_strrpos')) {
     function mb_strrpos($s, $needle, $offset = 0, $enc = null) { return p\Mbstring::mb_strrpos($s, $needle, $offset, $enc); }
+}
+if (!function_exists('mb_strstr')) {
     function mb_strstr($s, $needle, $part = false, $enc = null) { return p\Mbstring::mb_strstr($s, $needle, $part, $enc); }
+}
+if (!function_exists('mb_get_info')) {
     function mb_get_info($type = 'all') { return p\Mbstring::mb_get_info($type); }
+}
+if (!function_exists('mb_http_output')) {
     function mb_http_output($enc = null) { return p\Mbstring::mb_http_output($enc); }
+}
+if (!function_exists('mb_strwidth')) {
     function mb_strwidth($s, $enc = null) { return p\Mbstring::mb_strwidth($s, $enc); }
+}
+if (!function_exists('mb_substr_count')) {
     function mb_substr_count($haystack, $needle, $enc = null) { return p\Mbstring::mb_substr_count($haystack, $needle, $enc); }
+}
+if (!function_exists('mb_output_handler')) {
     function mb_output_handler($contents, $status) { return p\Mbstring::mb_output_handler($contents, $status); }
+}
+if (!function_exists('mb_http_input')) {
     function mb_http_input($type = '') { return p\Mbstring::mb_http_input($type); }
+}
+if (!function_exists('mb_convert_variables')) {
     function mb_convert_variables($toEncoding, $fromEncoding, &$a = null, &$b = null, &$c = null, &$d = null, &$e = null, &$f = null) { return p\Mbstring::mb_convert_variables($toEncoding, $fromEncoding, $a, $b, $c, $d, $e, $f); }
 }
-if (!function_exists('mb_chr')) {
+if (!function_exists('mb_ord')) {
     function mb_ord($s, $enc = null) { return p\Mbstring::mb_ord($s, $enc); }
+}
+if (!function_exists('mb_chr')) {
     function mb_chr($code, $enc = null) { return p\Mbstring::mb_chr($code, $enc); }
+}
+if (!function_exists('mb_scrub')) {
     function mb_scrub($s, $enc = null) { $enc = null === $enc ? mb_internal_encoding() : $enc; return mb_convert_encoding($s, $enc, $enc); }
 }
-
 if (!function_exists('mb_str_split')) {
     function mb_str_split($string, $split_length = 1, $encoding = null) { return p\Mbstring::mb_str_split($string, $split_length, $encoding); }
 }

--- a/src/Php56/bootstrap.php
+++ b/src/Php56/bootstrap.php
@@ -17,6 +17,8 @@ if (PHP_VERSION_ID < 50600) {
     }
     if (extension_loaded('ldap') && !defined('LDAP_ESCAPE_FILTER')) {
         define('LDAP_ESCAPE_FILTER', 1);
+    }
+    if (extension_loaded('ldap') && !defined('LDAP_ESCAPE_DN')) {
         define('LDAP_ESCAPE_DN', 2);
     }
 

--- a/src/Php72/bootstrap.php
+++ b/src/Php72/bootstrap.php
@@ -20,6 +20,8 @@ if (PHP_VERSION_ID < 70200) {
     }
     if (!function_exists('utf8_encode')) {
         function utf8_encode($s) { return p\Php72::utf8_encode($s); }
+    }
+    if (!function_exists('utf8_decode')) {
         function utf8_decode($s) { return p\Php72::utf8_decode($s); }
     }
     if (!function_exists('spl_object_id')) {
@@ -28,9 +30,13 @@ if (PHP_VERSION_ID < 70200) {
     if (!defined('PHP_OS_FAMILY')) {
         define('PHP_OS_FAMILY', p\Php72::php_os_family());
     }
-    if (!function_exists('mb_chr')) {
+    if (!function_exists('mb_ord')) {
         function mb_ord($s, $enc = null) { return p\Php72::mb_ord($s, $enc); }
+    }
+    if (!function_exists('mb_chr')) {
         function mb_chr($code, $enc = null) { return p\Php72::mb_chr($code, $enc); }
+    }
+    if (!function_exists('mb_scrub')) {
         function mb_scrub($s, $enc = null) { $enc = null === $enc ? mb_internal_encoding() : $enc; return mb_convert_encoding($s, $enc, $enc); }
     }
 }

--- a/src/Php80/bootstrap.php
+++ b/src/Php80/bootstrap.php
@@ -15,27 +15,21 @@ if (PHP_VERSION_ID < 80000) {
     if (!function_exists('fdiv')) {
         function fdiv(float $dividend, float $divisor): float { return p\Php80::fdiv($dividend, $divisor); }
     }
-
     if (!function_exists('preg_last_error_msg')) {
         function preg_last_error_msg(): string { return p\Php80::preg_last_error_msg(); }
     }
-
     if (!function_exists('str_contains')) {
         function str_contains(string $haystack, string $needle): bool { return p\Php80::str_contains($haystack, $needle); }
     }
-
     if (!function_exists('str_starts_with')) {
         function str_starts_with(string $haystack, string $needle): bool { return p\Php80::str_starts_with($haystack, $needle); }
     }
-
     if (!function_exists('str_ends_with')) {
         function str_ends_with(string $haystack, string $needle): bool { return p\Php80::str_ends_with($haystack, $needle); }
     }
-
     if (!defined('FILTER_VALIDATE_BOOL') && defined('FILTER_VALIDATE_BOOLEAN')) {
         define('FILTER_VALIDATE_BOOL', FILTER_VALIDATE_BOOLEAN);
     }
-
     if (!function_exists('get_debug_type')) {
         function get_debug_type($value): string { return p\Php80::get_debug_type($value); }
     }

--- a/src/Uuid/bootstrap.php
+++ b/src/Uuid/bootstrap.php
@@ -11,33 +11,79 @@
 
 use Symfony\Polyfill\Uuid as p;
 
-if (!defined('UUID_TYPE_DEFAULT')) {
+if (!defined('UUID_VARIANT_NCS')) {
     define('UUID_VARIANT_NCS', 0);
+}
+if (!defined('UUID_VARIANT_DCE')) {
     define('UUID_VARIANT_DCE', 1);
+}
+if (!defined('UUID_VARIANT_MICROSOFT')) {
     define('UUID_VARIANT_MICROSOFT', 2);
+}
+if (!defined('UUID_VARIANT_OTHER')) {
     define('UUID_VARIANT_OTHER', 3);
+}
+if (!defined('UUID_TYPE_DEFAULT')) {
     define('UUID_TYPE_DEFAULT', 0);
+}
+if (!defined('UUID_TYPE_TIME')) {
     define('UUID_TYPE_TIME', 1);
+}
+if (!defined('UUUID_TYPE_MD5')) {
     define('UUID_TYPE_MD5', 3);
+}
+if (!defined('UUID_TYPE_DCE')) {
     define('UUID_TYPE_DCE', 4); // Deprecated alias
+}
+if (!defined('UUID_TYPE_NAME')) {
     define('UUID_TYPE_NAME', 1); // Deprecated alias
+}
+if (!defined('UUID_TYPE_RANDOM')) {
     define('UUID_TYPE_RANDOM', 4);
+}
+if (!defined('UUID_TYPE_SHA1')) {
     define('UUID_TYPE_SHA1', 5);
+}
+if (!defined('UUID_TYPE_NULL')) {
     define('UUID_TYPE_NULL', -1);
+}
+if (!defined('UUID_TYPE_INVALID')) {
     define('UUID_TYPE_INVALID', -42);
 }
 
 if (!function_exists('uuid_create')) {
     function uuid_create($type = UUID_TYPE_DEFAULT) { return p\Uuid::uuid_create($type); }
+}
+if (!function_exists('uuid_generate_md5')) {
     function uuid_generate_md5($uuid_ns, $name) { return p\Uuid::uuid_generate_md5($uuid_ns, $name); }
+}
+if (!function_exists('uuid_generate_sha1')) {
     function uuid_generate_sha1($uuid_ns, $name) { return p\Uuid::uuid_generate_sha1($uuid_ns, $name); }
+}
+if (!function_exists('uuid_is_valid')) {
     function uuid_is_valid($uuid) { return p\Uuid::uuid_is_valid($uuid); }
+}
+if (!function_exists('uuid_compare')) {
     function uuid_compare($uuid1, $uuid2) { return p\Uuid::uuid_compare($uuid1, $uuid2); }
+}
+if (!function_exists('uuid_is_null')) {
     function uuid_is_null($uuid) { return p\Uuid::uuid_is_null($uuid); }
+}
+if (!function_exists('uuid_type')) {
     function uuid_type($uuid) { return p\Uuid::uuid_type($uuid); }
+}
+if (!function_exists('uuid_variant')) {
     function uuid_variant($uuid) { return p\Uuid::uuid_variant($uuid); }
+}
+if (!function_exists('uuid_time')) {
     function uuid_time($uuid) { return p\Uuid::uuid_time($uuid); }
+}
+if (!function_exists('uuid_mac')) {
     function uuid_mac($uuid) { return p\Uuid::uuid_mac($uuid); }
+}
+if (!function_exists('uuid_parse')) {
     function uuid_parse($uuid) { return p\Uuid::uuid_parse($uuid); }
+}
+if (!function_exists('uuid_unparse')) {
     function uuid_unparse($uuid) { return p\Uuid::uuid_unparse($uuid); }
 }


### PR DESCRIPTION
As originally discussed in https://github.com/symfony/polyfill-mbstring/pull/6 and later in https://github.com/symfony/polyfill/pull/251 in some scenarios it may be better to check for each constant/function before defining it. Such scenarios are typically those where some project or a library defines its polyfills for some parts of extension functionality but not all of it.

Probably the most popular example is WordPress, defining some polyfills in `wp-includes/compat.php` but not including complete functionalities (i.e. it defines only a few `mb_` functions). Plugin developers then may need other `mb_` functions and need to load those that WordPress didn't.

There may be some performance concerns but it seems that checks such as `function_exists` are [very fast](https://github.com/symfony/polyfill-mbstring/pull/6#issuecomment-621117197) - in fact, [PHP tries to evaluate both `function_exists` and `defined` at compile time](https://github.com/php/php-src/blob/e141592da6cdb15709e4aeaab5421c9a46564849/ext/opcache/Optimizer/pass1_5.c#L349) (see also [StackOverflow](https://stackoverflow.com/questions/21619939/does-function-exists-cache-its-queries/21620062#21620062)). This means on installs that do have the polyfilled extensions installed, there should be zero overhead (the conditions will evaluate to `true` at compile time).

Note that many of the currently existing polyfills already perform checks for each function separately (most of the PHP-version polyfills).

Closes https://github.com/symfony/polyfill/pull/251.