### PR TITLE
Fix QQQQQ date format

### DIFF
--- a/src/Intl/Icu/DateFormat/QuarterTransformer.php
+++ b/src/Intl/Icu/DateFormat/QuarterTransformer.php
@@ -33,10 +33,18 @@ class QuarterTransformer extends Transformer
                 return $this->padLeft($quarter, $length);
             case 3:
                 return 'Q'.$quarter;
-            default:
+            case 4:
                 $map = [1 => '1st quarter', 2 => '2nd quarter', 3 => '3rd quarter', 4 => '4th quarter'];
 
                 return $map[$quarter];
+            default:
+                if (\defined('INTL_ICU_VERSION') && version_compare(\INTL_ICU_VERSION, '70.1', '<')) {
+                    $map = [1 => '1st quarter', 2 => '2nd quarter', 3 => '3rd quarter', 4 => '4th quarter'];
+
+                    return $map[$quarter];
+                } else {
+                    return $quarter;
+                }
         }
     }
 

--- a/tests/Intl/Icu/AbstractIntlDateFormatterTest.php
+++ b/tests/Intl/Icu/AbstractIntlDateFormatterTest.php
@@ -81,6 +81,12 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
         $dateTime = new \DateTime('@0');
         $dateTimeImmutable = new \DateTimeImmutable('@0');
 
+        /* https://unicode-org.atlassian.net/browse/ICU-21647 */
+        $expectedQuarterX5 = '1';
+        if (\defined('INTL_ICU_VERSION') && version_compare(\INTL_ICU_VERSION, '70.1', '<')) {
+            $expectedQuarterX5 = '1st quarter';
+        }
+
         $formatData = [
             /* general */
             ['y-M-d', 0, '1970-1-1'],
@@ -129,13 +135,13 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
             ['QQ', 0, '01'],
             ['QQQ', 0, 'Q1'],
             ['QQQQ', 0, '1st quarter'],
-            ['QQQQQ', 0, '1st quarter'],
+            ['QQQQQ', 0, $expectedQuarterX5],
 
             ['q', 0, '1'],
             ['qq', 0, '01'],
             ['qqq', 0, 'Q1'],
             ['qqqq', 0, '1st quarter'],
-            ['qqqqq', 0, '1st quarter'],
+            ['qqqqq', 0, $expectedQuarterX5],
 
             // 4 months
             ['Q', 7776000, '2'],


### PR DESCRIPTION
As per [1], the QQQQQ and qqqqq quarter patterns are supposed to convert
quarter into numbers (1, 2, 3, or 4). Until vertion 70.1, ICU carried a
bug [2] which would make those patterns to convert into the wrong string,
mimicking the behavior of the QQQQ pattern. The issue has been fixed
upstream [3] and released in ICU 70.1.

This patch adjusts the pattern resolution according to the ICU version
being used by intl.

[1] https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table
[2] https://unicode-org.atlassian.net/browse/ICU-21647
[3] https://github.com/unicode-org/icu/commit/dcfdaca46c1e3cc08764ad1d85f321ad0c27ae16

Signed-off-by: Athos Ribeiro <athos.ribeiro@canonical.com>