### PR TITLE
Indicates that polyfills provides corresponding extensions

### DIFF
--- a/src/Ctype/composer.json
+++ b/src/Ctype/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=7.1"
     },
+    "provide": {
+        "ext-ctype": "*"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Ctype\\": "" },
         "files": [ "bootstrap.php" ]

--- a/src/Iconv/composer.json
+++ b/src/Iconv/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=7.1"
     },
+    "provide": {
+        "ext-iconv": "*"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Iconv\\": "" },
         "files": [ "bootstrap.php" ]

--- a/src/Mbstring/composer.json
+++ b/src/Mbstring/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=7.1"
     },
+    "provide": {
+        "ext-mbstring": "*"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Mbstring\\": "" },
         "files": [ "bootstrap.php" ]

--- a/src/Uuid/composer.json
+++ b/src/Uuid/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=7.1"
     },
+    "provide": {
+        "ext-uuid": "*"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Uuid\\": "" },
         "files": [ "bootstrap.php" ]


### PR DESCRIPTION
Hi,

Here are the results of some tests I made. ~~Results are the same on both composer v1.10.23 and v2.1.9.~~ Results are valid on composer v2.0.14 and v2.1.9.

Adding the `"provide": {"ext-mbstring": "*"}` will permit to install a dependency that requires this extension without actually having it installed.

I tested this behaviour on a PHP docker image I built without `ext-mbstring`, following this `composer.json` file. The forked `polyfill-mbstring` repository contains a 2.0.0 tag that contains the `"provide": {"ext-mbstring": "*"}` instruction.
```json
{
    "name": "foo/bar",
    "require": {
        "sabre/vobject": "^4.1"
    },
    "repositories": {
        "polyfill-mbstring": {
            "type": "git",
            "url": "https://github.com/cedric-anne/polyfill-mbstring.git"
        }
    }
}
```

Running `composer install` command fails with following error.
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - sabre/vobject[4.1.0, ..., 4.3.5] require ext-mbstring * -> it is missing from your system. Install or enable PHP's mbstring extension.
    - sabre/vobject[4.3.0, ..., 4.3.1] require php ^7.1 -> your php version (8.0.11) does not satisfy that requirement.
    - Root composer.json requires sabre/vobject ^4.1 -> satisfiable by sabre/vobject[4.1.0, ..., 4.3.5].
```

But installation will work as expected when the `polyfill-mbstring` is required.
```
$ composer require symfony/polyfill-mbstring
Using version ^2.0 for symfony/polyfill-mbstring
./composer.json has been updated
Running composer update symfony/polyfill-mbstring
Loading composer repositories with package information
Updating dependencies                                 
Lock file operations: 4 installs, 0 updates, 0 removals
  - Locking sabre/uri (2.2.1)
  - Locking sabre/vobject (4.3.5)
  - Locking sabre/xml (2.2.3)
  - Locking symfony/polyfill-mbstring (2.0.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 4 installs, 0 updates, 0 removals
  - Downloading symfony/polyfill-mbstring (2.0.0)
  - Installing sabre/uri (2.2.1): Extracting archive
  - Installing sabre/xml (2.2.3): Extracting archive
  - Installing symfony/polyfill-mbstring (2.0.0): Extracting archive
  - Installing sabre/vobject (4.3.5): Extracting archive
1 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
```

Closes #375