### PR TITLE
[PHP 8.3] Add `#[\Override]` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Polyfills are provided for:
 - the `Random\CryptoSafeEngine` interface introduced in PHP 8.2;
 - the `Random\Engine\Secure` class introduced in PHP 8.2 (check [arokettu/random-polyfill](https://packagist.org/packages/arokettu/random-polyfill) for more engines);
 - the `json_validate` function introduced in PHP 8.3;
+- the `Override` attribute introduced in PHP 8.3;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
             "src/Intl/Icu/Resources/stubs",
             "src/Intl/MessageFormatter/Resources/stubs",
             "src/Intl/Normalizer/Resources/stubs",
+            "src/Php83/Resources/stubs",
             "src/Php82/Resources/stubs",
             "src/Php81/Resources/stubs",
             "src/Php80/Resources/stubs",

--- a/src/Php83/README.md
+++ b/src/Php83/README.md
@@ -4,6 +4,7 @@ Symfony Polyfill / Php83
 This component provides features added to PHP 8.3 core:
 
 - [`json_validate`](https://wiki.php.net/rfc/json_validate)
+- [`Override`](https://wiki.php.net/rfc/marking_overriden_methods)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).

--- a/src/Php83/Resources/stubs/Override.php
+++ b/src/Php83/Resources/stubs/Override.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80300) {
+    #[Attribute(Attribute::TARGET_METHOD)]
+    final class Override
+    {
+        public function __construct()
+        {
+        }
+    }
+}

--- a/src/Php83/composer.json
+++ b/src/Php83/composer.json
@@ -21,7 +21,8 @@
     },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Php83\\": "" },
-        "files": [ "bootstrap.php" ]
+        "files": [ "bootstrap.php" ],
+        "classmap": [ "Resources/stubs" ]
     },
     "minimum-stability": "dev",
     "extra": {


### PR DESCRIPTION
Adds `#[\Override]` attribute introduced in PHP 8.3: https://wiki.php.net/rfc/marking_overriden_methods

Failing tests are unrelated