### PR TITLE
PHP 8.3: json_validate polyfill

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
                     - php: '8.0'
                     - php: '8.1'
                     - php: '8.2'
+                    - php: '8.3'
                       mode: experimental
             fail-fast: false
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Polyfills are provided for:
 - the `AllowDynamicProperties` attribute introduced in PHP 8.2;
 - the `SensitiveParameter` attribute introduced in PHP 8.2;
 - the `SensitiveParameterValue` class introduced in PHP 8.2;
+- the `json_validate` function introduced in PHP 8.3;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no
@@ -96,6 +97,7 @@ should **not** `require` the `symfony/polyfill` package, but the standalone ones
 - `symfony/polyfill-php80` for using the PHP 8.0 functions,
 - `symfony/polyfill-php81` for using the PHP 8.1 functions,
 - `symfony/polyfill-php82` for using the PHP 8.2 functions,
+- `symfony/polyfill-php83` for using the PHP 8.3 functions,
 - `symfony/polyfill-iconv` for using the iconv functions,
 - `symfony/polyfill-intl-grapheme` for using the `grapheme_*` functions,
 - `symfony/polyfill-intl-idn` for using the `idn_to_ascii` and `idn_to_utf8` functions,

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "symfony/polyfill-php80": "self.version",
         "symfony/polyfill-php81": "self.version",
         "symfony/polyfill-php82": "self.version",
+        "symfony/polyfill-php83": "self.version",
         "symfony/polyfill-iconv": "self.version",
         "symfony/polyfill-intl-grapheme": "self.version",
         "symfony/polyfill-intl-icu": "self.version",

--- a/src/Php83/LICENSE
+++ b/src/Php83/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2022 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Php83/Php83.php
+++ b/src/Php83/Php83.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Php83;
+
+/**
+ * @author Ion Bazan <ion.bazan@gmail.com>
+ *
+ * @internal
+ */
+final class Php83
+{
+    private const JSON_MAX_DEPTH = 0x7FFFFFFF; // see https://www.php.net/manual/en/function.json-decode.php
+
+    public static function json_validate(string $json, int $depth = 512, int $flags = 0): bool
+    {
+        if (0 !== $flags && \defined('JSON_INVALID_UTF8_IGNORE') && \JSON_INVALID_UTF8_IGNORE !== $flags) {
+            throw new \ValueError('json_validate(): Argument #3 ($flags) must be a valid flag (allowed flags: JSON_INVALID_UTF8_IGNORE)');
+        }
+
+        if ($depth <= 0) {
+            throw new \ValueError('json_validate(): Argument #2 ($depth) must be greater than 0');
+        }
+
+        if ($depth >= self::JSON_MAX_DEPTH) {
+            throw new \ValueError(sprintf('json_validate(): Argument #2 ($depth) must be less than %d', self::JSON_MAX_DEPTH));
+        }
+
+        json_decode($json, null, $depth, $flags);
+
+        return \JSON_ERROR_NONE === json_last_error();
+    }
+}

--- a/src/Php83/README.md
+++ b/src/Php83/README.md
@@ -1,0 +1,14 @@
+Symfony Polyfill / Php83
+========================
+
+This component provides features added to PHP 8.3 core:
+
+- [`json_validate`](https://wiki.php.net/rfc/json_validate)
+
+More information can be found in the
+[main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).
+
+License
+=======
+
+This library is released under the [MIT license](LICENSE).

--- a/src/Php83/bootstrap.php
+++ b/src/Php83/bootstrap.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\Php83 as p;
+
+if (\PHP_VERSION_ID >= 80300) {
+    return;
+}
+
+if (!function_exists('json_validate')) {
+    function json_validate(string $json, int $depth = 512, int $flags = 0): bool { return p\Php83::json_validate($json, $depth, $flags); }
+}

--- a/src/Php83/composer.json
+++ b/src/Php83/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "symfony/polyfill-php83",
+    "type": "library",
+    "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+    "keywords": ["polyfill", "shim", "compatibility", "portable"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Nicolas Grekas",
+            "email": "p@tchwork.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=7.1",
+        "symfony/polyfill-php80": "^1.14"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Polyfill\\Php83\\": "" },
+        "files": [ "bootstrap.php" ],
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.26-dev"
+        },
+        "thanks": {
+            "name": "symfony/polyfill",
+            "url": "https://github.com/symfony/polyfill"
+        }
+    }
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -32,3 +32,7 @@ if (\PHP_VERSION_ID < 80100) {
 if (\PHP_VERSION_ID < 80200) {
     require __DIR__.'/Php82/bootstrap.php';
 }
+
+if (\PHP_VERSION_ID < 80300) {
+    require __DIR__.'/Php83/bootstrap.php';
+}

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Php83;
+
+use PHPUnit\Framework\TestCase;
+
+class Php83Test extends TestCase
+{
+    /**
+     * @covers \Symfony\Polyfill\Php83\Php83::json_validate
+     * @dataProvider jsonDataProvider
+     */
+    public function testJsonValidate(bool $valid, string $json, string $errorMessage = 'No error', int $depth = 512, int $options = 0)
+    {
+        $this->assertSame($valid, json_validate($json, $depth, $options));
+        $this->assertSame($errorMessage, json_last_error_msg());
+    }
+
+    /**
+     * @return iterable<array{0: bool, 1: string, 2?: string, 3?: int, 4?: int}>
+     */
+    public function jsonDataProvider(): iterable
+    {
+        yield [false, '', 'Syntax error'];
+        yield [false, '.', 'Syntax error'];
+        yield [false, '<?>', 'Syntax error'];
+        yield [false, ';', 'Syntax error'];
+        yield [false, 'руссиш', 'Syntax error'];
+        yield [false, 'blah', 'Syntax error'];
+        yield [false, '{ "": "": "" } }', 'Syntax error'];
+        yield [false, '{ "test": {} "foo": "bar" }, "test2": {"foo" : "bar" }, "test2": {"foo" : "bar" } }', 'Syntax error'];
+        yield [true, '{ "test": { "foo": "bar" } }'];
+        yield [true, '{ "test": { "foo": "" } }'];
+        yield [true, '{ "": { "foo": "" } }'];
+        yield [true, '{ "": { "": "" } }'];
+        yield [true, '{ "test": {"foo": "bar"}, "test2": {"foo" : "bar" }, "test2": {"foo" : "bar" } }'];
+        yield [true, '{ "test": {"foo": "bar"}, "test2": {"foo" : "bar" }, "test3": {"foo" : "bar" } }'];
+        yield [false, '{"key1":"value1", "key2":"value2"}', 'Maximum stack depth exceeded', 1];
+        yield [false, "\"a\xb0b\"", 'Malformed UTF-8 characters, possibly incorrectly encoded'];
+
+        if (\defined('JSON_INVALID_UTF8_IGNORE')) {
+            yield [true, "\"a\xb0b\"", 'No error', 512, \JSON_INVALID_UTF8_IGNORE];
+        } else {
+            // The $options should not be validated when JSON_INVALID_UTF8_IGNORE is not defined (PHP 7.1)
+            yield [true, '{}', 'No error', 512, 1];
+        }
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php83\Php83::json_validate
+     *
+     * @dataProvider invalidOptionsProvider
+     */
+    public function testInvalidOptionsProvided(int $depth, int $flags, string $expectedError)
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectErrorMessage($expectedError);
+        json_validate('{}', $depth, $flags);
+    }
+
+    /**
+     * @return iterable<array{0: int, 1: int, 2: string}>
+     */
+    public function invalidOptionsProvider(): iterable
+    {
+        yield [0, 0, 'json_validate(): Argument #2 ($depth) must be greater than 0'];
+        yield [\PHP_INT_MAX, 0, 'json_validate(): Argument #2 ($depth) must be less than 2147483647'];
+
+        if (\defined('JSON_INVALID_UTF8_IGNORE')) {
+            yield [
+                512,
+                \JSON_BIGINT_AS_STRING,
+                'json_validate(): Argument #3 ($flags) must be a valid flag (allowed flags: JSON_INVALID_UTF8_IGNORE)',
+            ];
+        }
+    }
+}


### PR DESCRIPTION
This PR adds `json_validate()` polyfill - see: https://wiki.php.net/rfc/json_validate.
Tests examples were taken from the php-src implementation. 

Test failures are unrelated.
Float tests are fixed in #417, remaining PHP 8.2 mbstring test can be sorted out separately.