### PR TITLE
Fix declaring extra constants when `intl` is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.17.0
 
   * added `get_resource_id()` to the PHP 8 polyfill
+  * fix declaring extra constants when `intl` is loaded
 
 # 1.16.0
 

--- a/src/Iconv/bootstrap.php
+++ b/src/Iconv/bootstrap.php
@@ -11,6 +11,10 @@
 
 use Symfony\Polyfill\Iconv as p;
 
+if (extension_loaded('iconv')) {
+    return;
+}
+
 if (!defined('ICONV_IMPL')) {
     define('ICONV_IMPL', 'Symfony');
 }

--- a/src/Intl/Grapheme/bootstrap.php
+++ b/src/Intl/Grapheme/bootstrap.php
@@ -11,6 +11,10 @@
 
 use Symfony\Polyfill\Intl\Grapheme as p;
 
+if (extension_loaded('intl')) {
+    return;
+}
+
 if (!defined('GRAPHEME_EXTR_COUNT')) {
     define('GRAPHEME_EXTR_COUNT', 0);
 }

--- a/src/Intl/Idn/bootstrap.php
+++ b/src/Intl/Idn/bootstrap.php
@@ -11,6 +11,10 @@
 
 use Symfony\Polyfill\Intl\Idn as p;
 
+if (extension_loaded('intl')) {
+    return;
+}
+
 if (!defined('U_IDNA_PROHIBITED_ERROR')) {
     define('U_IDNA_PROHIBITED_ERROR', 66560);
 }

--- a/src/Mbstring/bootstrap.php
+++ b/src/Mbstring/bootstrap.php
@@ -11,16 +11,6 @@
 
 use Symfony\Polyfill\Mbstring as p;
 
-if (!defined('MB_CASE_UPPER')) {
-    define('MB_CASE_UPPER', 0);
-}
-if (!defined('MB_CASE_LOWER')) {
-    define('MB_CASE_LOWER', 1);
-}
-if (!defined('MB_CASE_TITLE')) {
-    define('MB_CASE_TITLE', 2);
-}
-
 if (!function_exists('mb_convert_encoding')) {
     function mb_convert_encoding($s, $to, $from = null) { return p\Mbstring::mb_convert_encoding($s, $to, $from); }
 }
@@ -134,4 +124,18 @@ if (!function_exists('mb_scrub')) {
 }
 if (!function_exists('mb_str_split')) {
     function mb_str_split($string, $split_length = 1, $encoding = null) { return p\Mbstring::mb_str_split($string, $split_length, $encoding); }
+}
+
+if (extension_loaded('mbstring')) {
+    return;
+}
+
+if (!defined('MB_CASE_UPPER')) {
+    define('MB_CASE_UPPER', 0);
+}
+if (!defined('MB_CASE_LOWER')) {
+    define('MB_CASE_LOWER', 1);
+}
+if (!defined('MB_CASE_TITLE')) {
+    define('MB_CASE_TITLE', 2);
 }

--- a/src/Php54/bootstrap.php
+++ b/src/Php54/bootstrap.php
@@ -11,24 +11,26 @@
 
 use Symfony\Polyfill\Php54 as p;
 
-if (PHP_VERSION_ID < 50400) {
-    if (!function_exists('trait_exists')) {
-        function trait_exists($class, $autoload = true) { return $autoload && \class_exists($class, $autoload) && false; }
-    }
-    if (!function_exists('class_uses')) {
-        function class_uses($class, $autoload = true)
-        {
-            if (\is_object($class) || \class_exists($class, $autoload) || \interface_exists($class, false)) {
-                return array();
-            }
+if (PHP_VERSION_ID >= 50400) {
+    return;
+}
 
-            return false;
+if (!function_exists('trait_exists')) {
+    function trait_exists($class, $autoload = true) { return $autoload && \class_exists($class, $autoload) && false; }
+}
+if (!function_exists('class_uses')) {
+    function class_uses($class, $autoload = true)
+    {
+        if (\is_object($class) || \class_exists($class, $autoload) || \interface_exists($class, false)) {
+            return array();
         }
+
+        return false;
     }
-    if (!function_exists('hex2bin')) {
-        function hex2bin($data) { return p\Php54::hex2bin($data); }
-    }
-    if (!function_exists('session_register_shutdown')) {
-        function session_register_shutdown() { register_shutdown_function('session_write_close'); }
-    }
+}
+if (!function_exists('hex2bin')) {
+    function hex2bin($data) { return p\Php54::hex2bin($data); }
+}
+if (!function_exists('session_register_shutdown')) {
+    function session_register_shutdown() { register_shutdown_function('session_write_close'); }
 }

--- a/src/Php55/bootstrap.php
+++ b/src/Php55/bootstrap.php
@@ -11,17 +11,19 @@
 
 use Symfony\Polyfill\Php55 as p;
 
-if (PHP_VERSION_ID < 50500) {
-    if (!function_exists('boolval')) {
-        function boolval($val) { return p\Php55::boolval($val); }
-    }
-    if (!function_exists('json_last_error_msg')) {
-        function json_last_error_msg() { return p\Php55::json_last_error_msg(); }
-    }
-    if (!function_exists('array_column')) {
-        function array_column($array, $columnKey, $indexKey = null) { return p\Php55ArrayColumn::array_column($array, $columnKey, $indexKey); }
-    }
-    if (!function_exists('hash_pbkdf2')) {
-        function hash_pbkdf2($algorithm, $password, $salt, $iterations, $length = 0, $rawOutput = false) { return p\Php55::hash_pbkdf2($algorithm, $password, $salt, $iterations, $length, $rawOutput); }
-    }
+if (PHP_VERSION_ID >= 50500) {
+    return;
+}
+
+if (!function_exists('boolval')) {
+    function boolval($val) { return p\Php55::boolval($val); }
+}
+if (!function_exists('json_last_error_msg')) {
+    function json_last_error_msg() { return p\Php55::json_last_error_msg(); }
+}
+if (!function_exists('array_column')) {
+    function array_column($array, $columnKey, $indexKey = null) { return p\Php55ArrayColumn::array_column($array, $columnKey, $indexKey); }
+}
+if (!function_exists('hash_pbkdf2')) {
+    function hash_pbkdf2($algorithm, $password, $salt, $iterations, $length = 0, $rawOutput = false) { return p\Php55::hash_pbkdf2($algorithm, $password, $salt, $iterations, $length, $rawOutput); }
 }

--- a/src/Php56/bootstrap.php
+++ b/src/Php56/bootstrap.php
@@ -11,32 +11,34 @@
 
 use Symfony\Polyfill\Php56 as p;
 
-if (PHP_VERSION_ID < 50600) {
-    if (!function_exists('hash_equals')) {
-        function hash_equals($knownString, $userInput) { return p\Php56::hash_equals($knownString, $userInput); }
-    }
-    if (extension_loaded('ldap') && !defined('LDAP_ESCAPE_FILTER')) {
-        define('LDAP_ESCAPE_FILTER', 1);
-    }
-    if (extension_loaded('ldap') && !defined('LDAP_ESCAPE_DN')) {
-        define('LDAP_ESCAPE_DN', 2);
-    }
+if (PHP_VERSION_ID >= 50600) {
+    return;
+}
 
-    if (extension_loaded('ldap') && !function_exists('ldap_escape')) {
-        function ldap_escape($subject, $ignore = '', $flags = 0) { return p\Php56::ldap_escape($subject, $ignore, $flags); }
-    }
+if (!function_exists('hash_equals')) {
+    function hash_equals($knownString, $userInput) { return p\Php56::hash_equals($knownString, $userInput); }
+}
+if (extension_loaded('ldap') && !defined('LDAP_ESCAPE_FILTER')) {
+    define('LDAP_ESCAPE_FILTER', 1);
+}
+if (extension_loaded('ldap') && !defined('LDAP_ESCAPE_DN')) {
+    define('LDAP_ESCAPE_DN', 2);
+}
 
-    if (50509 === PHP_VERSION_ID && 4 === PHP_INT_SIZE) {
-        // Missing functions in PHP 5.5.9 - affects 32 bit builds of Ubuntu 14.04LTS
-        // See https://bugs.launchpad.net/ubuntu/+source/php5/+bug/1315888
-        if (!function_exists('gzopen') && function_exists('gzopen64')) {
-            function gzopen($filename, $mode, $use_include_path = 0) { return gzopen64($filename, $mode, $use_include_path); }
-        }
-        if (!function_exists('gzseek') && function_exists('gzseek64')) {
-            function gzseek($zp, $offset, $whence = SEEK_SET) { return gzseek64($zp, $offset, $whence); }
-        }
-        if (!function_exists('gztell') && function_exists('gztell64')) {
-            function gztell($zp) { return gztell64($zp); }
-        }
+if (extension_loaded('ldap') && !function_exists('ldap_escape')) {
+    function ldap_escape($subject, $ignore = '', $flags = 0) { return p\Php56::ldap_escape($subject, $ignore, $flags); }
+}
+
+if (50509 === PHP_VERSION_ID && 4 === PHP_INT_SIZE) {
+    // Missing functions in PHP 5.5.9 - affects 32 bit builds of Ubuntu 14.04LTS
+    // See https://bugs.launchpad.net/ubuntu/+source/php5/+bug/1315888
+    if (!function_exists('gzopen') && function_exists('gzopen64')) {
+        function gzopen($filename, $mode, $use_include_path = 0) { return gzopen64($filename, $mode, $use_include_path); }
+    }
+    if (!function_exists('gzseek') && function_exists('gzseek64')) {
+        function gzseek($zp, $offset, $whence = SEEK_SET) { return gzseek64($zp, $offset, $whence); }
+    }
+    if (!function_exists('gztell') && function_exists('gztell64')) {
+        function gztell($zp) { return gztell64($zp); }
     }
 }

--- a/src/Php70/bootstrap.php
+++ b/src/Php70/bootstrap.php
@@ -11,17 +11,20 @@
 
 use Symfony\Polyfill\Php70 as p;
 
-if (PHP_VERSION_ID < 70000) {
-    if (!defined('PHP_INT_MIN')) {
-        define('PHP_INT_MIN', ~PHP_INT_MAX);
-    }
-    if (!function_exists('intdiv')) {
-        function intdiv($dividend, $divisor) { return p\Php70::intdiv($dividend, $divisor); }
-    }
-    if (!function_exists('preg_replace_callback_array')) {
-        function preg_replace_callback_array(array $patterns, $subject, $limit = -1, &$count = 0) { return p\Php70::preg_replace_callback_array($patterns, $subject, $limit, $count); }
-    }
-    if (!function_exists('error_clear_last')) {
-        function error_clear_last() { return p\Php70::error_clear_last(); }
-    }
+if (PHP_VERSION_ID >= 70000) {
+    return;
+}
+
+if (!defined('PHP_INT_MIN')) {
+    define('PHP_INT_MIN', ~PHP_INT_MAX);
+}
+
+if (!function_exists('intdiv')) {
+    function intdiv($dividend, $divisor) { return p\Php70::intdiv($dividend, $divisor); }
+}
+if (!function_exists('preg_replace_callback_array')) {
+    function preg_replace_callback_array(array $patterns, $subject, $limit = -1, &$count = 0) { return p\Php70::preg_replace_callback_array($patterns, $subject, $limit, $count); }
+}
+if (!function_exists('error_clear_last')) {
+    function error_clear_last() { return p\Php70::error_clear_last(); }
 }

--- a/src/Php71/bootstrap.php
+++ b/src/Php71/bootstrap.php
@@ -11,8 +11,6 @@
 
 use Symfony\Polyfill\Php71 as p;
 
-if (PHP_VERSION_ID < 70100) {
-    if (!function_exists('is_iterable')) {
-        function is_iterable($var) { return p\Php71::is_iterable($var); }
-    }
+if (!function_exists('is_iterable')) {
+    function is_iterable($var) { return p\Php71::is_iterable($var); }
 }

--- a/src/Php72/bootstrap.php
+++ b/src/Php72/bootstrap.php
@@ -11,45 +11,47 @@
 
 use Symfony\Polyfill\Php72 as p;
 
-if (PHP_VERSION_ID < 70200) {
-    if (!defined('PHP_FLOAT_DIG')) {
-        define('PHP_FLOAT_DIG', 15);
-    }
-    if (!defined('PHP_FLOAT_EPSILON')) {
-        define('PHP_FLOAT_EPSILON', 2.2204460492503E-16);
-    }
-    if (!defined('PHP_FLOAT_MIN')) {
-        define('PHP_FLOAT_MIN', 2.2250738585072E-308);
-    }
-    if (!defined('PHP_FLOAT_MAX')) {
-        define('PHP_FLOAT_MAX', 1.7976931348623157E+308);
-    }
-    if (!defined('PHP_OS_FAMILY')) {
-        define('PHP_OS_FAMILY', p\Php72::php_os_family());
-    }
+if (PHP_VERSION_ID >= 70200) {
+    return;
+}
 
-    if ('\\' === DIRECTORY_SEPARATOR && !function_exists('sapi_windows_vt100_support')) {
-        function sapi_windows_vt100_support($stream, $enable = null) { return p\Php72::sapi_windows_vt100_support($stream, $enable); }
-    }
-    if (!function_exists('stream_isatty')) {
-        function stream_isatty($stream) { return p\Php72::stream_isatty($stream); }
-    }
-    if (!function_exists('utf8_encode')) {
-        function utf8_encode($s) { return p\Php72::utf8_encode($s); }
-    }
-    if (!function_exists('utf8_decode')) {
-        function utf8_decode($s) { return p\Php72::utf8_decode($s); }
-    }
-    if (!function_exists('spl_object_id')) {
-        function spl_object_id($s) { return p\Php72::spl_object_id($s); }
-    }
-    if (!function_exists('mb_ord')) {
-        function mb_ord($s, $enc = null) { return p\Php72::mb_ord($s, $enc); }
-    }
-    if (!function_exists('mb_chr')) {
-        function mb_chr($code, $enc = null) { return p\Php72::mb_chr($code, $enc); }
-    }
-    if (!function_exists('mb_scrub')) {
-        function mb_scrub($s, $enc = null) { $enc = null === $enc ? mb_internal_encoding() : $enc; return mb_convert_encoding($s, $enc, $enc); }
-    }
+if (!defined('PHP_FLOAT_DIG')) {
+    define('PHP_FLOAT_DIG', 15);
+}
+if (!defined('PHP_FLOAT_EPSILON')) {
+    define('PHP_FLOAT_EPSILON', 2.2204460492503E-16);
+}
+if (!defined('PHP_FLOAT_MIN')) {
+    define('PHP_FLOAT_MIN', 2.2250738585072E-308);
+}
+if (!defined('PHP_FLOAT_MAX')) {
+    define('PHP_FLOAT_MAX', 1.7976931348623157E+308);
+}
+if (!defined('PHP_OS_FAMILY')) {
+    define('PHP_OS_FAMILY', p\Php72::php_os_family());
+}
+
+if ('\\' === DIRECTORY_SEPARATOR && !function_exists('sapi_windows_vt100_support')) {
+    function sapi_windows_vt100_support($stream, $enable = null) { return p\Php72::sapi_windows_vt100_support($stream, $enable); }
+}
+if (!function_exists('stream_isatty')) {
+    function stream_isatty($stream) { return p\Php72::stream_isatty($stream); }
+}
+if (!function_exists('utf8_encode')) {
+    function utf8_encode($s) { return p\Php72::utf8_encode($s); }
+}
+if (!function_exists('utf8_decode')) {
+    function utf8_decode($s) { return p\Php72::utf8_decode($s); }
+}
+if (!function_exists('spl_object_id')) {
+    function spl_object_id($s) { return p\Php72::spl_object_id($s); }
+}
+if (!function_exists('mb_ord')) {
+    function mb_ord($s, $enc = null) { return p\Php72::mb_ord($s, $enc); }
+}
+if (!function_exists('mb_chr')) {
+    function mb_chr($code, $enc = null) { return p\Php72::mb_chr($code, $enc); }
+}
+if (!function_exists('mb_scrub')) {
+    function mb_scrub($s, $enc = null) { $enc = null === $enc ? mb_internal_encoding() : $enc; return mb_convert_encoding($s, $enc, $enc); }
 }

--- a/src/Php73/bootstrap.php
+++ b/src/Php73/bootstrap.php
@@ -11,22 +11,21 @@
 
 use Symfony\Polyfill\Php73 as p;
 
-if (PHP_VERSION_ID < 70300) {
-    if (!function_exists('is_countable')) {
-        function is_countable($var) { return is_array($var) || $var instanceof Countable || $var instanceof ResourceBundle || $var instanceof SimpleXmlElement; }
-    }
+if (PHP_VERSION_ID >= 70300) {
+    return;
+}
 
-    if (!function_exists('hrtime')) {
-        require_once __DIR__.'/Php73.php';
-        p\Php73::$startAt = (int) microtime(true);
-        function hrtime($asNum = false) { return p\Php73::hrtime($asNum); }
-    }
-
-    if (!function_exists('array_key_first')) {
-        function array_key_first(array $array) { foreach ($array as $key => $value) { return $key; } }
-    }
-
-    if (!function_exists('array_key_last')) {
-        function array_key_last(array $array) { end($array); return key($array); }
-    }
+if (!function_exists('is_countable')) {
+    function is_countable($var) { return is_array($var) || $var instanceof Countable || $var instanceof ResourceBundle || $var instanceof SimpleXmlElement; }
+}
+if (!function_exists('hrtime')) {
+    require_once __DIR__.'/Php73.php';
+    p\Php73::$startAt = (int) microtime(true);
+    function hrtime($asNum = false) { return p\Php73::hrtime($asNum); }
+}
+if (!function_exists('array_key_first')) {
+    function array_key_first(array $array) { foreach ($array as $key => $value) { return $key; } }
+}
+if (!function_exists('array_key_last')) {
+    function array_key_last(array $array) { end($array); return key($array); }
 }

--- a/src/Php74/bootstrap.php
+++ b/src/Php74/bootstrap.php
@@ -11,16 +11,16 @@
 
 use Symfony\Polyfill\Php74 as p;
 
-if (PHP_VERSION_ID < 70400) {
-    if (!function_exists('get_mangled_object_vars')) {
-        function get_mangled_object_vars($obj) { return p\Php74::get_mangled_object_vars($obj); }
-    }
+if (PHP_VERSION_ID >= 70400) {
+    return;
+}
 
-    if (!function_exists('mb_str_split') && function_exists('mb_substr')) {
-        function mb_str_split($string, $split_length = 1, $encoding = null) { return p\Php74::mb_str_split($string, $split_length, $encoding); }
-    }
-
-    if (!function_exists('password_algos')) {
-        function password_algos() { return p\Php74::password_algos(); }
-    }
+if (!function_exists('get_mangled_object_vars')) {
+    function get_mangled_object_vars($obj) { return p\Php74::get_mangled_object_vars($obj); }
+}
+if (!function_exists('mb_str_split') && function_exists('mb_substr')) {
+    function mb_str_split($string, $split_length = 1, $encoding = null) { return p\Php74::mb_str_split($string, $split_length, $encoding); }
+}
+if (!function_exists('password_algos')) {
+    function password_algos() { return p\Php74::password_algos(); }
 }

--- a/src/Php80/bootstrap.php
+++ b/src/Php80/bootstrap.php
@@ -11,29 +11,32 @@
 
 use Symfony\Polyfill\Php80 as p;
 
-if (PHP_VERSION_ID < 80000) {
-    if (!function_exists('fdiv')) {
-        function fdiv(float $dividend, float $divisor): float { return p\Php80::fdiv($dividend, $divisor); }
-    }
-    if (!function_exists('preg_last_error_msg')) {
-        function preg_last_error_msg(): string { return p\Php80::preg_last_error_msg(); }
-    }
-    if (!function_exists('str_contains')) {
-        function str_contains(string $haystack, string $needle): bool { return p\Php80::str_contains($haystack, $needle); }
-    }
-    if (!function_exists('str_starts_with')) {
-        function str_starts_with(string $haystack, string $needle): bool { return p\Php80::str_starts_with($haystack, $needle); }
-    }
-    if (!function_exists('str_ends_with')) {
-        function str_ends_with(string $haystack, string $needle): bool { return p\Php80::str_ends_with($haystack, $needle); }
-    }
-    if (!defined('FILTER_VALIDATE_BOOL') && defined('FILTER_VALIDATE_BOOLEAN')) {
-        define('FILTER_VALIDATE_BOOL', FILTER_VALIDATE_BOOLEAN);
-    }
-    if (!function_exists('get_debug_type')) {
-        function get_debug_type($value): string { return p\Php80::get_debug_type($value); }
-    }
-    if (!function_exists('get_resource_id')) {
-        function get_resource_id($res): int { return p\Php80::get_resource_id($res); }
-    }
+if (PHP_VERSION_ID >= 80000) {
+    return;
+}
+
+if (!defined('FILTER_VALIDATE_BOOL') && defined('FILTER_VALIDATE_BOOLEAN')) {
+    define('FILTER_VALIDATE_BOOL', FILTER_VALIDATE_BOOLEAN);
+}
+
+if (!function_exists('fdiv')) {
+    function fdiv(float $dividend, float $divisor): float { return p\Php80::fdiv($dividend, $divisor); }
+}
+if (!function_exists('preg_last_error_msg')) {
+    function preg_last_error_msg(): string { return p\Php80::preg_last_error_msg(); }
+}
+if (!function_exists('str_contains')) {
+    function str_contains(string $haystack, string $needle): bool { return p\Php80::str_contains($haystack, $needle); }
+}
+if (!function_exists('str_starts_with')) {
+    function str_starts_with(string $haystack, string $needle): bool { return p\Php80::str_starts_with($haystack, $needle); }
+}
+if (!function_exists('str_ends_with')) {
+    function str_ends_with(string $haystack, string $needle): bool { return p\Php80::str_ends_with($haystack, $needle); }
+}
+if (!function_exists('get_debug_type')) {
+    function get_debug_type($value): string { return p\Php80::get_debug_type($value); }
+}
+if (!function_exists('get_resource_id')) {
+    function get_resource_id($res): int { return p\Php80::get_resource_id($res); }
 }

--- a/src/Uuid/bootstrap.php
+++ b/src/Uuid/bootstrap.php
@@ -11,6 +11,10 @@
 
 use Symfony\Polyfill\Uuid as p;
 
+if (extension_loaded('uuid')) {
+    return;
+}
+
 if (!defined('UUID_VARIANT_NCS')) {
     define('UUID_VARIANT_NCS', 0);
 }


### PR DESCRIPTION
Fix #262
Best to [ignore whitespace](https://github.com/symfony/polyfill/pull/263/files?w=1) when reviewing.