### PR TITLE
Improve performances of array_key_last

### DIFF
--- a/src/Php73/bootstrap.php
+++ b/src/Php73/bootstrap.php
@@ -27,5 +27,5 @@ if (!function_exists('array_key_first')) {
     function array_key_first(array $array) { foreach ($array as $key => $value) { return $key; } }
 }
 if (!function_exists('array_key_last')) {
-    function array_key_last(array $array) { end($array); return key($array); }
+    function array_key_last(array $array) { key(array_slice($array, -1, 1, true)); }
 }


### PR DESCRIPTION
Suggested by @donaldinou   (fix #293 )

up to 6 times faster on big arrays like `array_fill(0, 1024*1024, 'hello');`

https://blackfire.io/profiles/05de3d1f-0193-462d-839f-361c4c206a0d/graph