### PR TITLE
[Intl] Fix the IntlDateFormatter::formatObject signature

### DIFF
--- a/src/Intl/Icu/IntlDateFormatter.php
+++ b/src/Intl/Icu/IntlDateFormatter.php
@@ -276,7 +276,7 @@ abstract class IntlDateFormatter
      *
      * @throws MethodNotImplementedException
      */
-    public function formatObject($datetime, $format = null, string $locale = null)
+    public static function formatObject($datetime, $format = null, string $locale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }


### PR DESCRIPTION
Following bug fix on Symfony Intl component, see https://github.com/symfony/symfony/pull/46730 for the full description.