### PR TITLE
Fix outdated DTD in configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.3/phpunit.xsd"
          colors="true"
          bootstrap="vendor/autoload.php"
 >


### PR DESCRIPTION
Update DTD to version declared in `required-dev` in `composer.json` to fix IDE's warnings.
Remove attribute `backupGlobals="false"` because it's default value.