### PR TITLE
Skip PHP_FLOAT_* checks on PHP 7.3+

### DIFF
--- a/tests/Php72/Php72Test.php
+++ b/tests/Php72/Php72Test.php
@@ -50,6 +50,9 @@ class Php72Test extends TestCase
         $this->assertSame(\PHP_OS_FAMILY, p::php_os_family());
     }
 
+    /**
+     * @requires PHP <7.3
+     */
     public function testPhpFloat()
     {
         $this->assertSame(15, \PHP_FLOAT_DIG);


### PR DESCRIPTION
This change skips comparing `PHP_FLOAT_MIN` and `PHP_FLOAT_MAX` constants on PHP 7.3 and higher as they changed their values. The test will only be run on PHP 7.1 (using provided polyfill) and PHP 7.2 (using native PHP values).

These constants depend on `DBL_MIN` and `DBL_MAX` which might change depending on the platform and/or compiler. I believe the values have changed in PHP 7.3 due to gcc update or some other time-related factor.