### PR TITLE
[PHP 8.1] [PHP 7.3] Preventing redeclaration of PHP version related class stubs.

### DIFF
--- a/src/Php73/Resources/stubs/JsonException.php
+++ b/src/Php73/Resources/stubs/JsonException.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
-class JsonException extends Exception
-{
+if (\PHP_VERSION_ID < 70300) {
+    class JsonException extends Exception
+    {
+    }
 }

--- a/src/Php81/Resources/stubs/ReturnTypeWillChange.php
+++ b/src/Php81/Resources/stubs/ReturnTypeWillChange.php
@@ -1,9 +1,11 @@
 <?php
 
-#[Attribute(Attribute::TARGET_METHOD)]
-final class ReturnTypeWillChange
-{
-    public function __construct()
+if (\PHP_VERSION_ID < 80100) {
+    #[Attribute(Attribute::TARGET_METHOD)]
+    final class ReturnTypeWillChange
     {
+        public function __construct()
+        {
+        }
     }
 }


### PR DESCRIPTION
Same as https://github.com/symfony/polyfill/pull/359, only for other PHP version related class stubs.