### PR TITLE
[PHP 8.3] Add `SQLite3Exception` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Polyfills are provided for:
 - the `ldap_connect_wallet` function introduced in PHP 8.3;
 - the `stream_context_set_options` function introduced in PHP 8.3;
 - the `Date*Exception/Error` classes introduced in PHP 8.3;
+- the `SQLite3Exception` class introduced in PHP 8.3;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no

--- a/src/Php83/README.md
+++ b/src/Php83/README.md
@@ -10,6 +10,7 @@ This component provides features added to PHP 8.3 core:
 - [`ldap_connect_wallet`](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)
 - [`stream_context_set_options`](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)
 - [`Date*Exception/Error classes`](https://wiki.php.net/rfc/datetime-exceptions)
+- [`SQLite3Exception`](https://wiki.php.net/rfc/sqlite3_exceptions)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).

--- a/src/Php83/Resources/stubs/SQLite3Exception.php
+++ b/src/Php83/Resources/stubs/SQLite3Exception.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80300) {
+    class SQLite3Exception extends Exception
+    {
+    }
+}


### PR DESCRIPTION
Adds the new SQLite3Exception exception class added in PHP 8.3.

 - [RFC](https://wiki.php.net/rfc/sqlite3_exceptions)
 - [`SQLite3Exception`](https://www.php.net/manual/en/class.sqlite3exception.php) (TODO)
 - [PHP 8.3: SQLite3: New `\SQLite3Exception`, deprecations, and changes](https://php.watch/versions/8.3/SQLite3-exception-improvements#SQLite3Exception)