### PR TITLE
Add a polyfill for the Attribute class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.18.2
+
+  * Add a polyfill for the `Attribute` class
+
 # 1.18.1
 
   * Don't force labels containing URL delimiters to stay in their Unicode form when `using idn_to_ascii`

--- a/src/Php80/Resources/stubs/Attribute.php
+++ b/src/Php80/Resources/stubs/Attribute.php
@@ -1,0 +1,22 @@
+<?php
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Attribute
+{
+    const TARGET_CLASS = 1;
+    const TARGET_FUNCTION = 2;
+    const TARGET_METHOD = 4;
+    const TARGET_PROPERTY = 8;
+    const TARGET_CLASS_CONSTANT = 16;
+    const TARGET_PARAMETER = 32;
+    const TARGET_ALL = 63;
+    const IS_REPEATABLE = 64;
+
+    /** @var int */
+    public $flags;
+
+    public function __construct(int $flags = Attribute::TARGET_ALL)
+    {
+        $this->flags = $flags;
+    }
+}

--- a/tests/Php80/Php80Test.php
+++ b/tests/Php80/Php80Test.php
@@ -291,6 +291,14 @@ class Php80Test extends TestCase
         $this->assertSame('__PHP_Incomplete_Class', get_debug_type($var));
     }
 
+    public function testAttributePolyfill()
+    {
+        $attribute = new \Attribute();
+        $this->assertSame(\Attribute::TARGET_ALL, $attribute->flags);
+        $attribute = new \Attribute(\Attribute::TARGET_CLASS);
+        $this->assertSame(\Attribute::TARGET_CLASS, $attribute->flags);
+    }
+
     public function setExpectedException($exception, $message = '', $code = null)
     {
         if (!class_exists('PHPUnit\Framework\Error\Notice')) {


### PR DESCRIPTION
Code which works with both php 7 and 8 may need to use the class constants or
instances of the attribute class outside of attribute declarations. E.g.

    // This line throws without a polyfill for Attribute.
    const FUNCTIONLIKE_ATTRIBUTES = Attribute::TARGET_FUNCTION | Attribute::TARGET_METHOD;

    #[Attribute(FUNCTIONLIKE_ATTRIBUTES)]
    function example() { }

For #235

Attribute had real types in the actual constructor, is final, etc. This polyfill is currently targeting php 7+, so the real type `int $flags` was used.