### PR TITLE
Security Fix: Argument of a function used in an include/require, could lead to File Inclusion

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -953,8 +953,8 @@ final class Mbstring
 
     private static function getData($file)
     {
-        if (file_exists($file = __DIR__.'/Resources/unidata/'.$file.'.php')) {
-            return require $file;
+        if (file_exists(__DIR__.'/Resources/unidata/'.$file.'.php')) {
+            return require __DIR__.'/Resources/unidata/'.$file.'.php';
         }
 
         return false;


### PR DESCRIPTION

Argument of a function used in an include/require, could lead to File Inclusion | audit.php.lang.security.file.inclusion-arg
-- | --

Error from semgrep
audit.php.lang.security.file.inclusion-arg