### PR TITLE
Fix json_validate rejecting valid maximum depth

### DIFF
--- a/src/Php83/Php83.php
+++ b/src/Php83/Php83.php
@@ -30,7 +30,7 @@ final class Php83
             throw new \ValueError('json_validate(): Argument #2 ($depth) must be greater than 0');
         }
 
-        if ($depth >= self::JSON_MAX_DEPTH) {
+        if ($depth > self::JSON_MAX_DEPTH) {
             throw new \ValueError(sprintf('json_validate(): Argument #2 ($depth) must be less than %d', self::JSON_MAX_DEPTH));
         }
 

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -46,6 +46,7 @@ class Php83Test extends TestCase
         yield [true, '{ "test": {"foo": "bar"}, "test2": {"foo" : "bar" }, "test3": {"foo" : "bar" } }'];
         yield [false, '{"key1":"value1", "key2":"value2"}', 'Maximum stack depth exceeded', 1];
         yield [false, "\"a\xb0b\"", 'Malformed UTF-8 characters, possibly incorrectly encoded'];
+        yield [true, '{ "test": { "foo": "bar" } }', 'No error', 2147483647];
 
         if (\defined('JSON_INVALID_UTF8_IGNORE')) {
             yield [true, "\"a\xb0b\"", 'No error', 512, \JSON_INVALID_UTF8_IGNORE];
@@ -73,8 +74,9 @@ class Php83Test extends TestCase
     public static function invalidOptionsProvider(): iterable
     {
         yield [0, 0, 'json_validate(): Argument #2 ($depth) must be greater than 0'];
-        yield [\PHP_INT_MAX, 0, 'json_validate(): Argument #2 ($depth) must be less than 2147483647'];
-
+        if (\PHP_INT_MAX > 2147483647) {
+            yield [\PHP_INT_MAX, 0, 'json_validate(): Argument #2 ($depth) must be less than 2147483647'];
+        }
         if (\defined('JSON_INVALID_UTF8_IGNORE')) {
             yield [
                 512,


### PR DESCRIPTION
Even though the error message for json_decode will say 'Argument #3 ($depth) must be less than 2147483647', the actual behavior of the method allows this (https://3v4l.org/QdfHt) and the official online documentation also confirms this behavior (https://www.php.net/manual/en/function.json-decode.php ' The value must be greater than 0, and less than or equal to 2147483647'). I have not been able to confirm whether 2147483647 is accepted by json_decode on a 32 bit system (where it is equal to PHP_MAX_INT) as I do not have access to one. (3v4l also uses 64 bit PHP)