### PR TITLE
Update nullable types for PHP 8.4

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+a7548a261ad4bcdb675adceb6604cf1681b1f6e2

--- a/src/Intl/Icu/DateFormat/Hour1200Transformer.php
+++ b/src/Intl/Icu/DateFormat/Hour1200Transformer.php
@@ -28,7 +28,7 @@ class Hour1200Transformer extends HourTransformer
         return $this->padLeft($hourOfDay, $length);
     }
 
-    public function normalizeHour(int $hour, string $marker = null): int
+    public function normalizeHour(int $hour, ?string $marker = null): int
     {
         if ('PM' === $marker) {
             $hour += 12;

--- a/src/Intl/Icu/DateFormat/Hour1201Transformer.php
+++ b/src/Intl/Icu/DateFormat/Hour1201Transformer.php
@@ -25,7 +25,7 @@ class Hour1201Transformer extends HourTransformer
         return $this->padLeft($dateTime->format('g'), $length);
     }
 
-    public function normalizeHour(int $hour, string $marker = null): int
+    public function normalizeHour(int $hour, ?string $marker = null): int
     {
         if ('PM' !== $marker && 12 === $hour) {
             $hour = 0;

--- a/src/Intl/Icu/DateFormat/Hour2400Transformer.php
+++ b/src/Intl/Icu/DateFormat/Hour2400Transformer.php
@@ -25,7 +25,7 @@ class Hour2400Transformer extends HourTransformer
         return $this->padLeft($dateTime->format('G'), $length);
     }
 
-    public function normalizeHour(int $hour, string $marker = null): int
+    public function normalizeHour(int $hour, ?string $marker = null): int
     {
         if ('AM' === $marker) {
             $hour = 0;

--- a/src/Intl/Icu/DateFormat/Hour2401Transformer.php
+++ b/src/Intl/Icu/DateFormat/Hour2401Transformer.php
@@ -28,7 +28,7 @@ class Hour2401Transformer extends HourTransformer
         return $this->padLeft($hourOfDay, $length);
     }
 
-    public function normalizeHour(int $hour, string $marker = null): int
+    public function normalizeHour(int $hour, ?string $marker = null): int
     {
         if ((null === $marker && 24 === $hour) || 'AM' === $marker) {
             $hour = 0;

--- a/src/Intl/Icu/DateFormat/HourTransformer.php
+++ b/src/Intl/Icu/DateFormat/HourTransformer.php
@@ -28,5 +28,5 @@ abstract class HourTransformer extends Transformer
      *
      * @return int The normalized hour value
      */
-    abstract public function normalizeHour(int $hour, string $marker = null): int;
+    abstract public function normalizeHour(int $hour, ?string $marker = null): int;
 }

--- a/src/Intl/Icu/IntlDateFormatter.php
+++ b/src/Intl/Icu/IntlDateFormatter.php
@@ -193,7 +193,7 @@ abstract class IntlDateFormatter
      * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed
      */
-    public static function create(?string $locale, ?int $dateType, ?int $timeType, $timezone = null, int $calendar = null, ?string $pattern = '')
+    public static function create(?string $locale, ?int $dateType, ?int $timeType, $timezone = null, ?int $calendar = null, ?string $pattern = '')
     {
         return new static($locale, $dateType, $timeType, $timezone, $calendar, $pattern);
     }
@@ -276,7 +276,7 @@ abstract class IntlDateFormatter
      *
      * @throws MethodNotImplementedException
      */
-    public static function formatObject($datetime, $format = null, string $locale = null)
+    public static function formatObject($datetime, $format = null, ?string $locale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }

--- a/src/Intl/Icu/Locale.php
+++ b/src/Intl/Icu/Locale.php
@@ -147,7 +147,7 @@ abstract class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getDisplayLanguage(string $locale, string $displayLocale = null)
+    public static function getDisplayLanguage(string $locale, ?string $displayLocale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -161,7 +161,7 @@ abstract class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getDisplayName(string $locale, string $displayLocale = null)
+    public static function getDisplayName(string $locale, ?string $displayLocale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -175,7 +175,7 @@ abstract class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getDisplayRegion(string $locale, string $displayLocale = null)
+    public static function getDisplayRegion(string $locale, ?string $displayLocale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -189,7 +189,7 @@ abstract class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getDisplayScript(string $locale, string $displayLocale = null)
+    public static function getDisplayScript(string $locale, ?string $displayLocale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -203,7 +203,7 @@ abstract class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function getDisplayVariant(string $locale, string $displayLocale = null)
+    public static function getDisplayVariant(string $locale, ?string $displayLocale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }
@@ -271,7 +271,7 @@ abstract class Locale
      *
      * @throws MethodNotImplementedException
      */
-    public static function lookup(array $languageTag, string $locale, bool $canonicalize = false, string $defaultLocale = null)
+    public static function lookup(array $languageTag, string $locale, bool $canonicalize = false, ?string $defaultLocale = null)
     {
         throw new MethodNotImplementedException(__METHOD__);
     }

--- a/src/Intl/Icu/NumberFormatter.php
+++ b/src/Intl/Icu/NumberFormatter.php
@@ -254,7 +254,7 @@ abstract class NumberFormatter
      * @throws MethodArgumentValueNotImplementedException When the $style is not supported
      * @throws MethodArgumentNotImplementedException      When the pattern value is different than null
      */
-    public function __construct(?string $locale = 'en', int $style = null, string $pattern = null)
+    public function __construct(?string $locale = 'en', ?int $style = null, ?string $pattern = null)
     {
         if ('en' !== $locale && null !== $locale) {
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'locale', $locale, 'Only the locale "en" is supported');
@@ -293,7 +293,7 @@ abstract class NumberFormatter
      * @throws MethodArgumentValueNotImplementedException When the $style is not supported
      * @throws MethodArgumentNotImplementedException      When the pattern value is different than null
      */
-    public static function create(?string $locale = 'en', int $style = null, string $pattern = null)
+    public static function create(?string $locale = 'en', ?int $style = null, ?string $pattern = null)
     {
         return new static($locale, $style, $pattern);
     }

--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -827,7 +827,7 @@ final class Mbstring
         return $code;
     }
 
-    public static function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = \STR_PAD_RIGHT, string $encoding = null): string
+    public static function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = \STR_PAD_RIGHT, ?string $encoding = null): string
     {
         if (!\in_array($pad_type, [\STR_PAD_RIGHT, \STR_PAD_LEFT, \STR_PAD_BOTH], true)) {
             throw new \ValueError('mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH');

--- a/src/Php83/Php83.php
+++ b/src/Php83/Php83.php
@@ -40,7 +40,7 @@ final class Php83
         return \JSON_ERROR_NONE === json_last_error();
     }
 
-    public static function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = \STR_PAD_RIGHT, string $encoding = null): string
+    public static function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = \STR_PAD_RIGHT, ?string $encoding = null): string
     {
         if (!\in_array($pad_type, [\STR_PAD_RIGHT, \STR_PAD_LEFT, \STR_PAD_BOTH], true)) {
             throw new \ValueError('mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH');

--- a/src/Php83/bootstrap.php
+++ b/src/Php83/bootstrap.php
@@ -40,7 +40,7 @@ if (\PHP_VERSION_ID >= 80100) {
 }
 
 if (!function_exists('ldap_exop_sync') && function_exists('ldap_exop')) {
-    function ldap_exop_sync($ldap, string $request_oid, string $request_data = null, array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $response_oid); }
+    function ldap_exop_sync($ldap, string $request_oid, ?string $request_data = null, ?array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $response_oid); }
 }
 
 if (!function_exists('ldap_connect_wallet') && function_exists('ldap_connect')) {

--- a/src/Php83/bootstrap81.php
+++ b/src/Php83/bootstrap81.php
@@ -14,7 +14,7 @@ if (\PHP_VERSION_ID >= 80300) {
 }
 
 if (!function_exists('ldap_exop_sync') && function_exists('ldap_exop')) {
-    function ldap_exop_sync(\LDAP\Connection $ldap, string $request_oid, string $request_data = null, array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $response_oid); }
+    function ldap_exop_sync(\LDAP\Connection $ldap, string $request_oid, ?string $request_data = null, ?array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $response_oid); }
 }
 
 if (!function_exists('ldap_connect_wallet') && function_exists('ldap_connect')) {

--- a/src/Util/TestListenerForV7.php
+++ b/src/Util/TestListenerForV7.php
@@ -26,7 +26,7 @@ class TestListenerForV7 extends TestSuite implements TestListenerInterface
     private $suite;
     private $trait;
 
-    public function __construct(TestSuite $suite = null)
+    public function __construct(?TestSuite $suite = null)
     {
         if ($suite) {
             $this->suite = $suite;

--- a/src/Util/TestListenerForV9.php
+++ b/src/Util/TestListenerForV9.php
@@ -23,7 +23,7 @@ class TestListenerForV9 extends TestSuite implements TestListenerInterface
     private $suite;
     private $trait;
 
-    public function __construct(TestSuite $suite = null)
+    public function __construct(?TestSuite $suite = null)
     {
         if ($suite) {
             $this->suite = $suite;
@@ -43,7 +43,7 @@ class TestListenerForV9 extends TestSuite implements TestListenerInterface
         $this->trait->addError($test, $t, $time);
     }
 
-    public function addWarning($test, Warning $e = null, float $time = null): void
+    public function addWarning($test, ?Warning $e = null, ?float $time = null): void
     {
         if (\is_string($test)) {
             parent::addWarning($test);

--- a/tests/Intl/Icu/AbstractNumberFormatterTest.php
+++ b/tests/Intl/Icu/AbstractNumberFormatterTest.php
@@ -886,7 +886,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
     /**
      * @return NumberFormatter|\NumberFormatter
      */
-    abstract protected static function getNumberFormatter(string $locale = 'en', string $style = null, string $pattern = null);
+    abstract protected static function getNumberFormatter(string $locale = 'en', ?string $style = null, ?string $pattern = null);
 
     abstract protected static function getIntlErrorMessage(): string;
 

--- a/tests/Intl/Icu/NumberFormatterTest.php
+++ b/tests/Intl/Icu/NumberFormatterTest.php
@@ -171,7 +171,7 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
         $formatter->setTextAttribute(NumberFormatter::NEGATIVE_PREFIX, '-');
     }
 
-    protected static function getNumberFormatter(?string $locale = 'en', string $style = null, string $pattern = null): NumberFormatter
+    protected static function getNumberFormatter(?string $locale = 'en', ?string $style = null, ?string $pattern = null): NumberFormatter
     {
         return new class($locale, $style, $pattern) extends NumberFormatter {
         };

--- a/tests/Intl/Icu/Verification/NumberFormatterTest.php
+++ b/tests/Intl/Icu/Verification/NumberFormatterTest.php
@@ -46,7 +46,7 @@ class NumberFormatterTest extends AbstractNumberFormatterTest
         parent::testGetTextAttribute();
     }
 
-    protected static function getNumberFormatter(?string $locale = 'en', string $style = null, string $pattern = null): \NumberFormatter
+    protected static function getNumberFormatter(?string $locale = 'en', ?string $style = null, ?string $pattern = null): \NumberFormatter
     {
         return new \NumberFormatter($locale, $style, $pattern);
     }

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -635,7 +635,7 @@ class MbstringTest extends TestCase
      * @dataProvider paddingEmojiProvider
      * @dataProvider paddingEncodingProvider
      */
-    public function testMbStrPad(string $expectedResult, string $string, int $length, string $padString, int $padType, string $encoding = null): void
+    public function testMbStrPad(string $expectedResult, string $string, int $length, string $padString, int $padType, ?string $encoding = null): void
     {
         if ('UTF-32' === $encoding && \PHP_VERSION_ID < 73000) {
             $this->markTestSkipped('PHP < 7.3 doesn\'t handle UTF-32 encoding properly');
@@ -649,7 +649,7 @@ class MbstringTest extends TestCase
      *
      * @dataProvider mbStrPadInvalidArgumentsProvider
      */
-    public function testMbStrPadInvalidArguments(string $expectedError, string $string, int $length, string $padString, int $padType, string $encoding = null): void
+    public function testMbStrPadInvalidArguments(string $expectedError, string $string, int $length, string $padString, int $padType, ?string $encoding = null): void
     {
         $this->expectException(\ValueError::class);
         $this->expectErrorMessage($expectedError);

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -33,7 +33,7 @@ class Php83Test extends TestCase
      * @dataProvider paddingEmojiProvider
      * @dataProvider paddingEncodingProvider
      */
-    public function testMbStrPad(string $expectedResult, string $string, int $length, string $padString, int $padType, string $encoding = null): void
+    public function testMbStrPad(string $expectedResult, string $string, int $length, string $padString, int $padType, ?string $encoding = null): void
     {
         $this->assertSame($expectedResult, mb_convert_encoding(mb_str_pad($string, $length, $padString, $padType, $encoding), 'UTF-8', $encoding ?? mb_internal_encoding()));
     }
@@ -43,7 +43,7 @@ class Php83Test extends TestCase
      *
      * @dataProvider mbStrPadInvalidArgumentsProvider
      */
-    public function testMbStrPadInvalidArguments(string $expectedError, string $string, int $length, string $padString, int $padType, string $encoding = null): void
+    public function testMbStrPadInvalidArguments(string $expectedError, string $string, int $length, string $padString, int $padType, ?string $encoding = null): void
     {
         $this->expectException(\ValueError::class);
         $this->expectErrorMessage($expectedError);


### PR DESCRIPTION
The PR is meant to fix the deprecation notices raised since php/php-src@330cc5cdb2096c5d41041eaae1f1cc0ed7e36898

I had tried to update the php-cs-fixer rule, but running the fixer is re-formatting all the method bodies and I couldn't figure out how to cleanly get the desired result, so I used a trusted editor and some preg-fu to get the desired result.