### PR TITLE
[Php81] Optimize `array_is_list`

### DIFF
--- a/src/Php81/Php81.php
+++ b/src/Php81/Php81.php
@@ -20,7 +20,7 @@ final class Php81
 {
     public static function array_is_list(array $array): bool
     {
-        if ([] === $array) {
+        if ([] === $array || $array === array_values($array)) {
             return true;
         }
 

--- a/tests/Php81/Php81Test.php
+++ b/tests/Php81/Php81Test.php
@@ -26,6 +26,10 @@ class Php81Test extends TestCase
         $this->assertFalse(array_is_list(['a' => 'b']));
         $this->assertFalse(array_is_list([0 => 'a', 2 => 'b']));
         $this->assertFalse(array_is_list([1 => 'a', 2 => 'b']));
+
+        $x = ['key' => 2, NAN];
+        unset($x['key']);
+        $this->assertTrue(array_is_list($x));
     }
 
     /**


### PR DESCRIPTION
Hey there,

I've used this function quite a lot and I see a massive performance gap between [webmozart/assert](https://github.com/webmozarts/assert/blob/f07851c5b43e4cb502c24068620e9af6cbdd953f/src/Assert.php#L1823) and this polyfill.
https://3v4l.org/ruYVL

This polyfill covers a niche case with `\NAN` and thus, my previous attempt in #355 failed.

So I've worked out another solution which is still a little bit faster than the current one.
https://3v4l.org/KiCg2