### PR TITLE
[PHP 8.4] Add initial stubs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
                     - php: '8.1'
                     - php: '8.2'
                     - php: '8.3'
+                    - php: '8.4'
             fail-fast: false
 
         steps:

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ should **not** `require` the `symfony/polyfill` package, but the standalone ones
 - `symfony/polyfill-php81` for using the PHP 8.1 functions,
 - `symfony/polyfill-php82` for using the PHP 8.2 functions,
 - `symfony/polyfill-php83` for using the PHP 8.3 functions,
+- `symfony/polyfill-php84` for using the PHP 8.4 functions,
 - `symfony/polyfill-iconv` for using the iconv functions,
 - `symfony/polyfill-intl-grapheme` for using the `grapheme_*` functions,
 - `symfony/polyfill-intl-idn` for using the `idn_to_ascii` and `idn_to_utf8` functions,

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "symfony/polyfill-php81": "self.version",
         "symfony/polyfill-php82": "self.version",
         "symfony/polyfill-php83": "self.version",
+        "symfony/polyfill-php84": "self.version",
         "symfony/polyfill-iconv": "self.version",
         "symfony/polyfill-intl-grapheme": "self.version",
         "symfony/polyfill-intl-icu": "self.version",

--- a/src/Php84/LICENSE
+++ b/src/Php84/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Php84/Php84.php
+++ b/src/Php84/Php84.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Php84;
+
+/**
+ * @author Ayesh Karunaratne <ayesh@aye.sh>
+ *
+ * @internal
+ */
+final class Php84
+{
+}

--- a/src/Php84/README.md
+++ b/src/Php84/README.md
@@ -1,0 +1,12 @@
+Symfony Polyfill / Php84
+========================
+
+This component provides features added to PHP 8.4 core:
+
+More information can be found in the
+[main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).
+
+License
+=======
+
+This library is released under the [MIT license](LICENSE).

--- a/src/Php84/bootstrap.php
+++ b/src/Php84/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\Php84 as p;
+
+if (\PHP_VERSION_ID >= 80400) {
+    return;
+}

--- a/src/Php84/composer.json
+++ b/src/Php84/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "symfony/polyfill-php84",
+    "type": "library",
+    "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+    "keywords": ["polyfill", "shim", "compatibility", "portable"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Nicolas Grekas",
+            "email": "p@tchwork.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=7.1"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Polyfill\\Php84\\": "" },
+        "files": [ "bootstrap.php" ]
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.30-dev"
+        },
+        "thanks": {
+            "name": "symfony/polyfill",
+            "url": "https://github.com/symfony/polyfill"
+        }
+    }
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -36,3 +36,7 @@ if (\PHP_VERSION_ID < 80200) {
 if (\PHP_VERSION_ID < 80300) {
     require __DIR__.'/Php83/bootstrap.php';
 }
+
+if (\PHP_VERSION_ID < 80400) {
+    require __DIR__.'/Php84/bootstrap.php';
+}

--- a/tests/Php84/Php84Test.php
+++ b/tests/Php84/Php84Test.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Php84;
+
+use PHPUnit\Framework\TestCase;
+
+class Php84Test extends TestCase
+{
+}


### PR DESCRIPTION
 - Adds PHP 8.4 polyfill for splits
 - Enables PHP 8.4 in GitHub Actions tests

This is also to prepare for #458 to add new `mb_trim`, `mb_ltrim`, and `mb_rtrim` functions, which will be a separate PR.