### PR TITLE
[PHP 8.3] Add Exception/Error classes for `Date/Time` extension

### DIFF
--- a/src/Php83/Resources/stubs/DateError.php
+++ b/src/Php83/Resources/stubs/DateError.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80300) {
+    class DateError extends Error
+    {
+    }
+}

--- a/src/Php83/Resources/stubs/DateException.php
+++ b/src/Php83/Resources/stubs/DateException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80300) {
+    class DateException extends Exception
+    {
+    }
+}

--- a/src/Php83/Resources/stubs/DateInvalidOperationException.php
+++ b/src/Php83/Resources/stubs/DateInvalidOperationException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80300) {
+    class DateInvalidOperationException extends DateException
+    {
+    }
+}

--- a/src/Php83/Resources/stubs/DateInvalidTimeZoneException.php
+++ b/src/Php83/Resources/stubs/DateInvalidTimeZoneException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80300) {
+    class DateInvalidTimeZoneException extends DateException
+    {
+    }
+}

--- a/src/Php83/Resources/stubs/DateMalformedIntervalStringException.php
+++ b/src/Php83/Resources/stubs/DateMalformedIntervalStringException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80300) {
+    class DateMalformedIntervalStringException extends DateException
+    {
+    }
+}

--- a/src/Php83/Resources/stubs/DateMalformedPeriodStringException.php
+++ b/src/Php83/Resources/stubs/DateMalformedPeriodStringException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80300) {
+    class DateMalformedPeriodStringException extends DateException
+    {
+    }
+}

--- a/src/Php83/Resources/stubs/DateMalformedStringException.php
+++ b/src/Php83/Resources/stubs/DateMalformedStringException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80300) {
+    class DateMalformedStringException extends DateException
+    {
+    }
+}

--- a/src/Php83/Resources/stubs/DateObjectError.php
+++ b/src/Php83/Resources/stubs/DateObjectError.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80300) {
+    class DateObjectError extends DateError
+    {
+    }
+}

--- a/src/Php83/Resources/stubs/DateRangeError.php
+++ b/src/Php83/Resources/stubs/DateRangeError.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80300) {
+    class DateRangeError extends DateError
+    {
+    }
+}

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -189,4 +189,17 @@ class Php83Test extends TestCase
         $this->assertTrue(stream_context_set_options($context, ['http' => ['method' => 'POST']]));
         $this->assertSame(['http' => ['method' => 'POST']], stream_context_get_options($context));
     }
+
+    public function testDateTimeExceptionClassesExist()
+    {
+        $this->assertTrue(class_exists('\DateError'));
+        $this->assertTrue(class_exists('\DateObjectError'));
+        $this->assertTrue(class_exists('\DateRangeError'));
+        $this->assertTrue(class_exists('\DateException'));
+        $this->assertTrue(class_exists('\DateInvalidTimeZoneException'));
+        $this->assertTrue(class_exists('\DateInvalidOperationException'));
+        $this->assertTrue(class_exists('\DateMalformedStringException'));
+        $this->assertTrue(class_exists('\DateMalformedIntervalStringException'));
+        $this->assertTrue(class_exists('\DateMalformedPeriodStringException'));
+    }
 }


### PR DESCRIPTION
Adds nine classes for the new exceptions/errors declared in ext-date.

 - [RFC: PHP RFC: More Appropriate Date/Time Exceptions](https://wiki.php.net/rfc/datetime-exceptions)
 - [PHP.Watch: DateTime Exception Class Polyfill](https://php.watch/versions/8.3/datetime-exceptions#polyfill)