### PR TITLE
[PHP 8.4] Add `CURL_HTTP_VERSION_3(ONLY)` constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Polyfills are provided for:
 - the `array_find`, `array_find_key`, `array_any` and `array_all` functions introduced in PHP 8.4;
 - the `Deprecated` attribute introduced in PHP 8.4;
 - the `mb_trim`, `mb_ltrim` and `mb_rtrim` functions introduced in PHP 8.4;
+- the `CURL_HTTP_VERSION_3` and `CURL_HTTP_VERSION_3ONLY` constants introduced in PHP 8.4;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no

--- a/src/Php84/README.md
+++ b/src/Php84/README.md
@@ -6,6 +6,7 @@ This component provides features added to PHP 8.4 core:
 - [`mb_ucfirst` and `mb_lcfirst`](https://wiki.php.net/rfc/mb_ucfirst)
 - [`array_find`, `array_find_key`, `array_any` and `array_all`](https://wiki.php.net/rfc/array_find)
 - [`Deprecated`](https://wiki.php.net/rfc/deprecated_attribute)
+- `CURL_HTTP_VERSION_3` and `CURL_HTTP_VERSION_3ONLY` constants
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).

--- a/src/Php84/bootstrap.php
+++ b/src/Php84/bootstrap.php
@@ -15,6 +15,14 @@ if (\PHP_VERSION_ID >= 80400) {
     return;
 }
 
+if (defined('CURL_VERSION_HTTP3') || PHP_VERSION_ID < 80200 && function_exists('curl_version') && curl_version()['version'] >= 0x074200) { // libcurl >= 7.66.0
+    define('CURL_HTTP_VERSION_3', 30);
+
+    if (defined('CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256')) { // libcurl >= 7.80.0 (7.88 would be better but is slow to check)
+        define('CURL_HTTP_VERSION_3ONLY', 31);
+    }
+}
+
 if (!function_exists('array_find')) {
     function array_find(array $array, callable $callback) { return p\Php84::array_find($array, $callback); }
 }

--- a/tests/Php84/Php84Test.php
+++ b/tests/Php84/Php84Test.php
@@ -64,6 +64,18 @@ class Php84Test extends TestCase
         $this->assertSame($expected, array_all($array, $callback));
     }
 
+    /**
+     * @requires extension curl
+     */
+    public function testCurlHttp3Constants()
+    {
+        $ch = curl_init();
+        $hasH3 = defined('CURL_VERSION_HTTP3') && (curl_version()['features'] & CURL_VERSION_HTTP3);
+
+        $this->assertSame($hasH3, curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3));
+        $this->assertSame($hasH3 && defined('CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256'), curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3ONLY));
+    }
+
     public static function ucFirstDataProvider(): array
     {
         return [


### PR DESCRIPTION
If the underlying Curl build supports it, setting the HTTP version should be theoretically possible. The availability of the constants do not guarantee the feature support, so declaring them in the polyfill should be same and effective.

 - PR that added constants: [php-src#15350](https://github.com/php/php-src/pull/15350)
 - libcurl doc on `CURLOPT_HTTP_VERSION`](https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html)
 - [PHP.Watch: HTTP/3 Request with PHP Curl Extension](https://php.watch/articles/php-curl-http3)
 - Codex for [`CURL_HTTP_VERSION_3`](https://php.watch/codex/CURL_HTTP_VERSION_3) and [`CURL_HTTP_VERSION_3ONLY`](https://php.watch/codex/CURL_HTTP_VERSION_3ONLY)

Fixes GH-488.