### PR TITLE
Update `README.md` file with the new str_starts_with and str_ends_with

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Polyfills are provided for:
 - the `get_debug_type` function introduced in PHP 8.0;
 - the `preg_last_error_msg` function introduced in PHP 8.0;
 - the `str_contains` function introduced in PHP 8.0;
+- the `str_starts_with` and `str_ends_with` functions introduced in PHP 8.0;
 - the `ValueError` class introduced in PHP 8.0;
 - the `FILTER_VALIDATE_BOOL` constant introduced in PHP 8.0;
 

--- a/src/Php80/README.md
+++ b/src/Php80/README.md
@@ -10,6 +10,8 @@ This component provides features added to PHP 8.0 core:
 - [`get_debug_type`](https://php.net/get_debug_type)
 - [`preg_last_error_msg`](https://php.net/preg_last_error_msg)
 - [`str_contains`](https://php.net/str_contains)
+- [`str_starts_with`](https://php.net/str_starts_with)
+- [`str_ends_with`](https://php.net/str_ends_with)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).


### PR DESCRIPTION
I'm sorry the PR #250 did not update the root readme file with the two new functions. This commit changes it. 