### PR TITLE
iconv: Adjust `iconv_substr` PHP 8 compatibility

### DIFF
--- a/src/Iconv/Iconv.php
+++ b/src/Iconv/Iconv.php
@@ -544,7 +544,7 @@ final class Iconv
             return false;
         }
         if ($start >= $slen) {
-            return false;
+            return \PHP_VERSION_ID >= 80000 ? '' : false;
         }
 
         $rx = $slen - $start;

--- a/tests/Iconv/IconvTest.php
+++ b/tests/Iconv/IconvTest.php
@@ -75,6 +75,24 @@ class IconvTest extends TestCase
     }
 
     /**
+     * @covers \Symfony\Polyfill\Iconv\Iconv::iconv_substr
+     * @requires PHP < 8.0.0
+     */
+    public function testIconvSubstrReturnsFalsePrePHP8()
+    {
+        $this->assertFalse(iconv_substr('x', 5, 1, 'UTF-8'));
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Iconv\Iconv::iconv_substr
+     * @requires PHP >= 8.0.0
+     */
+    public function testIconvSubstrReturnsEmptyPostPHP8()
+    {
+        $this->assertSame('', iconv_substr('x', 5, 1, 'UTF-8'));
+    }
+
+    /**
      * @covers \Symfony\Polyfill\Iconv\Iconv::iconv_mime_encode
      */
     public function testIconvMimeEncode()


### PR DESCRIPTION
`iconv_substr` is changed in [PHP 8.0 to return an empty string on out-of-bound offsets](https://php.watch/versions/8.0/substr-out-of-bounds).
This commit updates the tests with `@requires` annotatios and polyfill updates to make sure the return results are in line with native function behavior.

Related: #288