### PR TITLE
Fix Php80Test::testFdiv()

### DIFF
--- a/tests/Php80/Php80Test.php
+++ b/tests/Php80/Php80Test.php
@@ -32,9 +32,9 @@ class Php80Test extends TestCase
         } catch (\DivisionByZeroError $e) {
             $result = $expected;
         }
-        $this->assertSame($expected, $result);
+        $this->assertEqualsWithDelta($expected, $result, 0.001);
         // Cast to string to detect negative zero "-0"
-        $this->assertSame((string) $expected, (string) $result);
+        $this->assertEquals(number_format($expected, 3), number_format($result, 3));
     }
 
     /**


### PR DESCRIPTION
Need using `$this->assertEqualsWithDelta()` to compare float values.
Why not use `$this->assertEquals()` or `$this->assertSame()`? Because `(0.1 * 0.1) / 0.1` not equal 0.1, it's ~0.10000000000000002