### PR TITLE
Only define classes if they don't exist

### DIFF
--- a/src/Intl/MessageFormatter/Resources/stubs/IntlException.php
+++ b/src/Intl/MessageFormatter/Resources/stubs/IntlException.php
@@ -1,5 +1,7 @@
 <?php
 
-class IntlException extends Exception
-{
+if (!class_exists('IntlException')) {
+    class IntlException extends Exception
+    {
+    }
 }

--- a/src/Intl/MessageFormatter/Resources/stubs/MessageFormatter.php
+++ b/src/Intl/MessageFormatter/Resources/stubs/MessageFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
-class MessageFormatter extends Symfony\Polyfill\Intl\MessageFormatter\MessageFormatter
-{
+if (!class_exists('MessageFormatter')) {
+    class MessageFormatter extends Symfony\Polyfill\Intl\MessageFormatter\MessageFormatter
+    {
+    }
 }

--- a/src/Intl/Normalizer/Resources/stubs/Normalizer.php
+++ b/src/Intl/Normalizer/Resources/stubs/Normalizer.php
@@ -1,17 +1,19 @@
 <?php
 
-class Normalizer extends Symfony\Polyfill\Intl\Normalizer\Normalizer
-{
-    /**
-     * @deprecated since ICU 56 and removed in PHP 8
-     */
-    const NONE = 1;
-    const FORM_D = 2;
-    const FORM_KD = 3;
-    const FORM_C = 4;
-    const FORM_KC = 5;
-    const NFD = 2;
-    const NFKD = 3;
-    const NFC = 4;
-    const NFKC = 5;
+if (!class_exists('Normalizer')) {
+    class Normalizer extends Symfony\Polyfill\Intl\Normalizer\Normalizer
+    {
+        /**
+         * @deprecated since ICU 56 and removed in PHP 8
+         */
+        const NONE = 1;
+        const FORM_D = 2;
+        const FORM_KD = 3;
+        const FORM_C = 4;
+        const FORM_KC = 5;
+        const NFD = 2;
+        const NFKD = 3;
+        const NFC = 4;
+        const NFKC = 5;
+    }
 }

--- a/src/Php54/Resources/stubs/CallbackFilterIterator.php
+++ b/src/Php54/Resources/stubs/CallbackFilterIterator.php
@@ -9,20 +9,22 @@
  * file that was distributed with this source code.
  */
 
-class CallbackFilterIterator extends FilterIterator
-{
-    private $iterator;
-    private $callback;
-
-    public function __construct(Iterator $iterator, $callback)
+if (!class_exists('CallbackFilterIterator')) {
+    class CallbackFilterIterator extends FilterIterator
     {
-        $this->iterator = $iterator;
-        $this->callback = $callback;
-        parent::__construct($iterator);
-    }
+        private $iterator;
+        private $callback;
 
-    public function accept()
-    {
-        return call_user_func($this->callback, $this->current(), $this->key(), $this->iterator);
+        public function __construct(Iterator $iterator, $callback)
+        {
+            $this->iterator = $iterator;
+            $this->callback = $callback;
+            parent::__construct($iterator);
+        }
+
+        public function accept()
+        {
+            return call_user_func($this->callback, $this->current(), $this->key(), $this->iterator);
+        }
     }
 }

--- a/src/Php54/Resources/stubs/RecursiveCallbackFilterIterator.php
+++ b/src/Php54/Resources/stubs/RecursiveCallbackFilterIterator.php
@@ -9,25 +9,27 @@
  * file that was distributed with this source code.
  */
 
-class RecursiveCallbackFilterIterator extends CallbackFilterIterator implements RecursiveIterator
-{
-    private $iterator;
-    private $callback;
-
-    public function __construct(RecursiveIterator $iterator, $callback)
+if (!class_exists('RecursiveCallbackFilterIterator')) {
+    class RecursiveCallbackFilterIterator extends CallbackFilterIterator implements RecursiveIterator
     {
-        $this->iterator = $iterator;
-        $this->callback = $callback;
-        parent::__construct($iterator, $callback);
-    }
+        private $iterator;
+        private $callback;
 
-    public function hasChildren()
-    {
-        return $this->iterator->hasChildren();
-    }
+        public function __construct(RecursiveIterator $iterator, $callback)
+        {
+            $this->iterator = $iterator;
+            $this->callback = $callback;
+            parent::__construct($iterator, $callback);
+        }
 
-    public function getChildren()
-    {
-        return new static($this->iterator->getChildren(), $this->callback);
+        public function hasChildren()
+        {
+            return $this->iterator->hasChildren();
+        }
+
+        public function getChildren()
+        {
+            return new static($this->iterator->getChildren(), $this->callback);
+        }
     }
 }

--- a/src/Php54/Resources/stubs/SessionHandlerInterface.php
+++ b/src/Php54/Resources/stubs/SessionHandlerInterface.php
@@ -29,74 +29,76 @@
  * @author Drak <drak@zikula.org>
  * @author Tobias Schultze <http://tobion.de>
  */
-interface SessionHandlerInterface
-{
-    /**
-     * Re-initializes existing session, or creates a new one.
-     *
-     * @see https://php.net/sessionhandlerinterface.open
-     *
-     * @param string $savePath    Save path
-     * @param string $sessionName Session name, see https://php.net/function.session-name.php
-     *
-     * @return bool true on success, false on failure
-     */
-    public function open($savePath, $sessionName);
+if (!interface_exists('SessionHandlerInterface')) {
+    interface SessionHandlerInterface
+    {
+        /**
+         * Re-initializes existing session, or creates a new one.
+         *
+         * @see https://php.net/sessionhandlerinterface.open
+         *
+         * @param string $savePath    Save path
+         * @param string $sessionName Session name, see https://php.net/function.session-name.php
+         *
+         * @return bool true on success, false on failure
+         */
+        public function open($savePath, $sessionName);
 
-    /**
-     * Closes the current session.
-     *
-     * @see https://php.net/sessionhandlerinterface.close
-     *
-     * @return bool true on success, false on failure
-     */
-    public function close();
+        /**
+         * Closes the current session.
+         *
+         * @see https://php.net/sessionhandlerinterface.close
+         *
+         * @return bool true on success, false on failure
+         */
+        public function close();
 
-    /**
-     * Reads the session data.
-     *
-     * @see https://php.net/sessionhandlerinterface.read
-     *
-     * @param string $sessionId Session ID, see https://php.net/function.session-id
-     *
-     * @return string Same session data as passed in write() or empty string when non-existent or on failure
-     */
-    public function read($sessionId);
+        /**
+         * Reads the session data.
+         *
+         * @see https://php.net/sessionhandlerinterface.read
+         *
+         * @param string $sessionId Session ID, see https://php.net/function.session-id
+         *
+         * @return string Same session data as passed in write() or empty string when non-existent or on failure
+         */
+        public function read($sessionId);
 
-    /**
-     * Writes the session data to the storage.
-     *
-     * Care, the session ID passed to write() can be different from the one previously
-     * received in read() when the session ID changed due to session_regenerate_id().
-     *
-     * @see https://php.net/sessionhandlerinterface.write
-     *
-     * @param string $sessionId Session ID , see https://php.net/function.session-id
-     * @param string $data      Serialized session data to save
-     *
-     * @return bool true on success, false on failure
-     */
-    public function write($sessionId, $data);
+        /**
+         * Writes the session data to the storage.
+         *
+         * Care, the session ID passed to write() can be different from the one previously
+         * received in read() when the session ID changed due to session_regenerate_id().
+         *
+         * @see https://php.net/sessionhandlerinterface.write
+         *
+         * @param string $sessionId Session ID , see https://php.net/function.session-id
+         * @param string $data      Serialized session data to save
+         *
+         * @return bool true on success, false on failure
+         */
+        public function write($sessionId, $data);
 
-    /**
-     * Destroys a session.
-     *
-     * @see https://php.net/sessionhandlerinterface.destroy
-     *
-     * @param string $sessionId Session ID, see https://php.net/function.session-id
-     *
-     * @return bool true on success, false on failure
-     */
-    public function destroy($sessionId);
+        /**
+         * Destroys a session.
+         *
+         * @see https://php.net/sessionhandlerinterface.destroy
+         *
+         * @param string $sessionId Session ID, see https://php.net/function.session-id
+         *
+         * @return bool true on success, false on failure
+         */
+        public function destroy($sessionId);
 
-    /**
-     * Cleans up expired sessions (garbage collection).
-     *
-     * @see https://php.net/sessionhandlerinterface.gc
-     *
-     * @param string|int $maxlifetime Sessions that have not updated for the last maxlifetime seconds will be removed
-     *
-     * @return bool true on success, false on failure
-     */
-    public function gc($maxlifetime);
+        /**
+         * Cleans up expired sessions (garbage collection).
+         *
+         * @see https://php.net/sessionhandlerinterface.gc
+         *
+         * @param string|int $maxlifetime Sessions that have not updated for the last maxlifetime seconds will be removed
+         *
+         * @return bool true on success, false on failure
+         */
+        public function gc($maxlifetime);
+    }
 }

--- a/src/Php70/Resources/stubs/ArithmeticError.php
+++ b/src/Php70/Resources/stubs/ArithmeticError.php
@@ -1,5 +1,7 @@
 <?php
 
-class ArithmeticError extends Error
-{
+if (!class_exists('ArithmeticError')) {
+    class ArithmeticError extends Error
+    {
+    }
 }

--- a/src/Php70/Resources/stubs/AssertionError.php
+++ b/src/Php70/Resources/stubs/AssertionError.php
@@ -1,5 +1,7 @@
 <?php
 
-class AssertionError extends Error
-{
+if (!class_exists('AssertionError')) {
+    class AssertionError extends Error
+    {
+    }
 }

--- a/src/Php70/Resources/stubs/DivisionByZeroError.php
+++ b/src/Php70/Resources/stubs/DivisionByZeroError.php
@@ -1,5 +1,7 @@
 <?php
 
-class DivisionByZeroError extends Error
-{
+if (!class_exists('DivisionByZeroError')) {
+    class DivisionByZeroError extends Error
+    {
+    }
 }

--- a/src/Php70/Resources/stubs/Error.php
+++ b/src/Php70/Resources/stubs/Error.php
@@ -1,5 +1,7 @@
 <?php
 
-class Error extends Exception
-{
+if (!class_exists('Error')) {
+    class Error extends Exception
+    {
+    }
 }

--- a/src/Php70/Resources/stubs/ParseError.php
+++ b/src/Php70/Resources/stubs/ParseError.php
@@ -1,5 +1,7 @@
 <?php
 
-class ParseError extends Error
-{
+if (!class_exists('ParseError')) {
+    class ParseError extends Error
+    {
+    }
 }

--- a/src/Php70/Resources/stubs/SessionUpdateTimestampHandlerInterface.php
+++ b/src/Php70/Resources/stubs/SessionUpdateTimestampHandlerInterface.php
@@ -1,23 +1,25 @@
 <?php
 
-interface SessionUpdateTimestampHandlerInterface
-{
-    /**
-     * Checks if a session identifier already exists or not.
-     *
-     * @param string $key
-     *
-     * @return bool
-     */
-    public function validateId($key);
+if (!interface_exists('SessionUpdateTimestampHandlerInterface')) {
+    interface SessionUpdateTimestampHandlerInterface
+    {
+        /**
+         * Checks if a session identifier already exists or not.
+         *
+         * @param string $key
+         *
+         * @return bool
+         */
+        public function validateId($key);
 
-    /**
-     * Updates the timestamp of a session when its data didn't change.
-     *
-     * @param string $key
-     * @param string $val
-     *
-     * @return bool
-     */
-    public function updateTimestamp($key, $val);
+        /**
+         * Updates the timestamp of a session when its data didn't change.
+         *
+         * @param string $key
+         * @param string $val
+         *
+         * @return bool
+         */
+        public function updateTimestamp($key, $val);
+    }
 }

--- a/src/Php70/Resources/stubs/TypeError.php
+++ b/src/Php70/Resources/stubs/TypeError.php
@@ -1,5 +1,7 @@
 <?php
 
-class TypeError extends Error
-{
+if (!class_exists('TypeError')) {
+    class TypeError extends Error
+    {
+    }
 }

--- a/src/Php73/Resources/stubs/JsonException.php
+++ b/src/Php73/Resources/stubs/JsonException.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
-class JsonException extends Exception
-{
+if (!class_exists('JsonException')) {
+    class JsonException extends Exception
+    {
+    }
 }

--- a/src/Php80/Resources/stubs/Stringable.php
+++ b/src/Php80/Resources/stubs/Stringable.php
@@ -1,9 +1,11 @@
 <?php
 
-interface Stringable
-{
-    /**
-     * @return string
-     */
-    public function __toString();
+if (!interface_exists('Stringable')) {
+    interface Stringable
+    {
+        /**
+         * @return string
+         */
+        public function __toString();
+    }
 }

--- a/src/Php80/Resources/stubs/UnhandledMatchError.php
+++ b/src/Php80/Resources/stubs/UnhandledMatchError.php
@@ -1,5 +1,7 @@
 <?php
 
-class UnhandledMatchError extends Error
-{
+if (!class_exists('UnhandledMatchError')) {
+    class UnhandledMatchError extends Error
+    {
+    }
 }

--- a/src/Php80/Resources/stubs/ValueError.php
+++ b/src/Php80/Resources/stubs/ValueError.php
@@ -1,5 +1,7 @@
 <?php
 
-class ValueError extends Error
-{
+if (!class_exists('ValueError')) {
+    class ValueError extends Error
+    {
+    }
 }


### PR DESCRIPTION
I noticed specifically with `Normalizer` that I get an error saying:

> Compile Error: Cannot declare class Normalizer, because the name is already in use

This occurred with the `intl` extension installed and trying to use the class without importing it with `use`.