### PR TITLE
[PHP 8.1] Add MYSQLI_REFRESH_REPLICA polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * added `CURLStringFile` to the PHP 8.1 polyfill
   * added `enum_exists()` to the PHP 8.1 polyfill
   * removed `INTL_IDNA_VARIANT_2003` on PHP 8
+  * added `MYSQLI_REFRESH_REPLICA` constant to PHP 8.1 polyfill
 
 # 1.22.1
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Polyfills are provided for:
 - the `get_resource_id` function introduced in PHP 8.0;
 - the `Attribute` class introduced in PHP 8.0;
 - the `Stringable` interface introduced in PHP 8.0;
+- the `array_is_list` function introduced in PHP 8.1;
+- the `MYSQLI_REFRESH_REPLICA` constant introduced in PHP 8.1;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no
@@ -85,6 +87,7 @@ should **not** `require` the `symfony/polyfill` package, but the standalone ones
 - `symfony/polyfill-php73` for using the PHP 7.3 functions,
 - `symfony/polyfill-php74` for using the PHP 7.4 functions,
 - `symfony/polyfill-php80` for using the PHP 8.0 functions,
+- `symfony/polyfill-php81` for using the PHP 8.1 functions,
 - `symfony/polyfill-iconv` for using the iconv functions,
 - `symfony/polyfill-intl-grapheme` for using the `grapheme_*` functions,
 - `symfony/polyfill-intl-idn` for using the `idn_to_ascii` and `idn_to_utf8` functions,

--- a/src/Php81/README.md
+++ b/src/Php81/README.md
@@ -1,9 +1,10 @@
-Symfony Polyfill / Php80
+Symfony Polyfill / Php81
 ========================
 
 This component provides features added to PHP 8.1 core:
 
 - [`array_is_list`](https://php.net/array_is_list)
+- [`MYSQLI_REFRESH_REPLICA`](https://www.php.net/manual/en/mysqli.constants.php#constantmysqli-refresh-replica) constant
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).

--- a/src/Php81/bootstrap.php
+++ b/src/Php81/bootstrap.php
@@ -15,6 +15,10 @@ if (\PHP_VERSION_ID >= 80100) {
     return;
 }
 
+if (defined('MYSQLI_REFRESH_SLAVE') && !defined('MYSQLI_REFRESH_REPLICA')) {
+    define('MYSQLI_REFRESH_REPLICA', MYSQLI_REFRESH_SLAVE);
+}
+
 if (!function_exists('array_is_list')) {
     function array_is_list(array $array): bool { return p\Php81::array_is_list($array); }
 }

--- a/tests/Php81/Php81Test.php
+++ b/tests/Php81/Php81Test.php
@@ -27,4 +27,13 @@ class Php81Test extends TestCase
         $this->assertFalse(array_is_list([0 => 'a', 2 => 'b']));
         $this->assertFalse(array_is_list([1 => 'a', 2 => 'b']));
     }
+
+    /**
+     * @requires extension mysqli
+     */
+    public function testMysqliRefreshReplicaDefined()
+    {
+        $this->assertTrue(defined('MYSQLI_REFRESH_REPLICA'));
+        $this->assertSame(MYSQLI_REFRESH_SLAVE, MYSQLI_REFRESH_REPLICA);
+    }
 }


### PR DESCRIPTION
This PR adds `MYSQLI_REFRESH_REPLICA` constant which equals to `MYSQLI_REFRESH_SLAVE`. This will allow users to move to new naming convention even before it is deprecated by PHP and MySQL.