### PR TITLE
[PHP 8.0] add `get_resource_id` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Polyfills are provided for:
 - the `str_starts_with` and `str_ends_with` functions introduced in PHP 8.0;
 - the `ValueError` class introduced in PHP 8.0;
 - the `FILTER_VALIDATE_BOOL` constant introduced in PHP 8.0;
+- the `get_resource_id` function introduced in PHP 8.0;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no

--- a/src/Php80/Php80.php
+++ b/src/Php80/Php80.php
@@ -57,6 +57,15 @@ final class Php80
         return (get_parent_class($class) ?: key(class_implements($class)) ?: 'class').'@anonymous';
     }
 
+    public static function get_resource_id($res): int
+    {
+        if (!\is_resource($res) && null === @get_resource_type($res)) {
+            throw new \TypeError(sprintf('Argument 1 passed to get_resource_id() must be of the type resource, %s given', get_debug_type($res)));
+        }
+
+        return (int) $res;
+    }
+
     public static function preg_last_error_msg(): string
     {
         switch (preg_last_error()) {

--- a/src/Php80/README.md
+++ b/src/Php80/README.md
@@ -12,6 +12,7 @@ This component provides features added to PHP 8.0 core:
 - [`str_contains`](https://php.net/str_contains)
 - [`str_starts_with`](https://php.net/str_starts_with)
 - [`str_ends_with`](https://php.net/str_ends_with)
+- [`get_resource_id`](https://php.net/get_resource_id)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).

--- a/src/Php80/bootstrap.php
+++ b/src/Php80/bootstrap.php
@@ -33,4 +33,7 @@ if (PHP_VERSION_ID < 80000) {
     if (!function_exists('get_debug_type')) {
         function get_debug_type($value): string { return p\Php80::get_debug_type($value); }
     }
+    if (!function_exists('get_resource_id')) {
+        function get_resource_id($res): int { return p\Php80::get_resource_id($res); }
+    }
 }

--- a/tests/Php80/Php80Test.php
+++ b/tests/Php80/Php80Test.php
@@ -179,6 +179,28 @@ class Php80Test extends TestCase
         $this->assertFalse(str_ends_with($testEmoji, "✨")); // 0xe2 0x9c 0xa8
     }
 
+    /**
+     * @covers \Symfony\Polyfill\Php80\Php80::get_resource_id
+     */
+    public function testGetResourceIdWithValidResource()
+    {
+        $resource = \fopen(__FILE__, 'r');
+        $resourceId = (int) $resource;
+        $this->assertSame($resourceId, get_resource_id($resource));
+        \fclose($resource);
+        $this->assertSame($resourceId, get_resource_id($resource));
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php80\Php80::get_resource_id
+     * @dataProvider invalidResourceProvider
+     */
+    public function testGetResourceWithInvalidValue($value)
+    {
+        $this->setExpectedException('TypeError');
+        get_resource_id($value);
+    }
+
     public function fdivProvider()
     {
         return array(
@@ -226,6 +248,18 @@ class Php80Test extends TestCase
             array('invalid', 1.0),
             array('invalid', 'invalid'),
             array(1.0, 'invalid'),
+        );
+    }
+
+    public function invalidResourceProvider()
+    {
+        return array(
+            array(true),
+            array(null),
+            array(new \stdClass()),
+            array('test'),
+            array(10),
+            array(10.0),
         );
     }
 


### PR DESCRIPTION
Resolves #259 

PHP 8.0 output for reference:
```
php > $res = fopen('test', 'w');
php > var_dump((int) $res, get_resource_id($res));
int(2)
int(2)
php > fclose($res);
php > var_dump((int) $res, get_resource_id($res));
int(2)
int(2)
php > $res = 10;
php > var_dump((int) $res, get_resource_id($res));
PHP Warning:  Uncaught TypeError: get_resource_id(): Argument #1 ($res) must be of type resource, int given in php shell code:1
Stack trace:
#0 php shell code(1): get_resource_id(10)
#1 {main}
  thrown in php shell code on line 1

Warning: Uncaught TypeError: get_resource_id(): Argument #1 ($res) must be of type resource, int given in php shell code:1
Stack trace:
#0 php shell code(1): get_resource_id(10)
#1 {main}
  thrown in php shell code on line 1
```