### PR TITLE
[PHP 8.1] Add `CURLStringFile` polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.28.0
+
+  * Add `CURLStringFile` class introduced in PHP 8.1 (but only if PHP >= 7.4 is used)
+
 # 1.27.0
 
   * Add PHP 8.3 polyfill for `json_validate()`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Polyfills are provided for:
 - the `enum_exists` function introduced in PHP 8.1;
 - the `MYSQLI_REFRESH_REPLICA` constant introduced in PHP 8.1;
 - the `ReturnTypeWillChange` attribute introduced in PHP 8.1;
+- the `CURLStringFile` class introduced in PHP 8.1 (but only if PHP >= 7.4 is used);
 - the `AllowDynamicProperties` attribute introduced in PHP 8.2;
 - the `SensitiveParameter` attribute introduced in PHP 8.2;
 - the `SensitiveParameterValue` class introduced in PHP 8.2;

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
             "src/Intl/MessageFormatter/Resources/stubs",
             "src/Intl/Normalizer/Resources/stubs",
             "src/Php82/Resources/stubs",
+            "src/Php81/Resources/stubs",
             "src/Php80/Resources/stubs",
             "src/Php73/Resources/stubs"
         ]

--- a/src/Apcu/composer.json
+++ b/src/Apcu/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Ctype/composer.json
+++ b/src/Ctype/composer.json
@@ -31,7 +31,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Iconv/composer.json
+++ b/src/Iconv/composer.json
@@ -31,7 +31,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Intl/Grapheme/composer.json
+++ b/src/Intl/Grapheme/composer.json
@@ -28,7 +28,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Intl/Icu/composer.json
+++ b/src/Intl/Icu/composer.json
@@ -32,7 +32,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Intl/Idn/composer.json
+++ b/src/Intl/Idn/composer.json
@@ -34,7 +34,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Intl/MessageFormatter/composer.json
+++ b/src/Intl/MessageFormatter/composer.json
@@ -29,7 +29,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Intl/Normalizer/composer.json
+++ b/src/Intl/Normalizer/composer.json
@@ -29,7 +29,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Mbstring/composer.json
+++ b/src/Mbstring/composer.json
@@ -31,7 +31,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Php72/composer.json
+++ b/src/Php72/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Php73/composer.json
+++ b/src/Php73/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Php74/composer.json
+++ b/src/Php74/composer.json
@@ -29,7 +29,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Php80/composer.json
+++ b/src/Php80/composer.json
@@ -30,7 +30,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Php81/README.md
+++ b/src/Php81/README.md
@@ -7,6 +7,7 @@ This component provides features added to PHP 8.1 core:
 - [`enum_exists`](https://php.net/enum-exists)
 - [`MYSQLI_REFRESH_REPLICA`](https://php.net/mysqli.constants#constantmysqli-refresh-replica) constant
 - [`ReturnTypeWillChange`](https://wiki.php.net/rfc/internal_method_return_types)
+- [`CURLStringFile`](https://php.net/CURLStringFile) (but only if PHP >= 7.4 is used)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).

--- a/src/Php81/Resources/stubs/CURLStringFile.php
+++ b/src/Php81/Resources/stubs/CURLStringFile.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID >= 70400 && extension_loaded('curl')) {
+    /**
+     * @property string $data
+     */
+    class CURLStringFile extends CURLFile
+    {
+        private $data;
+
+        public function __construct(string $data, string $postname, string $mime = 'application/octet-stream')
+        {
+            $this->data = $data;
+            parent::__construct('data://application/octet-stream;base64,'.base64_encode($data), $mime, $postname);
+        }
+
+        public function __set(string $name, $value): void
+        {
+            if ('data' !== $name) {
+                $this->$name = $value;
+
+                return;
+            }
+
+            if (is_object($value) ? !method_exists($value, '__toString') : !is_scalar($value)) {
+                throw new \TypeError('Cannot assign '.gettype($value).' to property CURLStringFile::$data of type string');
+            }
+
+            $this->name = 'data://application/octet-stream;base64,'.base64_encode($value);
+        }
+
+        public function __isset(string $name): bool
+        {
+            return isset($this->$name);
+        }
+
+        public function &__get(string $name)
+        {
+            return $this->$name;
+        }
+    }
+}

--- a/src/Php81/composer.json
+++ b/src/Php81/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Php82/composer.json
+++ b/src/Php82/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Php83/composer.json
+++ b/src/Php83/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Util/composer.json
+++ b/src/Util/composer.json
@@ -24,7 +24,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Uuid/composer.json
+++ b/src/Uuid/composer.json
@@ -31,7 +31,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/src/Xml/composer.json
+++ b/src/Xml/composer.json
@@ -23,7 +23,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-main": "1.27-dev"
+            "dev-main": "1.28-dev"
         },
         "thanks": {
             "name": "symfony/polyfill",

--- a/tests/Php81/CURLStringFileTest.php
+++ b/tests/Php81/CURLStringFileTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Php81;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @requires extension curl
+ * @requires PHP 7.4
+ */
+class CURLStringFileTest extends TestCase
+{
+    private static $server;
+
+    public static function setUpBeforeClass(): void
+    {
+        $spec = [
+            1 => ['file', '/dev/null', 'w'],
+            2 => ['file', '/dev/null', 'w'],
+        ];
+        if (!self::$server = @proc_open(('\\' === \DIRECTORY_SEPARATOR ? '' : 'exec ').\PHP_BINARY.' -S localhost:8086', $spec, $pipes, __DIR__.'/fixtures')) {
+            self::markTestSkipped('Unable to start PHP server.');
+        }
+        sleep(1);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::$server) {
+            proc_terminate(self::$server);
+            proc_close(self::$server);
+        }
+    }
+    
+    public function testCurlFileShowsContents(): void
+    {
+        $file = new \CURLStringFile('Hello', 'symfony.txt', 'text/plain');
+        $data = ['test_file' => $file];
+
+        $ch = curl_init('http://localhost:8086/curl-echo-server.php');
+
+        curl_setopt($ch, CURLOPT_POST,1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        $response = curl_exec($ch);
+
+        $this->assertEquals(200, curl_getinfo($ch, CURLINFO_HTTP_CODE));
+        $this->assertSame('{"test_file":{"name":"symfony.txt","type":"text\/plain","error":0,"size":5}}', $response);
+    }
+}

--- a/tests/Php81/fixtures/curl-echo-server.php
+++ b/tests/Php81/fixtures/curl-echo-server.php
@@ -1,0 +1,10 @@
+<?php
+
+$output = $_FILES;
+foreach ($_FILES as $name => $file) {
+    if (\is_string($file['tmp_name'] ?? null)) {
+        unset($file['tmp_name'], $file['full_path']);
+        $output[$name] = $file;
+    }
+}
+echo json_encode($output);


### PR DESCRIPTION
PHP 8.1 adds a [new class `CURLStringFile`](https://php.watch/versions/8.1/CURLStringFile), that works similar to `CURLFile`, but does not require a _path_ to a file, and accepts a string of file contents instead. This can be polyfilled with a `CURLFile` sub class that uses a `data://` URI inside a constructure and calling `CURLFile::__construct` with that data URI.

Closes #333.

I will leave this as a draft because I'm not sure how to write tests for this. I'm thinking a PHP CLI server that echoes `$_FILES`, and a test that checks the returned content for file(s) that it uploaded.