### PR TITLE
Skip loading `Stringable` on PHP 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 1.18.2
+# 1.19.0
 
   * Add a polyfill for the `Attribute` class
   * Fix polyfill for `mb_strrchr()`
+  * Skip loading `Stringable` on PHP 8
 
 # 1.18.1
 

--- a/src/Php80/Resources/stubs/Stringable.php
+++ b/src/Php80/Resources/stubs/Stringable.php
@@ -1,9 +1,11 @@
 <?php
 
-interface Stringable
-{
-    /**
-     * @return string
-     */
-    public function __toString();
+if (\PHP_VERSION_ID < 80000) {
+    interface Stringable
+    {
+        /**
+         * @return string
+         */
+        public function __toString();
+    }
 }


### PR DESCRIPTION
Fix https://github.com/symfony/symfony/issues/38588