### PR TITLE
Fix the CI setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
 
         env:
-            COMPOSER_ROOT_VERSION: dev-main
+            COMPOSER_ROOT_VERSION: 1.x-dev
             SYMFONY_PHPUNIT_VERSION: 9.5
 
         strategy:


### PR DESCRIPTION
As the default branch of the repository has been renamed, the COMPOSER_ROOT_VERSION cannot be set to dev-main relying on the branch alias as there is no such branch alias anymore.