### PR TITLE
Add ReturnTypeWillChange attribute

### DIFF
--- a/src/Php81/README.md
+++ b/src/Php81/README.md
@@ -5,6 +5,7 @@ This component provides features added to PHP 8.1 core:
 
 - [`array_is_list`](https://php.net/array_is_list)
 - [`MYSQLI_REFRESH_REPLICA`](https://www.php.net/manual/en/mysqli.constants.php#constantmysqli-refresh-replica) constant
+- [`ReturnTypeWillChange`](https://wiki.php.net/rfc/internal_method_return_types)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).

--- a/src/Php81/Resources/stubs/ReturnTypeWillChange.php
+++ b/src/Php81/Resources/stubs/ReturnTypeWillChange.php
@@ -1,0 +1,9 @@
+<?php
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class ReturnTypeWillChange
+{
+    public function __construct()
+    {
+    }
+}

--- a/src/Php81/composer.json
+++ b/src/Php81/composer.json
@@ -20,7 +20,8 @@
     },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Php81\\": "" },
-        "files": [ "bootstrap.php" ]
+        "files": [ "bootstrap.php" ],
+        "classmap": [ "Resources/stubs" ]
     },
     "minimum-stability": "dev",
     "extra": {


### PR DESCRIPTION
I'd like to add this nice little class that I've found in my PHP 8.1 nightly build.

```php
dump(new ReflectionClass(\ReturnTypeWillChange::class));
```

<img width="354" alt="Bildschirmfoto 2021-05-21 um 15 23 19" src="https://user-images.githubusercontent.com/1506493/119144552-0f7a8a00-ba49-11eb-845d-5d25f158f64b.png">

