### PR TITLE
Conform to IDNA version 15.1.0 revision 31

### DIFF
--- a/src/Intl/Idn/Idn.php
+++ b/src/Intl/Idn/Idn.php
@@ -280,10 +280,6 @@ final class Idn
 
             switch ($data['status']) {
                 case 'disallowed':
-                    $info->errors |= self::ERROR_DISALLOWED;
-
-                    // no break.
-
                 case 'valid':
                     $str .= mb_chr($codePoint, 'utf-8');
 
@@ -294,7 +290,7 @@ final class Idn
                     break;
 
                 case 'mapped':
-                    $str .= $data['mapping'];
+                    $str .= $transitional && 0x1E9E === $codePoint ? 'ss' : $data['mapping'];
 
                     break;
 
@@ -346,6 +342,18 @@ final class Idn
             $validationOptions = $options;
 
             if ('xn--' === substr($label, 0, 4)) {
+                // Step 4.1. If the label contains any non-ASCII code point (i.e., a code point greater than U+007F),
+                // record that there was an error, and continue with the next label.
+                if (preg_match('/[^\x00-\x7F]/', $label)) {
+                    $info->errors |= self::ERROR_PUNYCODE;
+
+                    continue;
+                }
+
+                // Step 4.2. Attempt to convert the rest of the label to Unicode according to Punycode [RFC3492]. If
+                // that conversion fails, record that there was an error, and continue
+                // with the next label. Otherwise replace the original label in the string by the results of the
+                // conversion.
                 try {
                     $label = self::punycodeDecode(substr($label, 4));
                 } catch (\Exception $e) {
@@ -516,6 +524,8 @@ final class Idn
             if ('-' === substr($label, -1, 1)) {
                 $info->errors |= self::ERROR_TRAILING_HYPHEN;
             }
+        } elseif ('xn--' === substr($label, 0, 4)) {
+            $info->errors |= self::ERROR_PUNYCODE;
         }
 
         // Step 4. The label must not contain a U+002E (.) FULL STOP.


### PR DESCRIPTION
This adds the necessary changes to conform to [IDNA version 15.1.0 revision 31](https://www.unicode.org/reports/tr46/tr46-31.html#Modifications).

Notable Changes

* Transitional processing (the default in PHP) is now deprecated. No deprecation notices were added as PHP does not yet report a deprecation notice in this case.
* An error is no longer recorded for characters with a status of disallowed.
* When performing code point mapping and transitional processing is enabled the code point U+1E9E capital sharp s (ẞ), is replaced by the string “ss”
* A new internal option "IgnoreInvalidPunycode" was added, which is supposed to allow for an all-ASCII fast-path, however, the official tests do not test this configuration option.