### PR TITLE
Fix the `ini_parse_quantity()` polyfill

### DIFF
--- a/src/Php82/bootstrap.php
+++ b/src/Php82/bootstrap.php
@@ -15,20 +15,18 @@ if (\PHP_VERSION_ID >= 80200) {
     return;
 }
 
-if (!extension_loaded('odbc')) {
-    return;
-}
+if (extension_loaded('odbc')) {
+    if (!function_exists('odbc_connection_string_is_quoted')) {
+        function odbc_connection_string_is_quoted(string $str): bool { return p\Php82::odbc_connection_string_is_quoted($str); }
+    }
 
-if (!function_exists('odbc_connection_string_is_quoted')) {
-    function odbc_connection_string_is_quoted(string $str): bool { return p\Php82::odbc_connection_string_is_quoted($str); }
-}
+    if (!function_exists('odbc_connection_string_should_quote')) {
+        function odbc_connection_string_should_quote(string $str): bool { return p\Php82::odbc_connection_string_should_quote($str); }
+    }
 
-if (!function_exists('odbc_connection_string_should_quote')) {
-    function odbc_connection_string_should_quote(string $str): bool { return p\Php82::odbc_connection_string_should_quote($str); }
-}
-
-if (!function_exists('odbc_connection_string_quote')) {
-    function odbc_connection_string_quote(string $str): string { return p\Php82::odbc_connection_string_quote($str); }
+    if (!function_exists('odbc_connection_string_quote')) {
+        function odbc_connection_string_quote(string $str): string { return p\Php82::odbc_connection_string_quote($str); }
+    }
 }
 
 if (!function_exists('ini_parse_quantity')) {

--- a/tests/Php82/Php82Test.php
+++ b/tests/Php82/Php82Test.php
@@ -13,14 +13,12 @@ namespace Symfony\Polyfill\Tests\Php82;
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * @requires extension odbc
- */
 class Php82Test extends TestCase
 {
     /**
      * @dataProvider provideConnectionStringValuesFromUpstream
      * @dataProvider provideMoreConnectionStringValues
+     * @requires extension odbc
      */
     public function testConnectionStringIsQuoted(string $value, bool $isQuoted)
     {
@@ -30,6 +28,7 @@ class Php82Test extends TestCase
     /**
      * @dataProvider provideConnectionStringValuesFromUpstream
      * @dataProvider provideMoreConnectionStringValues
+     * @requires extension odbc
      */
     public function testConnectionStringShouldQuote(string $value, bool $isQuoted, bool $shouldQuote)
     {
@@ -39,6 +38,7 @@ class Php82Test extends TestCase
     /**
      * @dataProvider provideConnectionStringValuesFromUpstream
      * @dataProvider provideMoreConnectionStringValues
+     * @requires extension odbc
      */
     public function testConnectionStringQuote(string $value, bool $isQuoted, bool $shouldQuote, string $quoted)
     {


### PR DESCRIPTION
It previously was only defined (and tested) of the odbc extension is available.