### PR TITLE
[CS] Remove 'nullable_type_declaration_for_default_null_value' rule

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -30,7 +30,6 @@ return (new PhpCsFixer\Config())
         '@Symfony:risky' => true,
         'protected_to_private' => false,
         'native_constant_invocation' => ['strict' => false],
-        'nullable_type_declaration_for_default_null_value' => ['use_nullable_type_declaration' => false],
         'no_superfluous_phpdoc_tags' => ['remove_inheritdoc' => true],
         'header_comment' => ['header' => $fileHeaderComment],
     ])


### PR DESCRIPTION
Not too sure here with all the PHP versions to consider...

Using [nullable_type_declaration_for_default_null_value](https://cs.symfony.com/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.html) rule with value `['use_nullable_type_declaration' => false]` is deprecated.

And, if i take the [Example 4](https://cs.symfony.com/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.html#example-4), this rule enforces code that will trigger deprecation warning with PHP 8.4.. right ? 

```diff
--- Original
+++ New
 <?php
-function sample(string|int|null $str = null)
+function sample(string|int $str = null)
 {}
```

I guess it's not so simple to revert the rule, so maybe a first step could be to remove the rule and avoid CI failures ? 


