### PR TITLE
Intl Grapheme: Adjust `grapheme_substr` PHP 8 compatibility

### DIFF
--- a/src/Iconv/Iconv.php
+++ b/src/Iconv/Iconv.php
@@ -541,7 +541,11 @@ final class Iconv
             $start += $slen;
         }
         if (0 > $start) {
-            return false;
+            if (\PHP_VERSION_ID < 80000) {
+                return false;
+            }
+
+            $start = 0;
         }
         if ($start >= $slen) {
             return \PHP_VERSION_ID >= 80000 ? '' : false;
@@ -556,7 +560,7 @@ final class Iconv
             return '';
         }
         if (0 > $length) {
-            return false;
+            return \PHP_VERSION_ID >= 80000 ? '' : false;
         }
 
         if ($length > $rx) {

--- a/src/Intl/Grapheme/Grapheme.php
+++ b/src/Intl/Grapheme/Grapheme.php
@@ -120,10 +120,14 @@ final class Grapheme
             $start += $slen;
         }
         if (0 > $start) {
-            return false;
+            if (\PHP_VERSION_ID < 80000) {
+                return false;
+            }
+
+            $start = 0;
         }
         if ($start >= $slen) {
-            return false;
+            return \PHP_VERSION_ID >= 80000 ? '' : false;
         }
 
         $rem = $slen - $start;
@@ -135,7 +139,7 @@ final class Grapheme
             return '';
         }
         if (0 > $len) {
-            return false;
+            return \PHP_VERSION_ID >= 80000 ? '' : false;
         }
         if ($len > $rem) {
             $len = $rem;

--- a/tests/Iconv/IconvTest.php
+++ b/tests/Iconv/IconvTest.php
@@ -76,20 +76,26 @@ class IconvTest extends TestCase
 
     /**
      * @covers \Symfony\Polyfill\Iconv\Iconv::iconv_substr
-     * @requires PHP < 8.0.0
+     * @requires PHP < 8
      */
     public function testIconvSubstrReturnsFalsePrePHP8()
     {
-        $this->assertFalse(iconv_substr('x', 5, 1, 'UTF-8'));
+        $c = 'déjà';
+        $this->assertFalse(iconv_substr($c, 42, 1, 'UTF-8'));
+        $this->assertFalse(iconv_substr($c, -42, 1));
+        $this->assertFalse(iconv_substr($c, 42, 26));
     }
 
     /**
      * @covers \Symfony\Polyfill\Iconv\Iconv::iconv_substr
-     * @requires PHP >= 8.0.0
+     * @requires PHP 8
      */
     public function testIconvSubstrReturnsEmptyPostPHP8()
     {
-        $this->assertSame('', iconv_substr('x', 5, 1, 'UTF-8'));
+        $c = 'déjà';
+        $this->assertSame('', iconv_substr($c, 42, 1, 'UTF-8'));
+        $this->assertSame('d', iconv_substr($c, -42, 1));
+        $this->assertSame('', iconv_substr($c, 42, 26));
     }
 
     /**

--- a/tests/Intl/Grapheme/GraphemeTest.php
+++ b/tests/Intl/Grapheme/GraphemeTest.php
@@ -93,7 +93,11 @@ class GraphemeTest extends TestCase
             $this->assertSame('jà', grapheme_substr($c, -2, null));
         }
 
-        if (\PHP_VERSION_ID >= 50418 && \PHP_VERSION_ID !== 50500) {
+        if (\PHP_VERSION_ID >= 80000) {
+            $this->assertSame('jà', grapheme_substr($c, -2, 3));
+            $this->assertSame('', grapheme_substr($c, -1, 0));
+            $this->assertSame('', grapheme_substr($c, 1, -4));
+        } elseif (\PHP_VERSION_ID >= 50418 && \PHP_VERSION_ID !== 50500) {
             // See http://bugs.php.net/62759 and 55562
             $this->assertSame('jà', grapheme_substr($c, -2, 3));
             $this->assertSame('', grapheme_substr($c, -1, 0));
@@ -104,8 +108,32 @@ class GraphemeTest extends TestCase
         $this->assertSame('jà', grapheme_substr($c, -2));
         $this->assertSame('j', grapheme_substr($c, -2, -1));
         $this->assertSame('', grapheme_substr($c, -2, -2));
-        $this->assertFalse(grapheme_substr($c, 5, 0));
-        $this->assertFalse(grapheme_substr($c, -5, 0));
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_substr
+     * @requires PHP < 8
+     */
+    public function testGraphemeSubstrReturnsFalsePrePHP8()
+    {
+        $c = 'déjà';
+        $this->assertFalse(grapheme_substr($c, 5, 1));
+        $this->assertFalse(grapheme_substr($c, -5, 1));
+        $this->assertFalse(grapheme_substr($c, -42, 1));
+        $this->assertFalse(grapheme_substr($c, 42, 5));
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_substr
+     * @requires PHP 8
+     */
+    public function testGraphemeSubstrReturnsEmptyPostPHP8()
+    {
+        $c = 'déjà';
+        $this->assertSame('', grapheme_substr($c, 5, 1));
+        $this->assertSame('d', grapheme_substr($c, -5, 1));
+        $this->assertSame('d', grapheme_substr($c, -42, 1));
+        $this->assertSame('', grapheme_substr($c, 42, 5));
     }
 
     /**


### PR DESCRIPTION
`grapheme_substr` is changed in [PHP 8.0 to return an empty string on out-of-bound offsets](https://php.watch/versions/8.0/substr-out-of-bounds#grapheme_substr).

This commit updates the tests with `@requires` annotations and polyfill updates to make sure the return results are in line with native function behavior. In PHP 8, an empty string (`""`) is returned if the length parameter is out of bounds of the given string. Prior to PHP 8.0, boolean `false` is returned.

Related: #288