### PR TITLE
[Mbstring] fix throwing from mb_substitute_character on PHP >= 8

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -602,6 +602,9 @@ final class Mbstring
         if (80000 > \PHP_VERSION_ID) {
             return false;
         }
+        if (\is_int($c) || 'long' === $c || 'entity' === $c) {
+            return false;
+        }
 
         throw new \ValueError('Argument #1 ($substitute_character) must be "none", "long", "entity" or a valid codepoint');
     }


### PR DESCRIPTION
While #322 correctly introduced the ValueError thrown for incorrect values, the exception is also thrown for various cases where the input to the function is actually accepted. 

While this PR does in no way improve the functionality of the mb_substitute_character polyfill (which might be needed to at some point, as the input is not used at all, currently), it does improve the compatibility with the function that is being polyfilled.