### PR TITLE
Optimize PHP8 polyfills

### DIFF
--- a/src/Php80/Php80.php
+++ b/src/Php80/Php80.php
@@ -100,6 +100,6 @@ final class Php80
 
     public static function str_ends_with(string $haystack, string $needle): bool
     {
-        return empty($needle) || 0 === substr_compare($haystack, $needle, -\strlen($needle));
+        return empty($needle) || (!empty($haystack) && 0 === substr_compare($haystack, $needle, -\strlen($needle));
     }
 }

--- a/src/Php80/Php80.php
+++ b/src/Php80/Php80.php
@@ -100,6 +100,6 @@ final class Php80
 
     public static function str_ends_with(string $haystack, string $needle): bool
     {
-        return empty($needle) || (!empty($haystack) && 0 === substr_compare($haystack, $needle, -\strlen($needle));
+        return empty($needle) || (!empty($haystack) && 0 === substr_compare($haystack, $needle, -\strlen($needle)));
     }
 }

--- a/src/Php80/Php80.php
+++ b/src/Php80/Php80.php
@@ -100,6 +100,6 @@ final class Php80
 
     public static function str_ends_with(string $haystack, string $needle): bool
     {
-        return 0 === substr_compare($haystack, $needle, -\strlen($needle));
+        return empty($needle) || 0 === substr_compare($haystack, $needle, -\strlen($needle));
     }
 }

--- a/src/Php80/Php80.php
+++ b/src/Php80/Php80.php
@@ -90,7 +90,7 @@ final class Php80
 
     public static function str_contains(string $haystack, string $needle): bool
     {
-        return '' === $needle || false !== strpos($haystack, $needle);
+        return empty($needle) || false !== strpos($haystack, $needle);
     }
 
     public static function str_starts_with(string $haystack, string $needle): bool
@@ -100,6 +100,6 @@ final class Php80
 
     public static function str_ends_with(string $haystack, string $needle): bool
     {
-        return '' === $needle || ('' !== $haystack && 0 === substr_compare($haystack, $needle, -\strlen($needle)));
+        return 0 === substr_compare($haystack, $needle, -\strlen($needle));
     }
 }


### PR DESCRIPTION
*updated*
faster than current version:
`str_contains()` ~ 0.001
`str_ends_with()` ~ 0.001

test matrix:
OS: Windows, Debian
PHP: 7.1, 7.4, 8.1

benchmark:
~~~php
<?php

function str_contains2(string $haystack, string $needle): bool
{
    return '' === $needle || false !== strpos($haystack, $needle);
}
function str_ends_with2(string $haystack, string $needle): bool
{
    return '' === $needle || ('' !== $haystack && 0 === substr_compare($haystack, $needle, -\strlen($needle)));
}

function str_contains3(string $haystack, string $needle): bool
{
    return empty($needle) || false !== strpos($haystack, $needle);
}
function str_ends_with3(string $haystack, string $needle): bool
{
    return empty($needle) || (!empty($haystack) && 0 === substr_compare($haystack, $needle, -\strlen($needle));
}

function benchStrContains($func)
{
    $func = 'str_contains' . $func;
    $start = microtime(true);
    $func('abc', '');
    $func('abc', 'a');
    $func('abc', 'bcf');
    $func('abc', 'bc c');
    $func('abc', 'abc');
    $func('한국어', '국');
    $func('한국어', '');
    $func('', '');
    $func('abc', 'd');
    $func('', 'd');
    $func('abc', 'abcd');
    $func('DÉJÀ', 'à');
    $func('a', 'à');
    return microtime(true) - $start;
}
function benchStrEndsWith($func)
{
    $func = 'str_ends_with' . $func;
    $start = microtime(true);
    $testStr = 'beginningMiddleEnd';
    $func($testStr, 'End');
    $func($testStr, 'end');
    $func($testStr, 'en');
    $func($testStr, $testStr);
    $func($testStr, $testStr.$testStr);
    $func($testStr, '');
    $func('', '');
    $func('', ' ');
    $func($testStr, "\x00");
    $func("\x00", '');
    $func("\x00", "\x00");
    $func("a\x00", "\x00");
    $func("ab\x00c", "b\x00c");
    $func("a\x00b", "d\x00b");
    $func("a\x00b", "a\x00z");
    $func('a', "\x00a");
    $func('a', "a\x00");
    $testMultiByte = 'අයේෂ්'; // 0xe0 0xb6 0x85 0xe0 0xb6 0xba 0xe0 0xb7 0x9a 0xe0 0xb7 0x82 0xe0 0xb7 0x8a
    $func($testMultiByte, 'ෂ්'); // 0xe0 0xb7 0x82 0xe0 0xb7 0x8a
    $func($testMultiByte, '්'); // 0xe0 0xb7 0x8a
    $func($testMultiByte, 'ෂ'); // 0xe0 0xb7 0x82
    $testEmoji = '🙌🎉✨🚀'; // 0xf0 0x9f 0x99 0x8c 0xf0 0x9f 0x8e 0x89 0xe2 0x9c 0xa8 0xf0 0x9f 0x9a 0x80
    $func($testEmoji, '🚀'); // 0xf0 0x9f 0x9a 0x80
    $func($testEmoji, '✨'); // 0xe2 0x9c 0xa8
    return microtime(true) - $start;
}

$suffixes = ['2', '3'];
$benchs = ['benchStrContains', 'benchStrEndsWith'];
$benchStrContains = ['2' => 0, '3' => 0];
$benchStrEndsWith = ['2' => 0, '3' => 0];

for($i = 0; $i < 10000; $i++) {
    shuffle($suffixes);
    shuffle($benchs);
    foreach ($benchs as $bench) {
        foreach ($suffixes as $suffix) {
            $$bench[$suffix] += $bench($suffix);
        }
    }
}
echo '<pre>';
var_dump(
    round($benchStrContains['2'] - $benchStrContains['3'], 6),
    round($benchStrEndsWith['2'] - $benchStrEndsWith['3'], 6)
);
echo '</pre>';
~~~