### PR TITLE
Align `APCuIterator` case with its implementation

### DIFF
--- a/src/Apcu/README.md
+++ b/src/Apcu/README.md
@@ -1,7 +1,7 @@
 Symfony Polyfill / APCu
 ========================
 
-This component provides `apcu_*` functions and the `APCUIterator` class to users of the legacy APC extension.
+This component provides `apcu_*` functions and the `APCuIterator` class to users of the legacy APC extension.
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).

--- a/src/Apcu/bootstrap.php
+++ b/src/Apcu/bootstrap.php
@@ -68,8 +68,8 @@ if (!function_exists('apcu_sma_info')) {
     function apcu_sma_info($limited = false) { return apc_sma_info($limited); }
 }
 
-if (!class_exists('APCUIterator', false) && class_exists('APCIterator', false)) {
-    class APCUIterator extends APCIterator
+if (!class_exists('APCuIterator', false) && class_exists('APCIterator', false)) {
+    class APCuIterator extends APCIterator
     {
         public function __construct($search = null, $format = APC_ITER_ALL, $chunk_size = 100, $list = APC_LIST_ACTIVE)
         {

--- a/tests/Apcu/ApcuTest.php
+++ b/tests/Apcu/ApcuTest.php
@@ -65,12 +65,12 @@ class ApcuTest extends TestCase
         $this->assertSame(array(), apcu_exists(array_keys($data)));
     }
 
-    public function testAPCUIterator()
+    public function testAPCuIterator()
     {
         $key = __CLASS__;
         $this->assertTrue(apcu_store($key, 456));
 
-        $entries = iterator_to_array(new \APCUIterator('/^'.preg_quote($key, '/').'$/', APC_ITER_KEY | APC_ITER_VALUE));
+        $entries = iterator_to_array(new \APCuIterator('/^'.preg_quote($key, '/').'$/', APC_ITER_KEY | APC_ITER_VALUE));
 
         $this->assertSame(array($key), array_keys($entries));
         $this->assertSame($key, $entries[$key]['key']);


### PR DESCRIPTION
This is the correct case defined in the source code: https://github.com/krakjoe/apcu/blob/1f98e34d93/apc_iterator.h#L29

This is an attempt to fix errors that a project started to report on PHPStan `v0.12.26`:

```
 ------ ------------------------------------------------------------------
  Line   src/State/StateStorage.php
 ------ ------------------------------------------------------------------
  6      Class APCUIterator referenced with incorrect case: APCuIterator.
  109    Class APCUIterator referenced with incorrect case: APCuIterator.
 ------ ------------------------------------------------------------------
```