### PR TITLE
Code cleanup: Remove redundant else/elseif blocks

### DIFF
--- a/src/Iconv/Iconv.php
+++ b/src/Iconv/Iconv.php
@@ -623,9 +623,9 @@ final class Iconv
                     trigger_error(self::ERROR_ILLEGAL_CHARACTER);
 
                     return false;
-                } else {
-                    $i += $ulen;
                 }
+
+                $i += $ulen;
 
                 $u[$j++] = $uchr[0];
 
@@ -679,9 +679,9 @@ final class Iconv
                 if ($ignore && (1 === $ulen || !($valid || preg_match('/^.$/us', $uchr)))) {
                     ++$i;
                     continue;
-                } else {
-                    $i += $ulen;
                 }
+
+                $i += $ulen;
             }
 
             if (isset($map[$uchr])) {

--- a/src/Intl/Idn/Idn.php
+++ b/src/Intl/Idn/Idn.php
@@ -703,7 +703,9 @@ final class Idn
             foreach ($iter as $codePoint) {
                 if ($codePoint < $n && 0 === ++$delta) {
                     throw new Exception('Integer overflow');
-                } elseif ($codePoint === $n) {
+                }
+
+                if ($codePoint === $n) {
                     $q = $delta;
 
                     for ($k = self::BASE; /* no condition */; $k += self::BASE) {


### PR DESCRIPTION
A very minor improvement in code clarity. Removed `else` and `elseif` blocks where the previous code block has `return`, `continue`, or `throw` calls, where the execution flaw is halted anyway. 

Thank you.