### PR TITLE
Do not run tests on fork's branchs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
     push:
+        branches:
+            - main
     pull_request:
 
 jobs:


### PR DESCRIPTION
Currently, when pushing a new commit to a PR, the job is played twice:
- on `symfony/polyfill` for the `PR` event
- on `my-user/polyfill` for the `push` event

This PR prevent GA running on "push" when branch is not main.
- do not run test on user's fork
- but STILL run tests when maintainer merge the PR on the `main` branch