### PR TITLE
Fix iconv_mime_decode() while using mbstring extension

### DIFF
--- a/src/Iconv/bootstrap.php
+++ b/src/Iconv/bootstrap.php
@@ -62,7 +62,7 @@ if (extension_loaded('mbstring')) {
         function iconv_substr($string, $offset, $length = 2147483647, $encoding = null) { null === $encoding && $encoding = p\Iconv::$internalEncoding; return mb_substr($string, $offset, $length, $encoding); }
     }
     if (!function_exists('iconv_mime_decode')) {
-        function iconv_mime_decode($string, $mode = 0, $encoding = null) { null === $encoding && $encoding = p\Iconv::$internalEncoding; return mb_decode_mimeheader($string, $mode, $encoding); }
+        function iconv_mime_decode($string, $mode = 0, $encoding = null) { $currentMbEncoding = mb_internal_encoding(); null === $encoding && $encoding = p\Iconv::$internalEncoding; mb_internal_encoding($encoding); $decoded = mb_decode_mimeheader($string); mb_internal_encoding($currentMbEncoding); return $decoded; }
     }
 } else {
     if (!function_exists('iconv_strlen')) {

--- a/src/Iconv/bootstrap80.php
+++ b/src/Iconv/bootstrap80.php
@@ -54,7 +54,7 @@ if (extension_loaded('mbstring')) {
         function iconv_substr(?string $string, ?int $offset, ?int $length = null, ?string $encoding = null): string|false { null === $encoding && $encoding = p\Iconv::$internalEncoding; return mb_substr((string) $string, (int) $offset, $length, $encoding); }
     }
     if (!function_exists('iconv_mime_decode')) {
-        function iconv_mime_decode($string, $mode = 0, $encoding = null) { null === $encoding && $encoding = p\Iconv::$internalEncoding; return mb_decode_mimeheader($string, $mode, $encoding); }
+        function iconv_mime_decode($string, $mode = 0, $encoding = null) { $currentMbEncoding = mb_internal_encoding(); null === $encoding && $encoding = p\Iconv::$internalEncoding; mb_internal_encoding($encoding); $decoded = mb_decode_mimeheader($string); mb_internal_encoding($currentMbEncoding); return $decoded; }
     }
 } else {
     if (!function_exists('iconv_strlen')) {

--- a/tests/Iconv/IconvTest.php
+++ b/tests/Iconv/IconvTest.php
@@ -124,6 +124,8 @@ class IconvTest extends TestCase
             $this->assertSame('Illegal encoded-word:  .', iconv_mime_decode('Illegal encoded-word: =?utf-8?Q??= .', \ICONV_MIME_DECODE_CONTINUE_ON_ERROR));
             $this->assertSame('Illegal encoded-word: .', iconv_mime_decode('Illegal encoded-word: =?utf-8?Q?'.\chr(0xA1).'?= .', \ICONV_MIME_DECODE_CONTINUE_ON_ERROR));
         }
+        $this->assertSame(sprintf('Test: %s', 'проверка'), iconv_mime_decode('Test: =?windows-1251?B?7/Du4uXw6uA=?=', 0, 'UTF-8'));
+        $this->assertSame(sprintf('Test: %s', base64_decode('7/Du4uXw6uA=')), iconv_mime_decode('Test: =?windows-1251?B?7/Du4uXw6uA=?=', 0, 'windows-1251'));
     }
 
     /**

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -567,4 +567,16 @@ class MbstringTest extends TestCase
         static::assertFalse(mb_parse_str('', $result));
         static::assertFalse(mb_parse_str(null, $result));
     }
+
+    /**
+     * @covers \Symfony\Polyfill\Mbstring\Mbstring::mb_decode_mimeheader
+     */
+    public function testDecodeMimeheader()
+    {
+        $this->assertTrue(mb_internal_encoding('utf8'));
+        $this->assertSame(sprintf('Test: %s', 'проверка'), mb_decode_mimeheader('Test: =?windows-1251?B?7/Du4uXw6uA=?='));
+        $this->assertTrue(mb_internal_encoding('windows-1251'));
+        $this->assertSame(sprintf('Test: %s', base64_decode('7/Du4uXw6uA=')), mb_decode_mimeheader('Test: =?windows-1251?B?7/Du4uXw6uA=?='));
+        $this->assertTrue(mb_internal_encoding('utf8'));
+    }
 }


### PR DESCRIPTION
1. `mb_decode_mimeheader` has only one argument (see https://www.php.net/manual/en/function.mb-decode-mimeheader.php).

Calling it with 3 arguments triggers following error: `mb_decode_mimeheader() expects exactly 1 argument, 3 given in ./vendor/symfony/polyfill-iconv/bootstrap80.php at line 57`.

2. `iconv_mime_decode()` `$encoding` argument is not correctly handled. Indeed, it should be used to convert result in expected encoding.