### PR TITLE
Prevent Cannot declare interface Stringable with multiple vendor folders

### DIFF
--- a/src/Php80/Resources/stubs/Stringable.php
+++ b/src/Php80/Resources/stubs/Stringable.php
@@ -1,6 +1,6 @@
 <?php
 
-if (\PHP_VERSION_ID < 80000) {
+if (\PHP_VERSION_ID < 80000 && !interface_exists('Stringable')) {
     interface Stringable
     {
         /**


### PR DESCRIPTION
Hey,

PhpStan uses this polyfill and inspects using reflection the project files and loads again a Stringable interface. This breaks. 
A simple interface check fixes it for me. Idk if this is a good way to fix this behaviour