### PR TITLE
[PHP 8.0] Use substr_compare() for str_ends_with()

### DIFF
--- a/src/Php80/Php80.php
+++ b/src/Php80/Php80.php
@@ -91,6 +91,6 @@ final class Php80
 
     public static function str_ends_with(string $haystack, string $needle): bool
     {
-        return '' === $needle || $needle === \substr($haystack, -\strlen($needle));
+        return '' === $needle || ('' !== $haystack && 0 === \substr_compare($haystack, $needle, -\strlen($needle)));
     }
 }


### PR DESCRIPTION
Refs https://github.com/symfony/polyfill/pull/250#discussion_r418961105

The benchmark http://sandbox.onlinephpfunctions.com/code/8d3dd885b40946d55e40aa918ed900f2a8d9741a shows that v 2 avoids extra memory allocation (like the native implementation), and is faster (significantly for large strings).