### PR TITLE
Polyfill AllowDynamicProperties attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Polyfills are provided for:
 - the `enum_exists` function introduced in PHP 8.1;
 - the `MYSQLI_REFRESH_REPLICA` constant introduced in PHP 8.1;
 - the `ReturnTypeWillChange` attribute introduced in PHP 8.1;
+- the `AllowDynamicProperties` attribute introduced in PHP 8.2;
 - the `SensitiveParameter` attribute introduced in PHP 8.2;
 - the `SensitiveParameterValue` class introduced in PHP 8.2;
 

--- a/src/Php82/README.md
+++ b/src/Php82/README.md
@@ -3,11 +3,12 @@ Symfony Polyfill / Php82
 
 This component provides features added to PHP 8.2 core:
 
+- [`AllowDynamicProperties`](https://wiki.php.net/rfc/deprecate_dynamic_properties)
 - [`SensitiveParameter`](https://wiki.php.net/rfc/redact_parameters_in_back_traces)
 - [`SensitiveParameterValue`](https://wiki.php.net/rfc/redact_parameters_in_back_traces)
 
 More information can be found in the
-[main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
+[main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).
 
 License
 =======

--- a/src/Php82/Resources/stubs/AllowDynamicProperties.php
+++ b/src/Php82/Resources/stubs/AllowDynamicProperties.php
@@ -1,0 +1,11 @@
+<?php
+
+if (\PHP_VERSION_ID < 80200) {
+    #[Attribute(Attribute::TARGET_CLASS)]
+    final class AllowDynamicProperties
+    {
+        public function __construct()
+        {
+        }
+    }
+}


### PR DESCRIPTION
Provides a polyfill for `AllowDynamicProperties` attribute introduced in PHP 8.2.

RFC: https://wiki.php.net/rfc/deprecate_dynamic_properties

Fixes: #403 