### PR TITLE
fix: don't define this class twice

### DIFF
--- a/src/Php80/Resources/stubs/Stringable.php
+++ b/src/Php80/Resources/stubs/Stringable.php
@@ -1,6 +1,6 @@
 <?php
 
-if (\PHP_VERSION_ID < 80000) {
+if (\PHP_VERSION_ID < 80000 && !interface_exists('Stringable', false)) {
     interface Stringable
     {
         /**


### PR DESCRIPTION
In the detached Git-CI this class will be defined twice, for the PhpStan Check, if you are using the symfony package and the ObjectManager class for Doctrine parsing. This fix will define it only once.