### PR TITLE
[Mbstring] The first arg of mb_convert_encoding can be an array

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -82,6 +82,21 @@ final class Mbstring
 
     public static function mb_convert_encoding($s, $toEncoding, $fromEncoding = null)
     {
+        if (\is_array($s)) {
+            if (PHP_VERSION_ID < 70200) {
+                trigger_error('mb_convert_encoding() expects parameter 1 to be string, array given', \E_USER_WARNING);
+
+                return null;
+            }
+
+            $r = [];
+            foreach ($s as $str) {
+                $r[] = self::mb_convert_encoding($str, $toEncoding, $fromEncoding);
+            }
+
+            return $r;
+        }
+
         if (\is_array($fromEncoding) || (null !== $fromEncoding && false !== strpos($fromEncoding, ','))) {
             $fromEncoding = self::mb_detect_encoding($s, $fromEncoding);
         } else {

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -78,6 +78,30 @@ class MbstringTest extends TestCase
     }
 
     /**
+     * @covers \Symfony\Polyfill\Mbstring\Mbstring::mb_convert_encoding
+     *
+     * @requires PHP 7.2
+     */
+    public function testConvertEncodingWithArrayValue()
+    {
+        $this->assertSame(['déjà', 'là'], mb_convert_encoding(['d&eacute;j&#224;', 'l&#224;'], 'Utf-8', 'Html-entities'));
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Mbstring\Mbstring::mb_convert_encoding
+     *
+     * @requires PHP < 7.2
+     */
+    public function testConvertEncodingWithArrayValueForPhpLessThan72()
+    {
+        $errorMessage = null;
+        set_error_handler(function ($type, $msg, $file, $line) use (&$errorMessage) { $errorMessage = \E_USER_WARNING === $type || \E_WARNING === $type ? $msg : null; });
+        $this->assertNull(mb_convert_encoding(['d&eacute;j&#224;', 'l&#224;'], 'Utf-8', 'Html-entities'));
+        restore_error_handler();
+        $this->assertSame('mb_convert_encoding() expects parameter 1 to be string, array given', $errorMessage);
+    }
+
+    /**
      * @covers \Symfony\Polyfill\Mbstring\Mbstring::mb_decode_numericentity
      */
     public function testDecodeNumericEntity()


### PR DESCRIPTION
As the [documentation](https://www.php.net/manual/en/function.mb-convert-encoding.php) says, since PHP 7.2 the first argument of `mb_convert_encoding` can be an array.