### PR TITLE
[PHP80] Prevent redefinition of PHP 8.0 classes

### DIFF
--- a/src/Php80/Resources/stubs/UnhandledMatchError.php
+++ b/src/Php80/Resources/stubs/UnhandledMatchError.php
@@ -1,5 +1,7 @@
 <?php
 
-class UnhandledMatchError extends Error
-{
+if (\PHP_VERSION_ID < 80000) {
+    class UnhandledMatchError extends Error
+    {
+    }
 }

--- a/src/Php80/Resources/stubs/ValueError.php
+++ b/src/Php80/Resources/stubs/ValueError.php
@@ -1,5 +1,7 @@
 <?php
 
-class ValueError extends Error
-{
+if (\PHP_VERSION_ID < 80000) {
+    class ValueError extends Error
+    {
+    }
 }


### PR DESCRIPTION
Not redeclaring polyfilled classes when PHP version is 8.0 or above.
The same approach is used for the Stringable interface in [this commit](https://github.com/symfony/polyfill/commit/8a3e84999b869b30bc8688eb3784681028007d5e).

One of my scripts runs [`opcache_compile_file`](https://www.php.net/manual/en/function.opcache-compile-file.php) on vendor files, including symfony. I'm in the process of upgrading to PHP 8. Running `opcache_compile_file` on either of the modified files causes a fatal error `Fatal error: Cannot declare class ValueError/UnhandledMatchError, because the name is already in use`.
That's not the case on PHP versions below 8.