### PR TITLE
Fix php8 error passing too many arguments to strrchr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.18.2
 
   * Add a polyfill for the `Attribute` class
+  * Fix polyfill for `mb_strrchr()`
 
 # 1.18.1
 

--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -629,10 +629,11 @@ final class Mbstring
     {
         $encoding = self::getEncoding($encoding);
         if ('CP850' === $encoding || 'ASCII' === $encoding) {
-            return strrchr($haystack, $needle, $part);
+            $pos = strrpos($haystack, $needle);
+        } else {
+            $needle = self::mb_substr($needle, 0, 1, $encoding);
+            $pos = iconv_strrpos($haystack, $needle, $encoding);
         }
-        $needle = self::mb_substr($needle, 0, 1, $encoding);
-        $pos = iconv_strrpos($haystack, $needle, $encoding);
 
         return self::getSubpart($pos, $part, $haystack, $encoding);
     }

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -349,12 +349,16 @@ class MbstringTest extends TestCase
         $this->assertSame('ÉJÀDÉJÀ', mb_stristr('DÉJÀDÉJÀ', 'é'));
         $this->assertSame('ςσb', mb_stristr('aςσb', 'ΣΣ'));
         $this->assertSame('éjà', mb_strrchr('déjàdéjà', 'é'));
+        $this->assertSame('éjà', mb_strrchr('déjàdéjà', 'é', false, 'ASCII'));
+        $this->assertSame(false, mb_strrchr('déjàdéjà', 'X', false, 'ASCII'));
         $this->assertSame('ÉJÀ', mb_strrichr('DÉJÀDÉJÀ', 'é'));
 
         $this->assertSame('d', mb_strstr('déjàdéjà', 'é', true));
         $this->assertSame('D', mb_stristr('DÉJÀDÉJÀ', 'é', true));
         $this->assertSame('a', mb_stristr('aςσb', 'ΣΣ', true));
         $this->assertSame('déjàd', mb_strrchr('déjàdéjà', 'é', true));
+        $this->assertSame('déjàd', mb_strrchr('déjàdéjà', 'é', true, 'ASCII'));
+        $this->assertSame(false, mb_strrchr('déjàdéjà', 'X', true, 'ASCII'));
         $this->assertSame('DÉJÀD', mb_strrichr('DÉJÀDÉJÀ', 'é', true));
         $this->assertSame('Paris', mb_stristr('der Straße nach Paris', 'Paris'));
     }


### PR DESCRIPTION
https://www.php.net/strrchr has the signature
`strrchr ( string $haystack , mixed $needle ) : string`

Passing the unused 3rd argument becomes an ArgumentCountError in php 8.0

Detected via static analysis