### PR TITLE
Fix return type for `Locale::parseLocale` - it can return `null`

### DIFF
--- a/src/Intl/Icu/Locale.php
+++ b/src/Intl/Icu/Locale.php
@@ -279,7 +279,7 @@ abstract class Locale
     /**
      * Not supported. Returns an associative array of locale identifier subtags.
      *
-     * @return array Associative array with the extracted subtags
+     * @return array|null Associative array with the extracted subtags
      *
      * @see https://php.net/locale.parselocale
      *


### PR DESCRIPTION
https://www.php.net/manual/en/locale.parselocale.php

> Returns null when the length of locale exceeds INTL_MAX_LOCALE_LEN.

----

> Recreated PR from https://github.com/symfony/polyfill-intl-icu/pull/1