### PR TITLE
Additional fixes in `iconv_substr` for PHP 8

### DIFF
--- a/src/Iconv/Iconv.php
+++ b/src/Iconv/Iconv.php
@@ -541,7 +541,7 @@ final class Iconv
             $start += $slen;
         }
         if (0 > $start) {
-            return false;
+            return \PHP_VERSION_ID >= 80000 ? '' : false;
         }
         if ($start >= $slen) {
             return \PHP_VERSION_ID >= 80000 ? '' : false;
@@ -556,7 +556,7 @@ final class Iconv
             return '';
         }
         if (0 > $length) {
-            return false;
+            return \PHP_VERSION_ID >= 80000 ? '' : false;
         }
 
         if ($length > $rx) {

--- a/tests/Iconv/IconvTest.php
+++ b/tests/Iconv/IconvTest.php
@@ -80,16 +80,22 @@ class IconvTest extends TestCase
      */
     public function testIconvSubstrReturnsFalsePrePHP8()
     {
-        $this->assertFalse(iconv_substr('x', 5, 1, 'UTF-8'));
+        $c = 'déjà';
+        $this->assertFalse(iconv_substr($c, 42, 1, 'UTF-8'));
+        $this->assertFalse(iconv_substr($c, -42, 0));
+        $this->assertFalse(iconv_substr($c, 42, 26));
     }
 
     /**
      * @covers \Symfony\Polyfill\Iconv\Iconv::iconv_substr
-     * @requires PHP >= 8.0.0
+     * @requires PHP 8.0.0
      */
     public function testIconvSubstrReturnsEmptyPostPHP8()
     {
-        $this->assertSame('', iconv_substr('x', 5, 1, 'UTF-8'));
+        $c = 'déjà';
+        $this->assertSame('', iconv_substr($c, 42, 1, 'UTF-8'));
+        $this->assertSame('', iconv_substr($c, -42, 0));
+        $this->assertSame('', iconv_substr($c, 42, 26));
     }
 
     /**


### PR DESCRIPTION
Related: #289 and #297
This PR further improves the `iconv_substr` polyfill to return empty strings on out-of-bound string offsets and lengths. The PR #289 was unfortunately not complete, and this PR brings both `iconv_substr` to the same level of `grapheme_substr` functionality.