### PR TITLE
[PHP 8.3] Polyfill new non-overloaded variants of functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 1.29.0
 
+  * Polyfill `ldap_exop_sync()`
+  * Polyfill `ldap_connect_wallet()`
+  * Polyfill `stream_context_set_options()`
   * Polyfill `odbc_connection_string_is_quoted()`
   * Polyfill `odbc_connection_string_should_quote()`
   * Polyfill `odbc_connection_string_quote()`

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Polyfills are provided for:
 - the `json_validate` function introduced in PHP 8.3;
 - the `Override` attribute introduced in PHP 8.3;
 - the `mb_str_pad` function introduced in PHP 8.3;
+- the `ldap_exop_sync` function introduced in PHP 8.3;
+- the `ldap_connect_wallet` function introduced in PHP 8.3;
+- the `stream_context_set_options` function introduced in PHP 8.3;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no

--- a/src/Php83/README.md
+++ b/src/Php83/README.md
@@ -6,6 +6,9 @@ This component provides features added to PHP 8.3 core:
 - [`json_validate`](https://wiki.php.net/rfc/json_validate)
 - [`Override`](https://wiki.php.net/rfc/marking_overriden_methods)
 - [`mb_str_pad`](https://wiki.php.net/rfc/mb_str_pad)
+- [`ldap_exop_sync`](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)
+- [`ldap_connect_wallet`](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)
+- [`stream_context_set_options`](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).

--- a/src/Php83/bootstrap.php
+++ b/src/Php83/bootstrap.php
@@ -22,3 +22,19 @@ if (!function_exists('json_validate')) {
 if (!function_exists('mb_str_pad') && function_exists('mb_substr')) {
     function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = STR_PAD_RIGHT, ?string $encoding = null): string { return p\Php83::mb_str_pad($string, $length, $pad_string, $pad_type, $encoding); }
 }
+
+if (!function_exists('stream_context_set_options')) {
+    function stream_context_set_options($context, array $options): bool { return stream_context_set_option($context, $options); }
+}
+
+if (\PHP_VERSION_ID >= 80100) {
+    return require __DIR__.'/bootstrap81.php';
+}
+
+if (!function_exists('ldap_exop_sync') && function_exists('ldap_exop')) {
+    function ldap_exop_sync($ldap, string $request_oid, string $request_data = null, array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $response_oid); }
+}
+
+if (!function_exists('ldap_connect_wallet') && function_exists('ldap_connect')) {
+    function ldap_connect_wallet(?string $uri, string $wallet, string $password, int $auth_mode = \GSLC_SSL_NO_AUTH) { return ldap_connect($uri, $wallet, $password, $auth_mode); }
+}

--- a/src/Php83/bootstrap81.php
+++ b/src/Php83/bootstrap81.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID >= 80300) {
+    return;
+}
+
+if (!function_exists('ldap_exop_sync') && function_exists('ldap_exop')) {
+    function ldap_exop_sync(\LDAP\Connection $ldap, string $request_oid, string $request_data = null, array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $response_oid); }
+}
+
+if (!function_exists('ldap_connect_wallet') && function_exists('ldap_connect')) {
+    function ldap_connect_wallet(?string $uri, string $wallet, #[\SensitiveParameter] string $password, int $auth_mode = \GSLC_SSL_NO_AUTH): \LDAP\Connection|false { return ldap_connect($uri, $wallet, $password, $auth_mode); }
+}

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -182,4 +182,11 @@ class Php83Test extends TestCase
             ];
         }
     }
+
+    public function testStreamContextSetOptions()
+    {
+        $context = stream_context_create();
+        $this->assertTrue(stream_context_set_options($context, ['http' => ['method' => 'POST']]));
+        $this->assertSame(['http' => ['method' => 'POST']], stream_context_get_options($context));
+    }
 }


### PR DESCRIPTION
This PR aims to add new PHP 8.3 functions introduced with RFC: https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures

Comments and feedback welcome 🙏🏻 

- [x] ~array_keys_filter~ (rejected)
- [x] ldap_connect_wallet
- [x] ldap_exop_sync
- [x] stream_context_set_options

Fixes #436 