### PR TITLE
Add `UnhandledMatchError` exception class

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Polyfills are provided for:
 - the `str_contains` function introduced in PHP 8.0;
 - the `str_starts_with` and `str_ends_with` functions introduced in PHP 8.0;
 - the `ValueError` class introduced in PHP 8.0;
+- the `UnhandledMatchError` class introduced in PHP 8.0;
 - the `FILTER_VALIDATE_BOOL` constant introduced in PHP 8.0;
 - the `get_resource_id` function introduced in PHP 8.0;
 

--- a/src/Php80/README.md
+++ b/src/Php80/README.md
@@ -6,6 +6,7 @@ This component provides features added to PHP 8.0 core:
 - `Stringable` interface
 - [`fdiv`](https://php.net/fdiv)
 - `ValueError` class
+- `UnhandledMatchError` class
 - `FILTER_VALIDATE_BOOL` constant
 - [`get_debug_type`](https://php.net/get_debug_type)
 - [`preg_last_error_msg`](https://php.net/preg_last_error_msg)

--- a/src/Php80/Resources/stubs/UnhandledMatchError.php
+++ b/src/Php80/Resources/stubs/UnhandledMatchError.php
@@ -1,0 +1,5 @@
+<?php
+
+class UnhandledMatchError extends Error
+{
+}


### PR DESCRIPTION
Along with the `match` expression syntax in PHP 8, it [registers](https://github.com/php/php-src/blob/c2d3cd2595481af4b2edd7cf26fb148de2d475aa/Zend/zend_exceptions.c#L819-L820) a new exception class `UnhandledMatchError` that extends `\Error`.

While the `match` expression itself cannot be polyfilled, we can backport this new class for the feature parity, so exceptions can be unserialized, or exceptions can be thrown in other code if they choose to throw `\UnhandledMatchError` exceptions.

 - [RFC](https://wiki.php.net/rfc/match_expression_v2)
 - [Implementation](https://github.com/php/php-src/blob/c2d3cd2595481af4b2edd7cf26fb148de2d475aa/Zend/zend_exceptions.c#L819-L820)
 - [`match` expressions # `UnhandledMatchError`](https://php.watch/versions/8.0/match-expression#UnhandledMatchError)
 - PR for `ValueError` (#219)