### PR TITLE
PHP 7.3 fix

### DIFF
--- a/src/Intl/Idn/Idn.php
+++ b/src/Intl/Idn/Idn.php
@@ -142,12 +142,13 @@ final class Idn
      * @param int    $options
      * @param int    $variant
      * @param array  $idna_info
+     * @param int    $phpVersion
      *
      * @return string|false
      */
-    public static function idn_to_ascii($domainName, $options = self::IDNA_DEFAULT, $variant = self::INTL_IDNA_VARIANT_UTS46, &$idna_info = [])
+    public static function idn_to_ascii($domainName, $options = self::IDNA_DEFAULT, $variant = self::INTL_IDNA_VARIANT_UTS46, &$idna_info = [], $phpVersion = \PHP_VERSION_ID)
     {
-        if (\PHP_VERSION_ID >= 70200 && self::INTL_IDNA_VARIANT_2003 === $variant) {
+        if ($phpVersion >= 70400 && self::INTL_IDNA_VARIANT_2003 === $variant) {
             @trigger_error('idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated', \E_USER_DEPRECATED);
         }
 
@@ -195,12 +196,13 @@ final class Idn
      * @param int    $options
      * @param int    $variant
      * @param array  $idna_info
+     * @param int    $phpVersion
      *
      * @return string|false
      */
-    public static function idn_to_utf8($domainName, $options = self::IDNA_DEFAULT, $variant = self::INTL_IDNA_VARIANT_UTS46, &$idna_info = [])
+    public static function idn_to_utf8($domainName, $options = self::IDNA_DEFAULT, $variant = self::INTL_IDNA_VARIANT_UTS46, &$idna_info = [], $phpVersion = \PHP_VERSION_ID)
     {
-        if (\PHP_VERSION_ID >= 70200 && self::INTL_IDNA_VARIANT_2003 === $variant) {
+        if ($phpVersion >= 70400 && self::INTL_IDNA_VARIANT_2003 === $variant) {
             @trigger_error('idn_to_utf8(): INTL_IDNA_VARIANT_2003 is deprecated', \E_USER_DEPRECATED);
         }
 

--- a/src/Intl/Idn/Idn.php
+++ b/src/Intl/Idn/Idn.php
@@ -142,7 +142,6 @@ final class Idn
      * @param int    $options
      * @param int    $variant
      * @param array  $idna_info
-     * @param int    $phpVersion
      *
      * @return string|false
      */
@@ -196,7 +195,6 @@ final class Idn
      * @param int    $options
      * @param int    $variant
      * @param array  $idna_info
-     * @param int    $phpVersion
      *
      * @return string|false
      */

--- a/src/Intl/Idn/Idn.php
+++ b/src/Intl/Idn/Idn.php
@@ -146,9 +146,9 @@ final class Idn
      *
      * @return string|false
      */
-    public static function idn_to_ascii($domainName, $options = self::IDNA_DEFAULT, $variant = self::INTL_IDNA_VARIANT_UTS46, &$idna_info = [], $phpVersion = \PHP_VERSION_ID)
+    public static function idn_to_ascii($domainName, $options = self::IDNA_DEFAULT, $variant = self::INTL_IDNA_VARIANT_UTS46, &$idna_info = [])
     {
-        if ($phpVersion >= 70400 && self::INTL_IDNA_VARIANT_2003 === $variant) {
+        if (\PHP_VERSION_ID >= 70400 && self::INTL_IDNA_VARIANT_2003 === $variant) {
             @trigger_error('idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated', \E_USER_DEPRECATED);
         }
 
@@ -200,9 +200,9 @@ final class Idn
      *
      * @return string|false
      */
-    public static function idn_to_utf8($domainName, $options = self::IDNA_DEFAULT, $variant = self::INTL_IDNA_VARIANT_UTS46, &$idna_info = [], $phpVersion = \PHP_VERSION_ID)
+    public static function idn_to_utf8($domainName, $options = self::IDNA_DEFAULT, $variant = self::INTL_IDNA_VARIANT_UTS46, &$idna_info = [])
     {
-        if ($phpVersion >= 70400 && self::INTL_IDNA_VARIANT_2003 === $variant) {
+        if (\PHP_VERSION_ID >= 70400 && self::INTL_IDNA_VARIANT_2003 === $variant) {
             @trigger_error('idn_to_utf8(): INTL_IDNA_VARIANT_2003 is deprecated', \E_USER_DEPRECATED);
         }
 

--- a/tests/Intl/Idn/IdnTest.php
+++ b/tests/Intl/Idn/IdnTest.php
@@ -288,15 +288,6 @@ class IdnTest extends TestCase
         $this->assertSame($encoded, $result);
     }
 
-    /**
-     * @dataProvider domainNamesProvider
-     */
-    public function testEncodeDefaultPhp73($decoded, $encoded)
-    {
-        $result = @Idn::idn_to_ascii($decoded, \IDNA_DEFAULT, \INTL_IDNA_VARIANT_2003, $info, 70324);
-        $this->assertSame($encoded, $result);
-    }
-
     public function domainNamesProvider()
     {
         return [

--- a/tests/Intl/Idn/IdnTest.php
+++ b/tests/Intl/Idn/IdnTest.php
@@ -288,6 +288,15 @@ class IdnTest extends TestCase
         $this->assertSame($encoded, $result);
     }
 
+    /**
+     * @dataProvider domainNamesProvider
+     */
+    public function testEncodeDefaultPhp73($decoded, $encoded)
+    {
+        $result = @Idn::idn_to_ascii($decoded, \IDNA_DEFAULT, \INTL_IDNA_VARIANT_2003, $info, 70324);
+        $this->assertSame($encoded, $result);
+    }
+
     public function domainNamesProvider()
     {
         return [


### PR DESCRIPTION
For PHP 7.3 default variant is INTL_IDNA_VARIANT_2003:

```
if (\PHP_VERSION_ID < 70400) {
    if (!function_exists('idn_to_ascii')) {
        function idn_to_ascii($domain, $flags = 0, $variant = \INTL_IDNA_VARIANT_2003, &$idna_info = null) { return p\Idn::idn_to_ascii($domain, $flags, $variant, $idna_info); }
    }
    if (!function_exists('idn_to_utf8')) {
        function idn_to_utf8($domain, $flags = 0, $variant = \INTL_IDNA_VARIANT_2003, &$idna_info = null) { return p\Idn::idn_to_utf8($domain, $flags, $variant, $idna_info); }
    }
}
```

But in Idn.php script executes error for INTL_IDNA_VARIANT_2003.

```
        if (\PHP_VERSION_ID >= 70200 && self::INTL_IDNA_VARIANT_2003 === $variant) {
            @trigger_error('idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated', \E_USER_DEPRECATED);
        }
```

In result all default functions like idn_to_ascii('demo.com') and idn_to_utf8('demo.com') are not working.
