### PR TITLE
Update return type for `IntlDateFormatter::format()`

### DIFF
--- a/src/Intl/Icu/IntlDateFormatter.php
+++ b/src/Intl/Icu/IntlDateFormatter.php
@@ -203,7 +203,7 @@ abstract class IntlDateFormatter
      *
      * @param int|string|\DateTimeInterface $datetime The timestamp to format
      *
-     * @return string|bool The formatted value or false if formatting failed
+     * @return string|false The formatted value or false if formatting failed
      *
      * @see https://php.net/intldateformatter.format
      *


### PR DESCRIPTION
Since PHP 8.0.0, the method is documented as having a `string|false` return (see https://github.com/php/php-src/blob/php-8.0.0/ext/intl/dateformat/dateformat.stub.php#L99-L104), this updates the polyfill to match the native signature which can help avoid static analysis issues where the polyfill has a wider return type than the native implementation.