### PR TITLE
Add polyfill for `PHP_FLOAT_*` constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.16.0
 
   * added `str_starts_with()` and `str_ends_with()` to the PHP 8 polyfill
+  * added polyfill for `PHP_FLOAT_*` constants
   * fixed `spl_object_id()` on 32-bit systems
   * fixed `idn_to_ascii()` not failing on leading or trailing hyphen-minus
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Polyfills are provided for:
   `mbstring.func_overload` is required;
 - the `spl_object_id` and `stream_isatty` functions introduced in PHP 7.2;
 - the `sapi_windows_vt100_support` function (Windows only) introduced in PHP 7.2;
+- the `PHP_FLOAT_*` constant introduced in PHP 7.2;
 - the `PHP_OS_FAMILY` constant introduced in PHP 7.2;
 - the `is_countable` function introduced in PHP 7.3;
 - the `array_key_first` and `array_key_last` functions introduced in PHP 7.3;

--- a/src/Php72/README.md
+++ b/src/Php72/README.md
@@ -16,6 +16,7 @@ Moved to core since 7.2 (was in the optional XML extension earlier):
 - [`utf8_decode`](https://php.net/utf8_decode)
 
 Also, it provides a constant added to PHP 7.2:
+- [`PHP_FLOAT_*`](https://php.net/reserved.constants#constant.php-float-dig)
 - [`PHP_OS_FAMILY`](https://php.net/reserved.constants#constant.php-os-family)
 
 More information can be found in the

--- a/src/Php72/bootstrap.php
+++ b/src/Php72/bootstrap.php
@@ -12,6 +12,22 @@
 use Symfony\Polyfill\Php72 as p;
 
 if (PHP_VERSION_ID < 70200) {
+    if (!defined('PHP_FLOAT_DIG')) {
+        define('PHP_FLOAT_DIG', 15);
+    }
+    if (!defined('PHP_FLOAT_EPSILON')) {
+        define('PHP_FLOAT_EPSILON', 2.2204460492503E-16);
+    }
+    if (!defined('PHP_FLOAT_MIN')) {
+        define('PHP_FLOAT_MIN', 2.2250738585072E-308);
+    }
+    if (!defined('PHP_FLOAT_MAX')) {
+        define('PHP_FLOAT_MAX', 1.7976931348623157E+308);
+    }
+    if (!defined('PHP_OS_FAMILY')) {
+        define('PHP_OS_FAMILY', p\Php72::php_os_family());
+    }
+
     if ('\\' === DIRECTORY_SEPARATOR && !function_exists('sapi_windows_vt100_support')) {
         function sapi_windows_vt100_support($stream, $enable = null) { return p\Php72::sapi_windows_vt100_support($stream, $enable); }
     }
@@ -26,9 +42,6 @@ if (PHP_VERSION_ID < 70200) {
     }
     if (!function_exists('spl_object_id')) {
         function spl_object_id($s) { return p\Php72::spl_object_id($s); }
-    }
-    if (!defined('PHP_OS_FAMILY')) {
-        define('PHP_OS_FAMILY', p\Php72::php_os_family());
     }
     if (!function_exists('mb_ord')) {
         function mb_ord($s, $enc = null) { return p\Php72::mb_ord($s, $enc); }

--- a/tests/Php72/Php72Test.php
+++ b/tests/Php72/Php72Test.php
@@ -50,6 +50,14 @@ class Php72Test extends TestCase
         $this->assertSame(PHP_OS_FAMILY, p::php_os_family());
     }
 
+    public function testPhpFloat()
+    {
+        $this->assertSame(15, PHP_FLOAT_DIG);
+        $this->assertSame(2.2204460492503E-16, PHP_FLOAT_EPSILON);
+        $this->assertSame(2.2250738585072E-308, PHP_FLOAT_MIN);
+        $this->assertSame(1.7976931348623157E+308, PHP_FLOAT_MAX);
+    }
+
     /**
      * @covers \Symfony\Polyfill\Php72\Php72::spl_object_id
      */


### PR DESCRIPTION
Fix #223

The values are the same on 32b and 64b systems.
They differ only on very exotic and old architectures (VAX/IBM floats).