### PR TITLE
Add polyfill for ini_parse_quantity based on the C code in PHP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Polyfill `odbc_connection_string_is_quoted()`
   * Polyfill `odbc_connection_string_should_quote()`
   * Polyfill `odbc_connection_string_quote()`
+  * Polyfill `ini_parse_quantity()`
   * Polyfill `mb_str_pad()`
   * Polyfill `#[\Override]` attribute
   * Use full case folding when using `MB_CASE_FOLD`

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Polyfills are provided for:
 - the `odbc_connection_string_is_quoted` function introduced in PHP 8.2;
 - the `odbc_connection_string_should_quote` function introduced in PHP 8.2;
 - the `odbc_connection_string_quote` function introduced in PHP 8.2;
+- the `ini_parse_quantity` function introduced in PHP 8.2;
 - the `json_validate` function introduced in PHP 8.3;
 - the `Override` attribute introduced in PHP 8.3;
 - the `mb_str_pad` function introduced in PHP 8.3;

--- a/src/Php82/Php82.php
+++ b/src/Php82/Php82.php
@@ -13,6 +13,7 @@ namespace Symfony\Polyfill\Php82;
 
 /**
  * @author Alexander M. Turek <me@derrabus.de>
+ * @author Greg Roach <greg@subaqua.co.uk>
  *
  * @internal
  */
@@ -70,5 +71,298 @@ class Php82
     public static function odbc_connection_string_quote(string $str): string
     {
         return '{'.str_replace('}', '}}', $str).'}';
+    }
+
+    /**
+     * Implementation closely based on the original C code - including the GOTOs
+     * and pointer-style string access.
+     *
+     * @see https://github.com/php/php-src/blob/master/Zend/zend_ini.c
+     */
+    public static function ini_parse_quantity(string $value): int
+    {
+        // Avoid dependency on ctype_space()
+        $ctype_space = " \t\v\r\n\f";
+
+        $str = 0;
+        $str_end = \strlen($value);
+        $digits = $str;
+        $overflow = false;
+
+        /* Ignore leading whitespace, but keep it for error messages. */
+        while ($digits < $str_end && false !== strpos($ctype_space, $value[$digits])) {
+            ++$digits;
+        }
+
+        /* Ignore trailing whitespace, but keep it for error messages. */
+        while ($digits < $str_end && false !== strpos($ctype_space, $value[$str_end - 1])) {
+            --$str_end;
+        }
+
+        if ($digits === $str_end) {
+            return 0;
+        }
+
+        $is_negative = false;
+
+        if ('+' === $value[$digits]) {
+            ++$digits;
+        } elseif ('-' === $value[$digits]) {
+            $is_negative = true;
+            ++$digits;
+        }
+
+        if ($value[$digits] < '0' || $value[$digits] > 9) {
+            $message = sprintf(
+                'Invalid quantity "%s": no valid leading digits, interpreting as "0" for backwards compatibility',
+                self::escapeString($value)
+            );
+
+            trigger_error($message, \E_USER_WARNING);
+
+            return 0;
+        }
+
+        $base = 10;
+        $allowed_digits = '0123456789';
+
+        if ('0' === $value[$digits] && ($digits + 1 === $str_end || false === strpos($allowed_digits, $value[$digits + 1]))) {
+            if ($digits + 1 === $str_end) {
+                return 0;
+            }
+
+            switch ($value[$digits + 1]) {
+                case 'g':
+                case 'G':
+                case 'm':
+                case 'M':
+                case 'k':
+                case 'K':
+                    goto evaluation;
+                case 'x':
+                case 'X':
+                    $base = 16;
+                    $allowed_digits = '0123456789abcdefABCDEF';
+                    break;
+                case 'o':
+                case 'O':
+                    $base = 8;
+                    $allowed_digits = '01234567';
+                    break;
+                case 'b':
+                case 'B':
+                    $base = 2;
+                    $allowed_digits = '01';
+                    break;
+                default:
+                    $message = sprintf(
+                        'Invalid prefix "0%s", interpreting as "0" for backwards compatibility',
+                        $value[$digits + 1]
+                    );
+                    trigger_error($message, \E_USER_WARNING);
+
+                    return 0;
+            }
+
+            $digits += 2;
+            if ($digits === $str_end) {
+                $message = sprintf(
+                    'Invalid quantity "%s": no digits after base prefix, interpreting as "0" for backwards compatibility',
+                    self::escapeString($value)
+                );
+                trigger_error($message, \E_USER_WARNING);
+
+                return 0;
+            }
+        }
+
+        evaluation:
+
+        if (10 === $base && '0' === $value[$digits]) {
+            $base = 8;
+            $allowed_digits = '01234567';
+        }
+
+        while ($digits < $str_end && ' ' === $value[$digits]) {
+            ++$digits;
+        }
+
+        if ($digits < $str_end && '+' === $value[$digits]) {
+            ++$digits;
+        } elseif ($digits < $str_end && '-' === $value[$digits]) {
+            $is_negative = true;
+            $overflow = true;
+            ++$digits;
+        }
+
+        $digits_end = $digits;
+
+        // The native function treats 0x0x123 the same as 0x123.  This is a bug which we must replicate.
+        if (
+            16 === $base
+            && $digits_end + 2 < $str_end
+            && '0x' === substr($value, $digits_end, 2)
+            && false !== strpos($allowed_digits, $value[$digits_end + 2])
+        ) {
+            $digits_end += 2;
+        }
+
+        while ($digits_end < $str_end && false !== strpos($allowed_digits, $value[$digits_end])) {
+            ++$digits_end;
+        }
+
+        $retval = base_convert(substr($value, $digits, $digits_end - $digits), $base, 10);
+
+        if ($is_negative && '0' === $retval) {
+            $is_negative = false;
+            $overflow = false;
+        }
+
+        // Check for overflow - remember that -PHP_INT_MIN = 1 + PHP_INT_MAX
+        if ($is_negative) {
+            $signed_max = strtr((string) \PHP_INT_MIN, ['-' => '']);
+        } else {
+            $signed_max = (string) \PHP_INT_MAX;
+        }
+
+        $max_length = max(\strlen($retval), \strlen($signed_max));
+
+        $tmp1 = str_pad($retval, $max_length, '0', \STR_PAD_LEFT);
+        $tmp2 = str_pad($signed_max, $max_length, '0', \STR_PAD_LEFT);
+
+        if ($tmp1 > $tmp2) {
+            $retval = -1;
+            $overflow = true;
+        } elseif ($is_negative) {
+            $retval = '-'.$retval;
+        }
+
+        $retval = (int) $retval;
+
+        if ($digits_end === $digits) {
+            $message = sprintf(
+                'Invalid quantity "%s": no valid leading digits, interpreting as "0" for backwards compatibility',
+                self::escapeString($value)
+            );
+            trigger_error($message, \E_USER_WARNING);
+
+            return 0;
+        }
+
+        /* Allow for whitespace between integer portion and any suffix character */
+        while ($digits_end < $str_end && false !== strpos($ctype_space, $value[$digits_end])) {
+            ++$digits_end;
+        }
+
+        /* No exponent suffix. */
+        if ($digits_end === $str_end) {
+            goto end;
+        }
+
+        switch ($value[$str_end - 1]) {
+            case 'g':
+            case 'G':
+                $shift = 30;
+                break;
+            case 'm':
+            case 'M':
+                $shift = 20;
+                break;
+            case 'k':
+            case 'K':
+                $shift = 10;
+                break;
+            default:
+                /* Unknown suffix */
+                $invalid = self::escapeString($value);
+                $interpreted = self::escapeString(substr($value, $str, $digits_end - $str));
+                $chr = self::escapeString($value[$str_end - 1]);
+
+                $message = sprintf(
+                    'Invalid quantity "%s": unknown multiplier "%s", interpreting as "%s" for backwards compatibility',
+                    $invalid,
+                    $chr,
+                    $interpreted
+                );
+
+                trigger_error($message, \E_USER_WARNING);
+
+                return $retval;
+        }
+
+        $factor = 1 << $shift;
+
+        if (!$overflow) {
+            if ($retval > 0) {
+                $overflow = $retval > \PHP_INT_MAX / $factor;
+            } else {
+                $overflow = $retval < \PHP_INT_MIN / $factor;
+            }
+        }
+
+        if (\is_float($retval * $factor)) {
+            $overflow = true;
+            $retval <<= $shift;
+        } else {
+            $retval *= $factor;
+        }
+
+        if ($digits_end !== $str_end - 1) {
+            /* More than one character in suffix */
+            $message = sprintf(
+                'Invalid quantity "%s", interpreting as "%s%s" for backwards compatibility',
+                self::escapeString($value),
+                self::escapeString(substr($value, $str, $digits_end - $str)),
+                self::escapeString($value[$str_end - 1])
+            );
+            trigger_error($message, \E_USER_WARNING);
+
+            return $retval;
+        }
+
+        end:
+
+        if ($overflow) {
+            /* Not specifying the resulting value here because the caller may make
+             * additional conversions. Not specifying the allowed range
+             * because the caller may do narrower range checks. */
+            $message = sprintf(
+                'Invalid quantity "%s": value is out of range, using overflow result for backwards compatibility',
+                self::escapeString($value)
+            );
+            trigger_error($message, \E_USER_WARNING);
+        }
+
+        return $retval;
+    }
+
+    /**
+     * Escape the string to avoid null bytes and to make non-printable chars visible.
+     */
+    private static function escapeString(string $string): string
+    {
+        $escaped = '';
+
+        for ($n = 0, $len = \strlen($string); $n < $len; ++$n) {
+            $c = \ord($string[$n]);
+
+            if ($c < 32 || '\\' === $string[$n] || $c > 126) {
+                switch ($string[$n]) {
+                    case "\n": $escaped .= '\\n'; break;
+                    case "\r": $escaped .= '\\r'; break;
+                    case "\t": $escaped .= '\\t'; break;
+                    case "\f": $escaped .= '\\f'; break;
+                    case "\v": $escaped .= '\\v'; break;
+                    case '\\': $escaped .= '\\\\'; break;
+                    case "\x1B": $escaped .= '\\e'; break;
+                    default:
+                        $escaped .= '\\x'.strtoupper(sprintf('%02x', $c));
+                }
+            } else {
+                $escaped .= $string[$n];
+            }
+        }
+
+        return $escaped;
     }
 }

--- a/src/Php82/README.md
+++ b/src/Php82/README.md
@@ -12,6 +12,7 @@ This component provides features added to PHP 8.2 core:
 - [`odbc_connection_string_is_quoted()`](https://php.net/odbc_connection_string_is_quoted)
 - [`odbc_connection_string_should_quote()`](https://php.net/odbc_connection_string_should_quote)
 - [`odbc_connection_string_quote()`](https://php.net/odbc_connection_string_quote)
+- [`ini_parse_quantity()`](https://php.net/ini_parse_quantity)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).

--- a/src/Php82/bootstrap.php
+++ b/src/Php82/bootstrap.php
@@ -30,3 +30,7 @@ if (!function_exists('odbc_connection_string_should_quote')) {
 if (!function_exists('odbc_connection_string_quote')) {
     function odbc_connection_string_quote(string $str): string { return p\Php82::odbc_connection_string_quote($str); }
 }
+
+if (!function_exists('ini_parse_quantity')) {
+    function ini_parse_quantity(string $shorthand): int { return p\Php82::ini_parse_quantity($shorthand); }
+}

--- a/tests/Php82/Php82Test.php
+++ b/tests/Php82/Php82Test.php
@@ -84,4 +84,332 @@ class Php82Test extends TestCase
     {
         yield 'double curly at the end' => ['foo}}', false, true, '{foo}}}}}'];
     }
+
+    public function testIniParseQuantity()
+    {
+        $this->assertSame(0, ini_parse_quantity(''));
+        $this->assertSame(0, ini_parse_quantity('0'));
+        $this->assertSame(0, ini_parse_quantity(' 0'));
+        $this->assertSame(0, ini_parse_quantity('0 '));
+        $this->assertSame(0, ini_parse_quantity(' +0 '));
+        $this->assertSame(0, ini_parse_quantity(' -0 '));
+
+        $this->assertSame(0, ini_parse_quantity('00'));
+        $this->assertSame(0, ini_parse_quantity(' 00'));
+        $this->assertSame(0, ini_parse_quantity('00 '));
+        $this->assertSame(0, ini_parse_quantity(' +00 '));
+        $this->assertSame(0, ini_parse_quantity(' -00 '));
+
+        $this->assertSame(1, ini_parse_quantity('1'));
+        $this->assertSame(-1, ini_parse_quantity('-1'));
+        $this->assertSame(1, ini_parse_quantity('+1'));
+
+        $this->assertSame(0, ini_parse_quantity('0b0'));
+        $this->assertSame(2, ini_parse_quantity('0b10'));
+        $this->assertSame(-2, ini_parse_quantity('-0b10'));
+        $this->assertSame(2, ini_parse_quantity('+0b10'));
+
+        $this->assertSame(0, ini_parse_quantity('0B0'));
+        $this->assertSame(2, ini_parse_quantity('0B10'));
+        $this->assertSame(-2, ini_parse_quantity('-0B10'));
+        $this->assertSame(2, ini_parse_quantity('+0B10'));
+
+        $this->assertSame(8, ini_parse_quantity('0o10'));
+        $this->assertSame(-8, ini_parse_quantity('-0o10'));
+        $this->assertSame(8, ini_parse_quantity('+0o10'));
+
+        $this->assertSame(8, ini_parse_quantity('0O10'));
+        $this->assertSame(-8, ini_parse_quantity('-0O10'));
+        $this->assertSame(8, ini_parse_quantity('+0O10'));
+
+        $this->assertSame(16, ini_parse_quantity('0x10'));
+        $this->assertSame(-16, ini_parse_quantity('-0x10'));
+        $this->assertSame(16, ini_parse_quantity('+0x10'));
+
+        $this->assertSame(16, ini_parse_quantity('0X10'));
+        $this->assertSame(-16, ini_parse_quantity('-0X10'));
+        $this->assertSame(16, ini_parse_quantity('+0X10'));
+
+        $this->assertSame(0, ini_parse_quantity('0k'));
+        $this->assertSame(0, ini_parse_quantity(' 0K'));
+        $this->assertSame(0, ini_parse_quantity('0k '));
+
+        $this->assertSame(1024, ini_parse_quantity('1k'));
+        $this->assertSame(1024, ini_parse_quantity('1 K'));
+        $this->assertSame(1024, ini_parse_quantity('+1k'));
+        $this->assertSame(-1024, ini_parse_quantity('-1K'));
+
+        $this->assertSame(2048, ini_parse_quantity('0b10k'));
+        $this->assertSame(2048, ini_parse_quantity('0b10 K'));
+        $this->assertSame(2048, ini_parse_quantity('+0b10k'));
+        $this->assertSame(-2048, ini_parse_quantity('-0b10K'));
+
+        $this->assertSame(2048, ini_parse_quantity('0B10k'));
+        $this->assertSame(2048, ini_parse_quantity('0B10 K'));
+        $this->assertSame(2048, ini_parse_quantity('+0B10k'));
+        $this->assertSame(-2048, ini_parse_quantity('-0B10K'));
+
+        $this->assertSame(8192, ini_parse_quantity('0o10k'));
+        $this->assertSame(8192, ini_parse_quantity('0o10 K'));
+        $this->assertSame(8192, ini_parse_quantity('+0o10k'));
+        $this->assertSame(-8192, ini_parse_quantity('-0o10K'));
+
+        $this->assertSame(8192, ini_parse_quantity('0O10k'));
+        $this->assertSame(8192, ini_parse_quantity('0O10 K'));
+        $this->assertSame(8192, ini_parse_quantity('+0O10k'));
+        $this->assertSame(-8192, ini_parse_quantity('-0O10K'));
+
+        $this->assertSame(16384, ini_parse_quantity('0x10k'));
+        $this->assertSame(16384, ini_parse_quantity('0x10 K'));
+        $this->assertSame(16384, ini_parse_quantity('+0x10k'));
+        $this->assertSame(-16384, ini_parse_quantity('-0x10K'));
+
+        $this->assertSame(16384, ini_parse_quantity('0X10k'));
+        $this->assertSame(16384, ini_parse_quantity('0X10 K'));
+        $this->assertSame(16384, ini_parse_quantity('+0X10k'));
+        $this->assertSame(-16384, ini_parse_quantity('-0X10K'));
+
+        $this->assertSame(1048576, ini_parse_quantity('1m'));
+        $this->assertSame(1048576, ini_parse_quantity('1 M'));
+        $this->assertSame(1048576, ini_parse_quantity('+1m'));
+        $this->assertSame(-1048576, ini_parse_quantity('-1M'));
+
+        $this->assertSame(2097152, ini_parse_quantity('0b10m'));
+        $this->assertSame(2097152, ini_parse_quantity('0b10 M'));
+        $this->assertSame(2097152, ini_parse_quantity('+0b10m'));
+        $this->assertSame(-2097152, ini_parse_quantity('-0b10M'));
+
+        $this->assertSame(2097152, ini_parse_quantity('0B10m'));
+        $this->assertSame(2097152, ini_parse_quantity('0B10 M'));
+        $this->assertSame(2097152, ini_parse_quantity('+0B10m'));
+        $this->assertSame(-2097152, ini_parse_quantity('-0B10M'));
+
+        $this->assertSame(8388608, ini_parse_quantity('0o10m'));
+        $this->assertSame(8388608, ini_parse_quantity('0o10 M'));
+        $this->assertSame(8388608, ini_parse_quantity('+0o10m'));
+        $this->assertSame(-8388608, ini_parse_quantity('-0o10M'));
+
+        $this->assertSame(8388608, ini_parse_quantity('0O10m'));
+        $this->assertSame(8388608, ini_parse_quantity('0O10 M'));
+        $this->assertSame(8388608, ini_parse_quantity('+0O10m'));
+        $this->assertSame(-8388608, ini_parse_quantity('-0O10M'));
+
+        $this->assertSame(16777216, ini_parse_quantity('0x10m'));
+        $this->assertSame(16777216, ini_parse_quantity('0x10 M'));
+        $this->assertSame(16777216, ini_parse_quantity('+0x10m'));
+        $this->assertSame(-16777216, ini_parse_quantity('-0x10M'));
+
+        $this->assertSame(16777216, ini_parse_quantity('0X10m'));
+        $this->assertSame(16777216, ini_parse_quantity('0X10 M'));
+        $this->assertSame(16777216, ini_parse_quantity('+0X10m'));
+        $this->assertSame(-16777216, ini_parse_quantity('-0X10M'));
+
+        $this->assertSame(1073741824, ini_parse_quantity('1g'));
+        $this->assertSame(1073741824, ini_parse_quantity('1 G'));
+        $this->assertSame(1073741824, ini_parse_quantity('+1g'));
+        $this->assertSame(-1073741824, ini_parse_quantity('-1G'));
+
+        $this->assertSame(2147483648, ini_parse_quantity('0b10g'));
+        $this->assertSame(2147483648, ini_parse_quantity('0b10 G'));
+        $this->assertSame(2147483648, ini_parse_quantity('+0b10g'));
+        $this->assertSame(-2147483648, ini_parse_quantity('-0b10G'));
+
+        $this->assertSame(2147483648, ini_parse_quantity('0B10g'));
+        $this->assertSame(2147483648, ini_parse_quantity('0B10 G'));
+        $this->assertSame(2147483648, ini_parse_quantity('+0B10g'));
+        $this->assertSame(-2147483648, ini_parse_quantity('-0B10G'));
+
+        $this->assertSame(8589934592, ini_parse_quantity('0o10g'));
+        $this->assertSame(8589934592, ini_parse_quantity('0o10 G'));
+        $this->assertSame(8589934592, ini_parse_quantity('+0o10g'));
+        $this->assertSame(-8589934592, ini_parse_quantity('-0o10G'));
+
+        $this->assertSame(8589934592, ini_parse_quantity('0O10g'));
+        $this->assertSame(8589934592, ini_parse_quantity('0O10 G'));
+        $this->assertSame(8589934592, ini_parse_quantity('+0O10g'));
+        $this->assertSame(-8589934592, ini_parse_quantity('-0O10G'));
+
+        $this->assertSame(17179869184, ini_parse_quantity('0x10g'));
+        $this->assertSame(17179869184, ini_parse_quantity('0x10 G'));
+        $this->assertSame(17179869184, ini_parse_quantity('+0x10g'));
+        $this->assertSame(-17179869184, ini_parse_quantity('-0x10G'));
+
+        $this->assertSame(17179869184, ini_parse_quantity('0X10g'));
+        $this->assertSame(17179869184, ini_parse_quantity('0X10 G'));
+        $this->assertSame(17179869184, ini_parse_quantity('+0X10g'));
+        $this->assertSame(-17179869184, ini_parse_quantity('-0X10G'));
+    }
+
+    public function testIniParseQuantityUndocumentedFeatures()
+    {
+        $this->assertSame(18, ini_parse_quantity('0x0x12'));
+
+        $this->assertSame(2, ini_parse_quantity('0b+10'));
+        $this->assertSame(8, ini_parse_quantity('0o+10'));
+        $this->assertSame(16, ini_parse_quantity('0x+10'));
+
+        $this->assertSame(2, ini_parse_quantity('0b 10'));
+        $this->assertSame(8, ini_parse_quantity('0o 10'));
+        $this->assertSame(16, ini_parse_quantity('0x 10'));
+    }
+
+    public function testIniParseQuantityZeroWithMultiplier()
+    {
+        // Note that "1 K" is valid
+        error_clear_last();
+        $this->assertSame(0, @ini_parse_quantity(' 0 K '));
+        $this->assertSame('Invalid prefix "0 ", interpreting as "0" for backwards compatibility', error_get_last()['message']);
+        $this->assertContains(error_get_last()['type'], [E_WARNING, E_USER_WARNING]);
+    }
+
+    public function testIniParseQuantityNoValidLeadingDigits()
+    {
+        error_clear_last();
+        $this->assertSame(0, @ini_parse_quantity(' foo '));
+        $this->assertSame('Invalid quantity " foo ": no valid leading digits, interpreting as "0" for backwards compatibility', error_get_last()['message']);
+        $this->assertContains(error_get_last()['type'], [E_WARNING, E_USER_WARNING]);
+    }
+
+    public function testIniParseQuantityUnknownMultiplier()
+    {
+        error_clear_last();
+        $this->assertSame(2, @ini_parse_quantity(' 0b102 '));
+        $this->assertSame('Invalid quantity " 0b102 ": unknown multiplier "2", interpreting as " 0b10" for backwards compatibility', error_get_last()['message']);
+        $this->assertContains(error_get_last()['type'], [E_WARNING, E_USER_WARNING]);
+    }
+
+    public function testIniParseQuantityNoDigitsAfterBasePrefix()
+    {
+        error_clear_last();
+        $this->assertSame(0, @ini_parse_quantity(' 0x '));
+        $this->assertSame('Invalid quantity " 0x ": no digits after base prefix, interpreting as "0" for backwards compatibility', error_get_last()['message']);
+        $this->assertContains(error_get_last()['type'], [E_WARNING, E_USER_WARNING]);
+    }
+
+    public function testIniParseQuantityInvalidPrefix()
+    {
+        error_clear_last();
+        $this->assertSame(0, @ini_parse_quantity('0q12'));
+        $this->assertSame('Invalid prefix "0q", interpreting as "0" for backwards compatibility', error_get_last()['message']);
+        $this->assertContains(error_get_last()['type'], [E_WARNING, E_USER_WARNING]);
+    }
+
+    public function testIniParseQuantityInvalidQuantity()
+    {
+        error_clear_last();
+        $this->assertSame(10240, @ini_parse_quantity(' 10 kk '));
+        $this->assertSame('Invalid quantity " 10 kk ", interpreting as " 10 k" for backwards compatibility', error_get_last()['message']);
+        $this->assertContains(error_get_last()['type'], [E_WARNING, E_USER_WARNING]);
+    }
+
+    public function testIniParseQuantityNoLeadingDigits()
+    {
+        // There are two paths to generate this error
+        error_clear_last();
+        $this->assertSame(0, @ini_parse_quantity(' K '));
+        $this->assertSame('Invalid quantity " K ": no valid leading digits, interpreting as "0" for backwards compatibility', error_get_last()['message']);
+        $this->assertContains(error_get_last()['type'], [E_WARNING, E_USER_WARNING]);
+    }
+
+    public function testIniParseQuantityOutOfRange()
+    {
+        error_clear_last();
+        $this->assertSame(-4096, @ini_parse_quantity(' 0x-4K '));
+        $this->assertSame('Invalid quantity " 0x-4K ": value is out of range, using overflow result for backwards compatibility', error_get_last()['message']);
+        $this->assertContains(error_get_last()['type'], [E_WARNING, E_USER_WARNING]);
+    }
+
+    public function testIniParseQuantityOverflowTooManyDigits()
+    {
+        error_clear_last();
+        $this->assertSame(-1, @ini_parse_quantity(' 99999999999999999999 '));
+        $this->assertSame('Invalid quantity " 99999999999999999999 ": value is out of range, using overflow result for backwards compatibility', error_get_last()['message']);
+        $this->assertContains(error_get_last()['type'], [E_WARNING, E_USER_WARNING]);
+    }
+
+    public function testIniParseQuantityOverflowWithMultiplier()
+    {
+        error_clear_last();
+        $this->assertSame(-7709325833709551616, @ini_parse_quantity(' 10000000000G '));
+        $this->assertSame('Invalid quantity " 10000000000G ": value is out of range, using overflow result for backwards compatibility', error_get_last()['message']);
+        $this->assertContains(error_get_last()['type'], [E_WARNING, E_USER_WARNING]);
+    }
+
+    public function testIniParseQuantitySignAfterPrefixButNoDigits()
+    {
+        error_clear_last();
+        $this->assertSame(0, @ini_parse_quantity(' 0b- '));
+        $this->assertSame('Invalid quantity " 0b- ": no valid leading digits, interpreting as "0" for backwards compatibility', error_get_last()['message']);
+        $this->assertContains(error_get_last()['type'], [E_WARNING, E_USER_WARNING]);
+    }
+
+    public function testIniParseQuantitySpecialCharactersAreEscaped()
+    {
+        error_clear_last();
+        $this->assertSame(0, @ini_parse_quantity("w-\n-\r-\t-\v-\f-\\-\x1B-\xCC-"));
+        $this->assertSame('Invalid quantity "w-\\n-\\r-\\t-\\v-\\f-\\\\-\\e-\\xCC-": no valid leading digits, interpreting as "0" for backwards compatibility', error_get_last()['message']);
+        $this->assertContains(error_get_last()['type'], [E_WARNING, E_USER_WARNING]);
+    }
+
+    /**
+     * This is a brute-force test that should only be used during local development.
+     * It takes approximately 4 hours to run.  It is good at picking up edge cases.
+     */
+    public function testIniParseQuantityUsingBruteForce()
+    {
+        if (PHP_VERSION_ID < 80200) {
+            $this->markTestSkipped('This test requires the PHP function as a reference.');
+
+            return;
+        }
+
+        // Comment these lines to run the tests.
+        $this->markTestSkipped('This test is slow and should only be used for local development.');
+        return;
+
+        $fn = function (string $test): void {
+            error_clear_last();
+            $x     = @ini_parse_quantity($test);
+            $err_x = error_get_last()['message'] ?? '';
+
+            error_clear_last();
+            $y     = @ini_parse_quantity($test);
+            $err_y = error_get_last()['message'] ?? '';
+
+            $this->assertSame($x, $y, 'Testing "' . $test . '"');
+            $this->assertSame($err_x, $err_y, 'Testing "' . $test . '"');
+        };
+
+        $chars = [' ', '-', '+', '0', '1', '7', '9', 'a', 'b', 'o', 'f', 'g', 'k', 'm', 'x', 'z', '\\'];
+
+        $fn('');
+
+        foreach ($chars as $char1) {
+            $fn($char1);
+
+            foreach ($chars as $char2) {
+                $fn($char1 . $char2);
+
+                foreach ($chars as $char3) {
+                    $fn($char1 . $char2 . $char3);
+
+                    foreach ($chars as $char4) {
+                        $fn($char1 . $char2 . $char3 . $char4);
+
+                        foreach ($chars as $char5) {
+                            $fn($char1 . $char2 . $char3 . $char4 . $char5);
+
+                            foreach ($chars as $char6) {
+                                $fn($char1 . $char2 . $char3 . $char4 . $char5 . $char6);
+
+                                foreach ($chars as $char7) {
+                                    $fn($char1 . $char2 . $char3 . $char4 . $char5 . $char6 . $char7);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
See #411 for a previous attempt to polyfill this function.

The `ini_parse_quantity()` is difficult to polyfill as the error handling is non-trivial, and several invalid inputs are treated as valid.

This polyfill is a simple/direct implementation of the C code from PHP.
As such it uses `goto`s and pointer-based string access.
I am fully aware that this would fail most code reviews :-)

However it works and I hope it will be useful until a cleaner implementation can be provided.

The unit tests provide 100% code coverage.  I have also included (but commented out) a brute-force test which takes many hours to run. I found it was very helpful in finding edge cases.  It may be useful for anyone who tries to refactor the code.

The two overflow tests will probably fail on a 32bit build of PHP, however the code itself should work.
I just haven't been able to work out the expected values.