### PR TITLE
Update GitHub Actions workflow to `actions/checkout@v4`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This fixes the following deprecation:

> The following actions uses node12 which is deprecated and will be forced to
> run on node16: actions/checkout@v2. For more info:
> https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/