### PR TITLE
Fix the name of arguments for PHP 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.19.0
 
   * Add a polyfill for the `Attribute` class
+  * Fix the name of arguments for PHP 8
   * Improve performances of `array_key_last()`
   * Fix polyfill for `mb_strrchr()`
   * Skip loading `Stringable` on PHP 8

--- a/src/Ctype/bootstrap.php
+++ b/src/Ctype/bootstrap.php
@@ -12,35 +12,35 @@
 use Symfony\Polyfill\Ctype as p;
 
 if (!function_exists('ctype_alnum')) {
-    function ctype_alnum($text) { return p\Ctype::ctype_alnum($text); }
+    function ctype_alnum($input) { return p\Ctype::ctype_alnum($input); }
 }
 if (!function_exists('ctype_alpha')) {
-    function ctype_alpha($text) { return p\Ctype::ctype_alpha($text); }
+    function ctype_alpha($input) { return p\Ctype::ctype_alpha($input); }
 }
 if (!function_exists('ctype_cntrl')) {
-    function ctype_cntrl($text) { return p\Ctype::ctype_cntrl($text); }
+    function ctype_cntrl($input) { return p\Ctype::ctype_cntrl($input); }
 }
 if (!function_exists('ctype_digit')) {
-    function ctype_digit($text) { return p\Ctype::ctype_digit($text); }
+    function ctype_digit($input) { return p\Ctype::ctype_digit($input); }
 }
 if (!function_exists('ctype_graph')) {
-    function ctype_graph($text) { return p\Ctype::ctype_graph($text); }
+    function ctype_graph($input) { return p\Ctype::ctype_graph($input); }
 }
 if (!function_exists('ctype_lower')) {
-    function ctype_lower($text) { return p\Ctype::ctype_lower($text); }
+    function ctype_lower($input) { return p\Ctype::ctype_lower($input); }
 }
 if (!function_exists('ctype_print')) {
-    function ctype_print($text) { return p\Ctype::ctype_print($text); }
+    function ctype_print($input) { return p\Ctype::ctype_print($input); }
 }
 if (!function_exists('ctype_punct')) {
-    function ctype_punct($text) { return p\Ctype::ctype_punct($text); }
+    function ctype_punct($input) { return p\Ctype::ctype_punct($input); }
 }
 if (!function_exists('ctype_space')) {
-    function ctype_space($text) { return p\Ctype::ctype_space($text); }
+    function ctype_space($input) { return p\Ctype::ctype_space($input); }
 }
 if (!function_exists('ctype_upper')) {
-    function ctype_upper($text) { return p\Ctype::ctype_upper($text); }
+    function ctype_upper($input) { return p\Ctype::ctype_upper($input); }
 }
 if (!function_exists('ctype_xdigit')) {
-    function ctype_xdigit($text) { return p\Ctype::ctype_xdigit($text); }
+    function ctype_xdigit($input) { return p\Ctype::ctype_xdigit($input); }
 }

--- a/src/Iconv/bootstrap.php
+++ b/src/Iconv/bootstrap.php
@@ -29,56 +29,56 @@ if (!defined('ICONV_MIME_DECODE_CONTINUE_ON_ERROR')) {
 }
 
 if (!function_exists('iconv')) {
-    function iconv($from, $to, $s) { return p\Iconv::iconv($from, $to, $s); }
+    function iconv($from_encoding, $to_encoding, $string) { return p\Iconv::iconv($from_encoding, $to_encoding, $string); }
 }
 if (!function_exists('iconv_get_encoding')) {
     function iconv_get_encoding($type = 'all') { return p\Iconv::iconv_get_encoding($type); }
 }
 if (!function_exists('iconv_set_encoding')) {
-    function iconv_set_encoding($type, $charset) { return p\Iconv::iconv_set_encoding($type, $charset); }
+    function iconv_set_encoding($type, $encoding) { return p\Iconv::iconv_set_encoding($type, $encoding); }
 }
 if (!function_exists('iconv_mime_encode')) {
-    function iconv_mime_encode($name, $value, $pref = null) { return p\Iconv::iconv_mime_encode($name, $value, $pref); }
+    function iconv_mime_encode($field_name, $field_value, $options = null) { return p\Iconv::iconv_mime_encode($field_name, $field_value, $options); }
 }
 if (!function_exists('iconv_mime_decode_headers')) {
-    function iconv_mime_decode_headers($encodedHeaders, $mode = 0, $enc = null) { return p\Iconv::iconv_mime_decode_headers($encodedHeaders, $mode, $enc); }
+    function iconv_mime_decode_headers($headers, $mode = 0, $encoding = null) { return p\Iconv::iconv_mime_decode_headers($headers, $mode, $encoding); }
 }
 
 if (extension_loaded('mbstring')) {
     if (!function_exists('iconv_strlen')) {
-        function iconv_strlen($s, $enc = null) { null === $enc and $enc = p\Iconv::$internalEncoding; return mb_strlen($s, $enc); }
+        function iconv_strlen($string, $encoding = null) { null === $encoding && $encoding = p\Iconv::$internalEncoding; return mb_strlen($string, $encoding); }
     }
     if (!function_exists('iconv_strpos')) {
-        function iconv_strpos($s, $needle, $offset = 0, $enc = null) { null === $enc and $enc = p\Iconv::$internalEncoding; return mb_strpos($s, $needle, $offset, $enc); }
+        function iconv_strpos($haystack, $needle, $offset = 0, $encoding = null) { null === $encoding && $encoding = p\Iconv::$internalEncoding; return mb_strpos($haystack, $needle, $offset, $encoding); }
     }
     if (!function_exists('iconv_strrpos')) {
-        function iconv_strrpos($s, $needle, $enc = null) { null === $enc and $enc = p\Iconv::$internalEncoding; return mb_strrpos($s, $needle, 0, $enc); }
+        function iconv_strrpos($haystack, $needle, $encoding = null) { null === $encoding && $encoding = p\Iconv::$internalEncoding; return mb_strrpos($haystack, $needle, 0, $encoding); }
     }
     if (!function_exists('iconv_substr')) {
-        function iconv_substr($s, $start, $length = 2147483647, $enc = null) { null === $enc and $enc = p\Iconv::$internalEncoding; return mb_substr($s, $start, $length, $enc); }
+        function iconv_substr($string, $offset, $length = 2147483647, $encoding = null) { null === $encoding && $encoding = p\Iconv::$internalEncoding; return mb_substr($string, $offset, $length, $encoding); }
     }
     if (!function_exists('iconv_mime_decode')) {
-        function iconv_mime_decode($encodedHeaders, $mode = 0, $enc = null) { null === $enc and $enc = p\Iconv::$internalEncoding; return mb_decode_mimeheader($encodedHeaders, $mode, $enc); }
+        function iconv_mime_decode($string, $mode = 0, $encoding = null) { null === $encoding && $encoding = p\Iconv::$internalEncoding; return mb_decode_mimeheader($string, $mode, $encoding); }
     }
 } else {
     if (!function_exists('iconv_strlen')) {
         if (extension_loaded('xml')) {
-            function iconv_strlen($s, $enc = null) { return p\Iconv::strlen1($s, $enc); }
+            function iconv_strlen($string, $encoding = null) { return p\Iconv::strlen1($string, $encoding); }
         } else {
-            function iconv_strlen($s, $enc = null) { return p\Iconv::strlen2($s, $enc); }
+            function iconv_strlen($string, $encoding = null) { return p\Iconv::strlen2($string, $encoding); }
         }
     }
 
     if (!function_exists('iconv_strpos')) {
-        function iconv_strpos($s, $needle, $offset = 0, $enc = null) { return p\Iconv::iconv_strpos($s, $needle, $offset, $enc); }
+        function iconv_strpos($haystack, $needle, $offset = 0, $encoding = null) { return p\Iconv::iconv_strpos($haystack, $needle, $offset, $encoding); }
     }
     if (!function_exists('iconv_strrpos')) {
-        function iconv_strrpos($s, $needle, $enc = null) { return p\Iconv::iconv_strrpos($s, $needle, $enc); }
+        function iconv_strrpos($haystack, $needle, $encoding = null) { return p\Iconv::iconv_strrpos($haystack, $needle, $encoding); }
     }
     if (!function_exists('iconv_substr')) {
-        function iconv_substr($s, $start, $length = 2147483647, $enc = null) { return p\Iconv::iconv_substr($s, $start, $length, $enc); }
+        function iconv_substr($string, $offset, $length = 2147483647, $encoding = null) { return p\Iconv::iconv_substr($string, $offset, $length, $encoding); }
     }
     if (!function_exists('iconv_mime_decode')) {
-        function iconv_mime_decode($encodedHeaders, $mode = 0, $enc = null) { return p\Iconv::iconv_mime_decode($encodedHeaders, $mode, $enc); }
+        function iconv_mime_decode($string, $mode = 0, $encoding = null) { return p\Iconv::iconv_mime_decode($string, $mode, $encoding); }
     }
 }

--- a/src/Intl/Grapheme/bootstrap.php
+++ b/src/Intl/Grapheme/bootstrap.php
@@ -26,29 +26,29 @@ if (!defined('GRAPHEME_EXTR_MAXCHARS')) {
 }
 
 if (!function_exists('grapheme_extract')) {
-    function grapheme_extract($s, $size, $type = 0, $start = 0, &$next = 0) { return p\Grapheme::grapheme_extract($s, $size, $type, $start, $next); }
+    function grapheme_extract($haystack, $size, $extract_type = 0, $start = 0, &$next = 0) { return p\Grapheme::grapheme_extract($haystack, $size, $extract_type, $start, $next); }
 }
 if (!function_exists('grapheme_stripos')) {
-    function grapheme_stripos($s, $needle, $offset = 0) { return p\Grapheme::grapheme_stripos($s, $needle, $offset); }
+    function grapheme_stripos($haystack, $needle, $offset = 0) { return p\Grapheme::grapheme_stripos($haystack, $needle, $offset); }
 }
 if (!function_exists('grapheme_stristr')) {
-    function grapheme_stristr($s, $needle, $beforeNeedle = false) { return p\Grapheme::grapheme_stristr($s, $needle, $beforeNeedle); }
+    function grapheme_stristr($haystack, $needle, $before_needle = false) { return p\Grapheme::grapheme_stristr($haystack, $needle, $before_needle); }
 }
 if (!function_exists('grapheme_strlen')) {
-    function grapheme_strlen($s) { return p\Grapheme::grapheme_strlen($s); }
+    function grapheme_strlen($input) { return p\Grapheme::grapheme_strlen($input); }
 }
 if (!function_exists('grapheme_strpos')) {
-    function grapheme_strpos($s, $needle, $offset = 0) { return p\Grapheme::grapheme_strpos($s, $needle, $offset); }
+    function grapheme_strpos($haystack, $needle, $offset = 0) { return p\Grapheme::grapheme_strpos($haystack, $needle, $offset); }
 }
 if (!function_exists('grapheme_strripos')) {
-    function grapheme_strripos($s, $needle, $offset = 0) { return p\Grapheme::grapheme_strripos($s, $needle, $offset); }
+    function grapheme_strripos($haystack, $needle, $offset = 0) { return p\Grapheme::grapheme_strripos($haystack, $needle, $offset); }
 }
 if (!function_exists('grapheme_strrpos')) {
-    function grapheme_strrpos($s, $needle, $offset = 0) { return p\Grapheme::grapheme_strrpos($s, $needle, $offset); }
+    function grapheme_strrpos($haystack, $needle, $offset = 0) { return p\Grapheme::grapheme_strrpos($haystack, $needle, $offset); }
 }
 if (!function_exists('grapheme_strstr')) {
-    function grapheme_strstr($s, $needle, $beforeNeedle = false) { return p\Grapheme::grapheme_strstr($s, $needle, $beforeNeedle); }
+    function grapheme_strstr($haystack, $needle, $before_needle = false) { return p\Grapheme::grapheme_strstr($haystack, $needle, $before_needle); }
 }
 if (!function_exists('grapheme_substr')) {
-    function grapheme_substr($s, $start, $len = null) { return p\Grapheme::grapheme_substr($s, $start, $len); }
+    function grapheme_substr($string, $start, $length = null) { return p\Grapheme::grapheme_substr($string, $start, $length); }
 }

--- a/src/Intl/Icu/bootstrap.php
+++ b/src/Intl/Icu/bootstrap.php
@@ -12,7 +12,7 @@
 use Symfony\Component\Intl\Globals\IntlGlobals;
 
 if (!function_exists('intl_is_failure')) {
-    function intl_is_failure($errorCode) { return IntlGlobals::isFailure($errorCode); }
+    function intl_is_failure($error_code) { return IntlGlobals::isFailure($error_code); }
 }
 if (!function_exists('intl_get_error_code')) {
     function intl_get_error_code() { return IntlGlobals::getErrorCode(); }
@@ -21,5 +21,5 @@ if (!function_exists('intl_get_error_message')) {
     function intl_get_error_message() { return IntlGlobals::getErrorMessage(); }
 }
 if (!function_exists('intl_error_name')) {
-    function intl_error_name($errorCode) { return IntlGlobals::getErrorName($errorCode); }
+    function intl_error_name($error_code) { return IntlGlobals::getErrorName($error_code); }
 }

--- a/src/Intl/Normalizer/bootstrap.php
+++ b/src/Intl/Normalizer/bootstrap.php
@@ -12,8 +12,8 @@
 use Symfony\Polyfill\Intl\Normalizer as p;
 
 if (!function_exists('normalizer_is_normalized')) {
-    function normalizer_is_normalized($s, $form = p\Normalizer::NFC) { return p\Normalizer::isNormalized($s, $form); }
+    function normalizer_is_normalized($input, $form = p\Normalizer::NFC) { return p\Normalizer::isNormalized($input, $form); }
 }
 if (!function_exists('normalizer_normalize')) {
-    function normalizer_normalize($s, $form = p\Normalizer::NFC) { return p\Normalizer::normalize($s, $form); }
+    function normalizer_normalize($input, $form = p\Normalizer::NFC) { return p\Normalizer::normalize($input, $form); }
 }

--- a/src/Mbstring/Resources/mb_convert_variables.php8
+++ b/src/Mbstring/Resources/mb_convert_variables.php8
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\Mbstring as p;
+
+if (!function_exists('mb_convert_variables')) {
+    /**
+     * Convert character code in variable(s)
+     */
+    function mb_convert_variables($to_encoding, $from_encoding, &$var, &...$vars)
+    {
+        $vars = [&$var, ...$vars];
+
+        $ok = true;
+        array_walk_recursive($vars, function (&$v) use (&$ok, $to_encoding, $from_encoding) {
+            if (false === $v = p\Mbstring::mb_convert_encoding($v, $to_encoding, $from_encoding)) {
+                $ok = false;
+            }
+        });
+
+        return $ok ? $from_encoding : false;
+    }
+}

--- a/src/Mbstring/bootstrap.php
+++ b/src/Mbstring/bootstrap.php
@@ -12,28 +12,28 @@
 use Symfony\Polyfill\Mbstring as p;
 
 if (!function_exists('mb_convert_encoding')) {
-    function mb_convert_encoding($s, $to, $from = null) { return p\Mbstring::mb_convert_encoding($s, $to, $from); }
+    function mb_convert_encoding($string, $to_encoding, $from_encoding = null) { return p\Mbstring::mb_convert_encoding($string, $to_encoding, $from_encoding); }
 }
 if (!function_exists('mb_decode_mimeheader')) {
-    function mb_decode_mimeheader($s) { return p\Mbstring::mb_decode_mimeheader($s); }
+    function mb_decode_mimeheader($string) { return p\Mbstring::mb_decode_mimeheader($string); }
 }
 if (!function_exists('mb_encode_mimeheader')) {
-    function mb_encode_mimeheader($s, $charset = null, $transferEnc = null, $lf = null, $indent = null) { return p\Mbstring::mb_encode_mimeheader($s, $charset, $transferEnc, $lf, $indent); }
+    function mb_encode_mimeheader($string, $charset = null, $transfer_encoding = null, $newline = null, $indent = null) { return p\Mbstring::mb_encode_mimeheader($string, $charset, $transfer_encoding, $newline, $indent); }
 }
 if (!function_exists('mb_decode_numericentity')) {
-    function mb_decode_numericentity($s, $convmap, $enc = null) { return p\Mbstring::mb_decode_numericentity($s, $convmap, $enc); }
+    function mb_decode_numericentity($string, $map, $encoding = null) { return p\Mbstring::mb_decode_numericentity($string, $map, $encoding); }
 }
 if (!function_exists('mb_encode_numericentity')) {
-    function mb_encode_numericentity($s, $convmap, $enc = null, $is_hex = false) { return p\Mbstring::mb_encode_numericentity($s, $convmap, $enc, $is_hex); }
+    function mb_encode_numericentity($string, $map, $encoding = null, $hex = false) { return p\Mbstring::mb_encode_numericentity($string, $map, $encoding, $hex); }
 }
 if (!function_exists('mb_convert_case')) {
-    function mb_convert_case($s, $mode, $enc = null) { return p\Mbstring::mb_convert_case($s, $mode, $enc); }
+    function mb_convert_case($string, $mode, $encoding = null) { return p\Mbstring::mb_convert_case($string, $mode, $encoding); }
 }
 if (!function_exists('mb_internal_encoding')) {
-    function mb_internal_encoding($enc = null) { return p\Mbstring::mb_internal_encoding($enc); }
+    function mb_internal_encoding($encoding = null) { return p\Mbstring::mb_internal_encoding($encoding); }
 }
 if (!function_exists('mb_language')) {
-    function mb_language($lang = null) { return p\Mbstring::mb_language($lang); }
+    function mb_language($language = null) { return p\Mbstring::mb_language($language); }
 }
 if (!function_exists('mb_list_encodings')) {
     function mb_list_encodings() { return p\Mbstring::mb_list_encodings(); }
@@ -42,88 +42,92 @@ if (!function_exists('mb_encoding_aliases')) {
     function mb_encoding_aliases($encoding) { return p\Mbstring::mb_encoding_aliases($encoding); }
 }
 if (!function_exists('mb_check_encoding')) {
-    function mb_check_encoding($var = null, $encoding = null) { return p\Mbstring::mb_check_encoding($var, $encoding); }
+    function mb_check_encoding($value = null, $encoding = null) { return p\Mbstring::mb_check_encoding($value, $encoding); }
 }
 if (!function_exists('mb_detect_encoding')) {
-    function mb_detect_encoding($str, $encodingList = null, $strict = false) { return p\Mbstring::mb_detect_encoding($str, $encodingList, $strict); }
+    function mb_detect_encoding($string, $encodings = null, $strict = false) { return p\Mbstring::mb_detect_encoding($string, $encodings, $strict); }
 }
 if (!function_exists('mb_detect_order')) {
-    function mb_detect_order($encodingList = null) { return p\Mbstring::mb_detect_order($encodingList); }
+    function mb_detect_order($encoding = null) { return p\Mbstring::mb_detect_order($encoding); }
 }
 if (!function_exists('mb_parse_str')) {
-    function mb_parse_str($s, &$result = array()) { parse_str($s, $result); }
+    function mb_parse_str($string, &$result = array()) { parse_str($string, $result); }
 }
 if (!function_exists('mb_strlen')) {
-    function mb_strlen($s, $enc = null) { return p\Mbstring::mb_strlen($s, $enc); }
+    function mb_strlen($string, $encoding = null) { return p\Mbstring::mb_strlen($string, $encoding); }
 }
 if (!function_exists('mb_strpos')) {
-    function mb_strpos($s, $needle, $offset = 0, $enc = null) { return p\Mbstring::mb_strpos($s, $needle, $offset, $enc); }
+    function mb_strpos($haystack, $needle, $offset = 0, $encoding = null) { return p\Mbstring::mb_strpos($haystack, $needle, $offset, $encoding); }
 }
 if (!function_exists('mb_strtolower')) {
-    function mb_strtolower($s, $enc = null) { return p\Mbstring::mb_strtolower($s, $enc); }
+    function mb_strtolower($string, $encoding = null) { return p\Mbstring::mb_strtolower($string, $encoding); }
 }
 if (!function_exists('mb_strtoupper')) {
-    function mb_strtoupper($s, $enc = null) { return p\Mbstring::mb_strtoupper($s, $enc); }
+    function mb_strtoupper($string, $encoding = null) { return p\Mbstring::mb_strtoupper($string, $encoding); }
 }
 if (!function_exists('mb_substitute_character')) {
-    function mb_substitute_character($char = null) { return p\Mbstring::mb_substitute_character($char); }
+    function mb_substitute_character($substitute_character = null) { return p\Mbstring::mb_substitute_character($substitute_character); }
 }
 if (!function_exists('mb_substr')) {
-    function mb_substr($s, $start, $length = 2147483647, $enc = null) { return p\Mbstring::mb_substr($s, $start, $length, $enc); }
+    function mb_substr($string, $start, $length = 2147483647, $encoding = null) { return p\Mbstring::mb_substr($string, $start, $length, $encoding); }
 }
 if (!function_exists('mb_stripos')) {
-    function mb_stripos($s, $needle, $offset = 0, $enc = null) { return p\Mbstring::mb_stripos($s, $needle, $offset, $enc); }
+    function mb_stripos($haystack, $needle, $offset = 0, $encoding = null) { return p\Mbstring::mb_stripos($haystack, $needle, $offset, $encoding); }
 }
 if (!function_exists('mb_stristr')) {
-    function mb_stristr($s, $needle, $part = false, $enc = null) { return p\Mbstring::mb_stristr($s, $needle, $part, $enc); }
+    function mb_stristr($haystack, $needle, $before_needle = false, $encoding = null) { return p\Mbstring::mb_stristr($haystack, $needle, $before_needle, $encoding); }
 }
 if (!function_exists('mb_strrchr')) {
-    function mb_strrchr($s, $needle, $part = false, $enc = null) { return p\Mbstring::mb_strrchr($s, $needle, $part, $enc); }
+    function mb_strrchr($haystack, $needle, $before_needle = false, $encoding = null) { return p\Mbstring::mb_strrchr($haystack, $needle, $before_needle, $encoding); }
 }
 if (!function_exists('mb_strrichr')) {
-    function mb_strrichr($s, $needle, $part = false, $enc = null) { return p\Mbstring::mb_strrichr($s, $needle, $part, $enc); }
+    function mb_strrichr($haystack, $needle, $before_needle = false, $encoding = null) { return p\Mbstring::mb_strrichr($haystack, $needle, $before_needle, $encoding); }
 }
 if (!function_exists('mb_strripos')) {
-    function mb_strripos($s, $needle, $offset = 0, $enc = null) { return p\Mbstring::mb_strripos($s, $needle, $offset, $enc); }
+    function mb_strripos($haystack, $needle, $offset = 0, $encoding = null) { return p\Mbstring::mb_strripos($haystack, $needle, $offset, $encoding); }
 }
 if (!function_exists('mb_strrpos')) {
-    function mb_strrpos($s, $needle, $offset = 0, $enc = null) { return p\Mbstring::mb_strrpos($s, $needle, $offset, $enc); }
+    function mb_strrpos($haystack, $needle, $offset = 0, $encoding = null) { return p\Mbstring::mb_strrpos($haystack, $needle, $offset, $encoding); }
 }
 if (!function_exists('mb_strstr')) {
-    function mb_strstr($s, $needle, $part = false, $enc = null) { return p\Mbstring::mb_strstr($s, $needle, $part, $enc); }
+    function mb_strstr($haystack, $needle, $before_needle = false, $encoding = null) { return p\Mbstring::mb_strstr($haystack, $needle, $before_needle, $encoding); }
 }
 if (!function_exists('mb_get_info')) {
     function mb_get_info($type = 'all') { return p\Mbstring::mb_get_info($type); }
 }
 if (!function_exists('mb_http_output')) {
-    function mb_http_output($enc = null) { return p\Mbstring::mb_http_output($enc); }
+    function mb_http_output($encoding = null) { return p\Mbstring::mb_http_output($encoding); }
 }
 if (!function_exists('mb_strwidth')) {
-    function mb_strwidth($s, $enc = null) { return p\Mbstring::mb_strwidth($s, $enc); }
+    function mb_strwidth($string, $encoding = null) { return p\Mbstring::mb_strwidth($string, $encoding); }
 }
 if (!function_exists('mb_substr_count')) {
-    function mb_substr_count($haystack, $needle, $enc = null) { return p\Mbstring::mb_substr_count($haystack, $needle, $enc); }
+    function mb_substr_count($haystack, $needle, $encoding = null) { return p\Mbstring::mb_substr_count($haystack, $needle, $encoding); }
 }
 if (!function_exists('mb_output_handler')) {
-    function mb_output_handler($contents, $status) { return p\Mbstring::mb_output_handler($contents, $status); }
+    function mb_output_handler($string, $status) { return p\Mbstring::mb_output_handler($string, $status); }
 }
 if (!function_exists('mb_http_input')) {
     function mb_http_input($type = '') { return p\Mbstring::mb_http_input($type); }
 }
-if (!function_exists('mb_convert_variables')) {
+
+if (PHP_VERSION_ID >= 80000) {
+    require_once __DIR__.'/Resources/mb_convert_variables.php8';
+} elseif (!function_exists('mb_convert_variables')) {
     function mb_convert_variables($toEncoding, $fromEncoding, &$a = null, &$b = null, &$c = null, &$d = null, &$e = null, &$f = null) { return p\Mbstring::mb_convert_variables($toEncoding, $fromEncoding, $a, $b, $c, $d, $e, $f); }
 }
+
 if (!function_exists('mb_ord')) {
-    function mb_ord($s, $enc = null) { return p\Mbstring::mb_ord($s, $enc); }
+    function mb_ord($string, $encoding = null) { return p\Mbstring::mb_ord($string, $encoding); }
 }
 if (!function_exists('mb_chr')) {
-    function mb_chr($code, $enc = null) { return p\Mbstring::mb_chr($code, $enc); }
+    function mb_chr($codepoint, $encoding = null) { return p\Mbstring::mb_chr($codepoint, $encoding); }
 }
 if (!function_exists('mb_scrub')) {
-    function mb_scrub($s, $enc = null) { $enc = null === $enc ? mb_internal_encoding() : $enc; return mb_convert_encoding($s, $enc, $enc); }
+    function mb_scrub($string, $encoding = null) { $encoding = null === $encoding ? mb_internal_encoding() : $encoding; return mb_convert_encoding($string, $encoding, $encoding); }
 }
 if (!function_exists('mb_str_split')) {
-    function mb_str_split($string, $split_length = 1, $encoding = null) { return p\Mbstring::mb_str_split($string, $split_length, $encoding); }
+    function mb_str_split($string, $length = 1, $encoding = null) { return p\Mbstring::mb_str_split($string, $length, $encoding); }
 }
 
 if (extension_loaded('mbstring')) {

--- a/src/Php54/bootstrap.php
+++ b/src/Php54/bootstrap.php
@@ -29,7 +29,7 @@ if (!function_exists('class_uses')) {
     }
 }
 if (!function_exists('hex2bin')) {
-    function hex2bin($data) { return p\Php54::hex2bin($data); }
+    function hex2bin($string) { return p\Php54::hex2bin($string); }
 }
 if (!function_exists('session_register_shutdown')) {
     function session_register_shutdown() { register_shutdown_function('session_write_close'); }

--- a/src/Php55/bootstrap.php
+++ b/src/Php55/bootstrap.php
@@ -16,13 +16,13 @@ if (PHP_VERSION_ID >= 50500) {
 }
 
 if (!function_exists('boolval')) {
-    function boolval($val) { return p\Php55::boolval($val); }
+    function boolval($value) { return p\Php55::boolval($value); }
 }
 if (!function_exists('json_last_error_msg')) {
     function json_last_error_msg() { return p\Php55::json_last_error_msg(); }
 }
 if (!function_exists('array_column')) {
-    function array_column($array, $columnKey, $indexKey = null) { return p\Php55ArrayColumn::array_column($array, $columnKey, $indexKey); }
+    function array_column($array, $column_key, $index_key = null) { return p\Php55ArrayColumn::array_column($array, $column_key, $index_key); }
 }
 if (!function_exists('hash_pbkdf2')) {
     function hash_pbkdf2($algorithm, $password, $salt, $iterations, $length = 0, $rawOutput = false) { return p\Php55::hash_pbkdf2($algorithm, $password, $salt, $iterations, $length, $rawOutput); }

--- a/src/Php56/bootstrap.php
+++ b/src/Php56/bootstrap.php
@@ -16,7 +16,7 @@ if (PHP_VERSION_ID >= 50600) {
 }
 
 if (!function_exists('hash_equals')) {
-    function hash_equals($knownString, $userInput) { return p\Php56::hash_equals($knownString, $userInput); }
+    function hash_equals($known_string, $user_string) { return p\Php56::hash_equals($known_string, $user_string); }
 }
 if (extension_loaded('ldap') && !defined('LDAP_ESCAPE_FILTER')) {
     define('LDAP_ESCAPE_FILTER', 1);
@@ -26,7 +26,7 @@ if (extension_loaded('ldap') && !defined('LDAP_ESCAPE_DN')) {
 }
 
 if (extension_loaded('ldap') && !function_exists('ldap_escape')) {
-    function ldap_escape($subject, $ignore = '', $flags = 0) { return p\Php56::ldap_escape($subject, $ignore, $flags); }
+    function ldap_escape($value, $ignore = '', $flags = 0) { return p\Php56::ldap_escape($value, $ignore, $flags); }
 }
 
 if (50509 === PHP_VERSION_ID && 4 === PHP_INT_SIZE) {
@@ -36,9 +36,9 @@ if (50509 === PHP_VERSION_ID && 4 === PHP_INT_SIZE) {
         function gzopen($filename, $mode, $use_include_path = 0) { return gzopen64($filename, $mode, $use_include_path); }
     }
     if (!function_exists('gzseek') && function_exists('gzseek64')) {
-        function gzseek($zp, $offset, $whence = SEEK_SET) { return gzseek64($zp, $offset, $whence); }
+        function gzseek($fp, $offset, $whence = SEEK_SET) { return gzseek64($fp, $offset, $whence); }
     }
     if (!function_exists('gztell') && function_exists('gztell64')) {
-        function gztell($zp) { return gztell64($zp); }
+        function gztell($fp) { return gztell64($fp); }
     }
 }

--- a/src/Php70/bootstrap.php
+++ b/src/Php70/bootstrap.php
@@ -20,10 +20,10 @@ if (!defined('PHP_INT_MIN')) {
 }
 
 if (!function_exists('intdiv')) {
-    function intdiv($dividend, $divisor) { return p\Php70::intdiv($dividend, $divisor); }
+    function intdiv($num1, $num2) { return p\Php70::intdiv($num1, $num2); }
 }
 if (!function_exists('preg_replace_callback_array')) {
-    function preg_replace_callback_array(array $patterns, $subject, $limit = -1, &$count = 0) { return p\Php70::preg_replace_callback_array($patterns, $subject, $limit, $count); }
+    function preg_replace_callback_array(array $pattern, $subject, $limit = -1, &$count = 0, $flags = null) { return p\Php70::preg_replace_callback_array($pattern, $subject, $limit, $count); }
 }
 if (!function_exists('error_clear_last')) {
     function error_clear_last() { return p\Php70::error_clear_last(); }

--- a/src/Php71/bootstrap.php
+++ b/src/Php71/bootstrap.php
@@ -12,5 +12,5 @@
 use Symfony\Polyfill\Php71 as p;
 
 if (!function_exists('is_iterable')) {
-    function is_iterable($var) { return p\Php71::is_iterable($var); }
+    function is_iterable($value) { return p\Php71::is_iterable($value); }
 }

--- a/src/Php72/bootstrap.php
+++ b/src/Php72/bootstrap.php
@@ -38,20 +38,20 @@ if (!function_exists('stream_isatty')) {
     function stream_isatty($stream) { return p\Php72::stream_isatty($stream); }
 }
 if (!function_exists('utf8_encode')) {
-    function utf8_encode($s) { return p\Php72::utf8_encode($s); }
+    function utf8_encode($string) { return p\Php72::utf8_encode($string); }
 }
 if (!function_exists('utf8_decode')) {
-    function utf8_decode($s) { return p\Php72::utf8_decode($s); }
+    function utf8_decode($string) { return p\Php72::utf8_decode($string); }
 }
 if (!function_exists('spl_object_id')) {
-    function spl_object_id($s) { return p\Php72::spl_object_id($s); }
+    function spl_object_id($object) { return p\Php72::spl_object_id($object); }
 }
 if (!function_exists('mb_ord')) {
-    function mb_ord($s, $enc = null) { return p\Php72::mb_ord($s, $enc); }
+    function mb_ord($string, $encoding = null) { return p\Php72::mb_ord($string, $encoding); }
 }
 if (!function_exists('mb_chr')) {
-    function mb_chr($code, $enc = null) { return p\Php72::mb_chr($code, $enc); }
+    function mb_chr($codepoint, $encoding = null) { return p\Php72::mb_chr($codepoint, $encoding); }
 }
 if (!function_exists('mb_scrub')) {
-    function mb_scrub($s, $enc = null) { $enc = null === $enc ? mb_internal_encoding() : $enc; return mb_convert_encoding($s, $enc, $enc); }
+    function mb_scrub($string, $encoding = null) { $encoding = null === $encoding ? mb_internal_encoding() : $encoding; return mb_convert_encoding($string, $encoding, $encoding); }
 }

--- a/src/Php73/bootstrap.php
+++ b/src/Php73/bootstrap.php
@@ -16,12 +16,12 @@ if (PHP_VERSION_ID >= 70300) {
 }
 
 if (!function_exists('is_countable')) {
-    function is_countable($var) { return is_array($var) || $var instanceof Countable || $var instanceof ResourceBundle || $var instanceof SimpleXmlElement; }
+    function is_countable($value) { return is_array($value) || $value instanceof Countable || $value instanceof ResourceBundle || $value instanceof SimpleXmlElement; }
 }
 if (!function_exists('hrtime')) {
     require_once __DIR__.'/Php73.php';
     p\Php73::$startAt = (int) microtime(true);
-    function hrtime($asNum = false) { return p\Php73::hrtime($asNum); }
+    function hrtime($as_number  = false) { return p\Php73::hrtime($as_number ); }
 }
 if (!function_exists('array_key_first')) {
     function array_key_first(array $array) { foreach ($array as $key => $value) { return $key; } }

--- a/src/Php74/bootstrap.php
+++ b/src/Php74/bootstrap.php
@@ -16,10 +16,10 @@ if (PHP_VERSION_ID >= 70400) {
 }
 
 if (!function_exists('get_mangled_object_vars')) {
-    function get_mangled_object_vars($obj) { return p\Php74::get_mangled_object_vars($obj); }
+    function get_mangled_object_vars($object) { return p\Php74::get_mangled_object_vars($object); }
 }
 if (!function_exists('mb_str_split') && function_exists('mb_substr')) {
-    function mb_str_split($string, $split_length = 1, $encoding = null) { return p\Php74::mb_str_split($string, $split_length, $encoding); }
+    function mb_str_split($string, $length = 1, $encoding = null) { return p\Php74::mb_str_split($string, $length, $encoding); }
 }
 if (!function_exists('password_algos')) {
     function password_algos() { return p\Php74::password_algos(); }

--- a/src/Php80/bootstrap.php
+++ b/src/Php80/bootstrap.php
@@ -20,7 +20,7 @@ if (!defined('FILTER_VALIDATE_BOOL') && defined('FILTER_VALIDATE_BOOLEAN')) {
 }
 
 if (!function_exists('fdiv')) {
-    function fdiv(float $dividend, float $divisor): float { return p\Php80::fdiv($dividend, $divisor); }
+    function fdiv(float $num1, float $num2): float { return p\Php80::fdiv($num1, $num2); }
 }
 if (!function_exists('preg_last_error_msg')) {
     function preg_last_error_msg(): string { return p\Php80::preg_last_error_msg(); }


### PR DESCRIPTION
With PHP 8 coming, we need to have function/methods parameters names consistent between polyfills and the original implementations.

I'm not sure if this is all of it yet.


see: 
https://github.com/php/php-tasks/issues/23
https://github.com/php/php-tasks/issues/16

