### PR TITLE
[PHP 8.2] Add `ini_parse_quantity` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Polyfills are provided for:
 - the `AllowDynamicProperties` attribute introduced in PHP 8.2;
 - the `SensitiveParameter` attribute introduced in PHP 8.2;
 - the `SensitiveParameterValue` class introduced in PHP 8.2;
+- the `ini_parse_quantity` function introduced in PHP 8.2;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no

--- a/src/Php82/Php82.php
+++ b/src/Php82/Php82.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Php82;
+
+final class Php82
+{
+    // https://php.watch/versions/8.2/ini_parse_quantity#polyfill
+    public static function ini_parse_quantity(string $shorthand): int
+    {
+        $original_shorthand = $shorthand;
+        $multiplier = 1;
+        $sign = '';
+        $return_value = 0;
+
+        $shorthand = trim($shorthand);
+
+        // Return 0 for empty strings.
+        if ($shorthand === '') {
+            return 0;
+        }
+
+        // Accept + and - as the sign.
+        if ($shorthand[0] === '-' || $shorthand[0] === '+') {
+            if ($shorthand[0] === '-') {
+                $multiplier = -1;
+                $sign = '-';
+            }
+            $shorthand = substr($shorthand, 1);
+        }
+
+        // If there is no suffix, return the integer value with the sign.
+        if (preg_match('/^\d+$/', $shorthand, $matches)) {
+            return $multiplier * $matches[0];
+        }
+
+        // Return 0 with a warning if there are no leading digits
+        if (preg_match('/^\d/', $shorthand) === 0) {
+            trigger_error(
+                sprintf(
+                    'Invalid quantity "%s": no valid leading digits, interpreting as "0" for backwards compatibility',
+                    $original_shorthand
+                ),
+                E_USER_WARNING
+            );
+
+            return $return_value;
+        }
+
+        // Removing whitespace characters.
+        $shorthand = preg_replace('/\s/', '', $shorthand);
+
+        $suffix = strtoupper(substr($shorthand, -1));
+        switch ($suffix) {
+            case 'K':
+                $multiplier *= 1024;
+                break;
+            case 'M':
+                $multiplier *= 1024 * 1024;
+                break;
+            case 'G':
+                $multiplier *= 1024 * 1024 * 1024;
+                break;
+            default:
+                preg_match('/\d+/', $shorthand, $matches);
+                trigger_error(
+                    sprintf(
+                        'Invalid quantity "%s": unknown multiplier "%s", interpreting as "%d" for backwards compatibility',
+                        $original_shorthand,
+                        $suffix,
+                        $sign.$matches[0]
+                    ),
+                    E_USER_WARNING
+                );
+
+                return $matches[0] * $multiplier;
+        }
+
+        $stripped_shorthand = preg_replace('/^(\d+)(\D.*)([kKmMgG])$/', '$1$3', $shorthand, -1, $count);
+        if ($count > 0) {
+            trigger_error(
+                sprintf(
+                    'Invalid quantity "%s", interpreting as "%s" for backwards compatibility',
+                    $original_shorthand,
+                    $sign.$stripped_shorthand
+                ),
+                E_USER_WARNING
+            );
+        }
+
+        preg_match('/\d+/', $shorthand, $matches);
+
+        $multiplied = $matches[0] * $multiplier;
+        if (is_float($multiplied)) {
+            trigger_error(
+                sprintf(
+                    'Invalid quantity "%s": value is out of range, using overflow result for backwards compatibility',
+                    $original_shorthand
+                ),
+                E_USER_WARNING
+            );
+        }
+
+        return (int)($matches[0] * $multiplier);
+    }
+}

--- a/src/Php82/README.md
+++ b/src/Php82/README.md
@@ -6,6 +6,7 @@ This component provides features added to PHP 8.2 core:
 - [`AllowDynamicProperties`](https://wiki.php.net/rfc/deprecate_dynamic_properties)
 - [`SensitiveParameter`](https://wiki.php.net/rfc/redact_parameters_in_back_traces)
 - [`SensitiveParameterValue`](https://wiki.php.net/rfc/redact_parameters_in_back_traces)
+- [`ini_parse_quantity`](https://www.php.net/ini_parse_quantity)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).

--- a/src/Php82/bootstrap.php
+++ b/src/Php82/bootstrap.php
@@ -14,3 +14,7 @@ use Symfony\Polyfill\Php82 as p;
 if (\PHP_VERSION_ID >= 80200) {
     return;
 }
+
+if (!function_exists('ini_parse_quantity')) {
+    function ini_parse_quantity(string $shorthand): int { return p\Php82::ini_parse_quantity($shorthand); }
+}

--- a/tests/Php82/Php82Test.php
+++ b/tests/Php82/Php82Test.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Php82;
+
+use PHPUnit\Framework\TestCase;
+
+class Php82Test extends TestCase
+{
+    /**
+     * @covers \Symfony\Polyfill\Php82\Php82::ini_parse_quantity
+     */
+    public function testIniParseQuantity()
+    {
+        $this->assertSame(1024, ini_parse_quantity('1K'));
+        $this->assertSame(1024, ini_parse_quantity('1k'));
+        $this->assertSame(1024 * 1024 * 5, ini_parse_quantity('5M'));
+        $this->assertSame(1024 * 1024 * 5, ini_parse_quantity('5 M'));
+        $this->assertSame(1024 * 1024 * -5, ini_parse_quantity('-5M'));
+        $this->assertSame(-696969, ini_parse_quantity('-696969'));
+        $this->assertSame(696969, ini_parse_quantity('696969'));
+    }
+}


### PR DESCRIPTION
Polyfill taken from [PHP.Watch - PHP 8.2: New `ini_parse_quantity` function](https://php.watch/versions/8.2/ini_parse_quantity#polyfill)

Tries to mimic the native warnings with `E_USER_WARNING` errors, and overflow/underflow conditions by inspecting the int to float type change.