### PR TITLE
[PHP 8.1] Fiber exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
             "src/Intl/MessageFormatter/Resources/stubs",
             "src/Intl/Normalizer/Resources/stubs",
             "src/Php80/Resources/stubs",
+            "src/Php81/Resources/stubs",
             "src/Php73/Resources/stubs"
         ]
     },

--- a/src/Php81/README.md
+++ b/src/Php81/README.md
@@ -4,6 +4,7 @@ Symfony Polyfill / Php80
 This component provides features added to PHP 8.1 core:
 
 - [`array_is_list`](https://php.net/array_is_list)
+- `FiberError` and `FiberExit` exception classes
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).

--- a/src/Php81/Resources/stubs/FiberError.php
+++ b/src/Php81/Resources/stubs/FiberError.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Exception thrown due to invalid fiber actions, such as resuming a terminated fiber.
+ */
+final class FiberError extends Error
+{
+    /**
+     * Constructor throws to prevent user code from throwing FiberError.
+     */
+    public function __construct()
+    {
+        throw new \Error('The "FiberError" class is reserved for internal use and cannot be manually instantiated');
+    }
+}

--- a/src/Php81/Resources/stubs/FiberExit.php
+++ b/src/Php81/Resources/stubs/FiberExit.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Exception thrown when destroying a fiber. This exception cannot be caught by user code.
+ */
+final class FiberExit extends Exception
+{
+    /**
+     * Constructor throws to prevent user code from throwing FiberExit.
+     */
+    public function __construct()
+    {
+        throw new \Error('The "FiberExit" class is reserved for internal use and cannot be manually instantiated');
+    }
+}

--- a/src/Php81/composer.json
+++ b/src/Php81/composer.json
@@ -20,7 +20,8 @@
     },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Php81\\": "" },
-        "files": [ "bootstrap.php" ]
+        "files": [ "bootstrap.php" ],
+        "classmap": [ "Resources/stubs" ]
     },
     "minimum-stability": "dev",
     "extra": {

--- a/tests/Php81/Php81Test.php
+++ b/tests/Php81/Php81Test.php
@@ -27,4 +27,10 @@ class Php81Test extends TestCase
         $this->assertFalse(array_is_list([0 => 'a', 2 => 'b']));
         $this->assertFalse(array_is_list([1 => 'a', 2 => 'b']));
     }
+
+    public function testFiberThrowablesExist()
+    {
+        $this->assertTrue(class_exists('\FiberError'));
+        $this->assertTrue(class_exists('\FiberExit'));
+    }
 }


### PR DESCRIPTION
The Fiber [RFC](https://wiki.php.net/rfc/fibers) is concluding today with 48:14 in favor. So it looks like it will pass and we will get Fibers in PHP 8.1 🎉🍾.  I'm getting ahead of myself, but this RFC is just as good as passed now :)

While we cannot bring the main `Fiber` class, I think bringing [`FiberError`](https://php.watch/versions/8.1/fibers#FiberError) (extends `\Error`) and [`FiberExit`](https://php.watch/versions/8.1/fibers#FiberExit) (extends `\Exception`) can help bring cross-version compatibility for error logs (that serialize exceptions), and elsewhere Exceptions are dealt with. 

We previously added Exception classes (such as `ValueError` and `match` expressions exceptions) to PHP 8.0 polyfill on similar use cases. 