### PR TITLE
Skip tests of the 7.2/7.4 polyfills that cause Errors on PHP 8

### DIFF
--- a/tests/Php72/Php72Test.php
+++ b/tests/Php72/Php72Test.php
@@ -70,7 +70,14 @@ class Php72Test extends TestCase
         $dump = ob_get_clean();
 
         $this->assertStringContainsString("#$id ", $dump);
+    }
 
+    /**
+     * @covers \Symfony\Polyfill\Php72\Php72::spl_object_id
+     * @requires PHP < 8
+     */
+    public function testSplObjectIdWithInvalidType()
+    {
         $this->assertNull(@spl_object_id(123));
     }
 
@@ -150,6 +157,7 @@ class Php72Test extends TestCase
 
     /**
      * @covers \Symfony\Polyfill\Php72\Php72::stream_isatty
+     * @requires PHP < 8
      */
     public function testStreamIsattyWarnsOnInvalidInputType()
     {

--- a/tests/Php74/Php74Test.php
+++ b/tests/Php74/Php74Test.php
@@ -54,6 +54,7 @@ class Php74Test extends TestCase
 
     /**
      * @covers \Symfony\Polyfill\Php74\Php74::get_mangled_object_vars
+     * @requires PHP < 8
      */
     public function testGetMangledObjectVarsOnNonObject()
     {
@@ -96,6 +97,14 @@ class Php74Test extends TestCase
         $this->assertSame(array('źr', 'ebi', 'ę'), mb_str_split('źrebię', 3, 'ASCII'));
         $this->assertSame(array('alpha', 'bet'), mb_str_split('alphabet', 5));
         $this->assertSame(array('e', '́', '💩', '𐍈'), mb_str_split('é💩𐍈', 1, 'UTF-8'));
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php74\Php74::mb_str_split
+     * @requires PHP < 8
+     */
+    public function testStrSplitWithInvalidValues()
+    {
         $this->assertSame(array(), mb_str_split('', 1, 'UTF-8'));
         $this->assertFalse(@mb_str_split('победа', 0));
         $this->assertNull(@mb_str_split(array(), 0));


### PR DESCRIPTION
Some functions that were added with PHP 7.2/7.4 have been made a bit stricter with PHP 8: They now trigger `TypeError`s and `ValueError`s on invalid input.

I think the PHP 7.2 polyfill should implement the polyfilled functions as they were shipped with PHP 7.2. Because of that, I think we can skip the affected tests on PHP 8.