### PR TITLE
Handle null being passed to PHP80 str_* methods

### DIFF
--- a/src/Php80/Php80.php
+++ b/src/Php80/Php80.php
@@ -88,17 +88,22 @@ final class Php80
         }
     }
 
-    public static function str_contains(string $haystack, string $needle): bool
+    public static function str_contains(string $haystack = null, string $needle = null): bool
     {
+        // Cast to string to avoid deprecation notices
+        if (null === $needle) {
+            $needle = '';
+        }
+
         return '' === $needle || false !== strpos($haystack, $needle);
     }
 
-    public static function str_starts_with(string $haystack, string $needle): bool
+    public static function str_starts_with(string $haystack = null, string $needle = null): bool
     {
         return 0 === \strncmp($haystack, $needle, \strlen($needle));
     }
 
-    public static function str_ends_with(string $haystack, string $needle): bool
+    public static function str_ends_with(string $haystack = null, string $needle = null): bool
     {
         return '' === $needle || ('' !== $haystack && 0 === \substr_compare($haystack, $needle, -\strlen($needle)));
     }

--- a/src/Php80/Php80.php
+++ b/src/Php80/Php80.php
@@ -91,9 +91,7 @@ final class Php80
     public static function str_contains(string $haystack = null, string $needle = null): bool
     {
         // Cast to string to avoid deprecation notices
-        if (null === $needle) {
-            $needle = '';
-        }
+        $needle = (string)$needle;
 
         return '' === $needle || false !== strpos($haystack, $needle);
     }

--- a/src/Php80/Php80.php
+++ b/src/Php80/Php80.php
@@ -103,6 +103,10 @@ final class Php80
 
     public static function str_ends_with(string $haystack = null, string $needle = null): bool
     {
+        // Cast both to string
+        $needle = (string)$needle;
+        $haystack = (string)$haystack;
+
         return '' === $needle || ('' !== $haystack && 0 === \substr_compare($haystack, $needle, -\strlen($needle)));
     }
 }

--- a/src/Php80/bootstrap.php
+++ b/src/Php80/bootstrap.php
@@ -26,13 +26,13 @@ if (!function_exists('preg_last_error_msg')) {
     function preg_last_error_msg(): string { return p\Php80::preg_last_error_msg(); }
 }
 if (!function_exists('str_contains')) {
-    function str_contains(string $haystack, string $needle): bool { return p\Php80::str_contains($haystack, $needle); }
+    function str_contains(string $haystack = null, string $needle = null): bool { return p\Php80::str_contains($haystack, $needle); }
 }
 if (!function_exists('str_starts_with')) {
-    function str_starts_with(string $haystack, string $needle): bool { return p\Php80::str_starts_with($haystack, $needle); }
+    function str_starts_with(string $haystack = null, string $needle = null): bool { return p\Php80::str_starts_with($haystack, $needle); }
 }
 if (!function_exists('str_ends_with')) {
-    function str_ends_with(string $haystack, string $needle): bool { return p\Php80::str_ends_with($haystack, $needle); }
+    function str_ends_with(string $haystack = null, string $needle = null): bool { return p\Php80::str_ends_with($haystack, $needle); }
 }
 if (!function_exists('get_debug_type')) {
     function get_debug_type($value): string { return p\Php80::get_debug_type($value); }

--- a/tests/Php80/Php80Test.php
+++ b/tests/Php80/Php80Test.php
@@ -103,6 +103,10 @@ class Php80Test extends TestCase
         $this->assertFalse(str_contains('abc', 'abcd'));
         $this->assertFalse(str_contains('DÉJÀ', 'à'));
         $this->assertFalse(str_contains('a', 'à'));
+        $this->assertTrue(str_contains(null, ''));
+        $this->assertTrue(str_contains('', null));
+        $this->assertFalse(str_contains(null, 'a'));
+        $this->assertTrue(str_contains('a', null));
     }
 
     /**
@@ -142,6 +146,11 @@ class Php80Test extends TestCase
         $testEmoji = '🙌🎉✨🚀'; // 0xf0 0x9f 0x99 0x8c 0xf0 0x9f 0x8e 0x89 0xe2 0x9c 0xa8 0xf0 0x9f 0x9a 0x80
         $this->assertTrue(str_starts_with($testEmoji, "🙌")); // 0xf0 0x9f 0x99 0x8c
         $this->assertFalse(str_starts_with($testEmoji, "✨")); // 0xe2 0x9c 0xa8
+
+        $this->assertTrue(str_starts_with(null, ''));
+        $this->assertTrue(str_starts_with('', null));
+        $this->assertFalse(str_starts_with(null, 'test'));
+        $this->assertTrue(str_starts_with('test', null));
     }
 
     /**
@@ -177,6 +186,11 @@ class Php80Test extends TestCase
         $testEmoji = '🙌🎉✨🚀'; // 0xf0 0x9f 0x99 0x8c 0xf0 0x9f 0x8e 0x89 0xe2 0x9c 0xa8 0xf0 0x9f 0x9a 0x80
         $this->assertTrue(str_ends_with($testEmoji, "🚀")); // 0xf0 0x9f 0x9a 0x80
         $this->assertFalse(str_ends_with($testEmoji, "✨")); // 0xe2 0x9c 0xa8
+
+        $this->assertTrue(str_starts_with(null, ''));
+        $this->assertTrue(str_starts_with('', null));
+        $this->assertFalse(str_starts_with(null, 'test'));
+        $this->assertTrue(str_starts_with('test', null));
     }
 
     /**

--- a/tests/Php80/Php80Test.php
+++ b/tests/Php80/Php80Test.php
@@ -103,10 +103,20 @@ class Php80Test extends TestCase
         $this->assertFalse(str_contains('abc', 'abcd'));
         $this->assertFalse(str_contains('DÉJÀ', 'à'));
         $this->assertFalse(str_contains('a', 'à'));
+
         $this->assertTrue(str_contains(null, ''));
         $this->assertTrue(str_contains('', null));
         $this->assertFalse(str_contains(null, 'a'));
         $this->assertTrue(str_contains('a', null));
+
+        $this->assertTrue(str_contains(true, '1'));
+        $this->assertTrue(str_contains('1', true));
+        $this->assertFalse(str_contains(false, '0'));
+        $this->assertTrue(str_contains('0', false));
+        $this->assertTrue(str_contains(123, '2'));
+        $this->assertTrue(str_contains('123456', 123));
+        $this->assertTrue(str_contains(1.23, '2'));
+        $this->assertTrue(str_contains('1.2345', 1.23));
     }
 
     /**
@@ -151,6 +161,15 @@ class Php80Test extends TestCase
         $this->assertTrue(str_starts_with('', null));
         $this->assertFalse(str_starts_with(null, 'test'));
         $this->assertTrue(str_starts_with('test', null));
+
+        $this->assertTrue(str_starts_with(true, '1'));
+        $this->assertTrue(str_starts_with('1', true));
+        $this->assertFalse(str_starts_with(false, '0'));
+        $this->assertTrue(str_starts_with('0', false));
+        $this->assertTrue(str_starts_with(123, '1'));
+        $this->assertTrue(str_starts_with('123456', 123));
+        $this->assertTrue(str_starts_with(1.23, '1'));
+        $this->assertTrue(str_starts_with('1.2345', 1.23));
     }
 
     /**
@@ -187,10 +206,59 @@ class Php80Test extends TestCase
         $this->assertTrue(str_ends_with($testEmoji, "🚀")); // 0xf0 0x9f 0x9a 0x80
         $this->assertFalse(str_ends_with($testEmoji, "✨")); // 0xe2 0x9c 0xa8
 
-        $this->assertTrue(str_starts_with(null, ''));
-        $this->assertTrue(str_starts_with('', null));
-        $this->assertFalse(str_starts_with(null, 'test'));
-        $this->assertTrue(str_starts_with('test', null));
+        $this->assertTrue(str_ends_with(null, ''));
+        $this->assertFalse(str_ends_with('', null));
+        $this->assertFalse(str_ends_with(null, 'test'));
+        $this->assertFalse(str_ends_with('test', null));
+
+        $this->assertTrue(str_ends_with(true, '1'));
+        $this->assertTrue(str_ends_with('1', true));
+        $this->assertFalse(str_ends_with(false, '0'));
+        $this->assertTrue(str_ends_with('0', false));
+        $this->assertTrue(str_ends_with(123, '3'));
+        $this->assertTrue(str_ends_with('123456', 456));
+        $this->assertTrue(str_ends_with(1.23, '3'));
+        $this->assertFalse(str_ends_with('1.2345', 1.23));
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php80\Php80::str_contains
+     * @dataProvider provideStrMethodTypeErrors
+     */
+    public function testStrContainsTypeErrors($firstArg, $secondArg)
+    {
+        $this->setExpectedException('TypeError');
+        str_contains($firstArg, $secondArg);
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php80\Php80::str_starts_with
+     * @dataProvider provideStrMethodTypeErrors
+     */
+    public function testStrStartsWithTypeErrors($firstArg, $secondArg)
+    {
+        $this->setExpectedException('TypeError');
+        str_starts_with($firstArg, $secondArg);
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php80\Php80::str_ends_with
+     * @dataProvider provideStrMethodTypeErrors
+     */
+    public function testStrEndsWithTypeErrors($firstArg, $secondArg)
+    {
+        $this->setExpectedException('TypeError');
+        str_ends_with($firstArg, $secondArg);
+    }
+
+    public function provideStrMethodTypeErrors()
+    {
+        return array(
+            array(array(), 'test'),
+            array('test', array()),
+            array(new \stdClass(), 'test'),
+            array('test', new \stdClass()),
+        );
     }
 
     /**

--- a/tests/Php80/Php80Test.php
+++ b/tests/Php80/Php80Test.php
@@ -207,9 +207,9 @@ class Php80Test extends TestCase
         $this->assertFalse(str_ends_with($testEmoji, "✨")); // 0xe2 0x9c 0xa8
 
         $this->assertTrue(str_ends_with(null, ''));
-        $this->assertFalse(str_ends_with('', null));
+        $this->assertTrue(str_ends_with('', null));
         $this->assertFalse(str_ends_with(null, 'test'));
-        $this->assertFalse(str_ends_with('test', null));
+        $this->assertTrue(str_ends_with('test', null));
 
         $this->assertTrue(str_ends_with(true, '1'));
         $this->assertTrue(str_ends_with('1', true));


### PR DESCRIPTION
The previous version of the polyfills didn't accept null as a value as
either the haystack or the needle because of the string typehint. In
PHP8, these are silently cast to an empty string.

This matches that behaviour, by making the typehints nullable.

Fixes #282