### PR TITLE
Fail on leading or trailing hyphen-minus (RFC 3492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * added `str_starts_with()` and `str_ends_with()` to the PHP 8 polyfill
   * fixed `spl_object_id()` on 32-bit systems
+  * fixed `idn_to_ascii()` not failing on leading or trailing hyphen-minus
 
 # 1.15.0
 

--- a/src/Intl/Idn/Idn.php
+++ b/src/Intl/Idn/Idn.php
@@ -127,6 +127,10 @@ final class Idn
 
     private static function encodePart($input)
     {
+        if (\substr($input, 0, 1) === '-' || \substr($input, -1) === '-') {
+            return false;
+        }
+
         $codePoints = self::listCodePoints($input);
 
         $n = 128;

--- a/tests/Intl/Idn/IdnTest.php
+++ b/tests/Intl/Idn/IdnTest.php
@@ -298,6 +298,12 @@ class IdnTest extends TestCase
             array(
                 'aa..aa.de',
             ),
+            array(
+                '-leading.de',
+            ),
+            array(
+                'trailing-.de',
+            ),
         );
     }
 


### PR DESCRIPTION
Fixes #256.