### PR TITLE
mbstring polyfills must not raise value errors in PHP 7

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -194,7 +194,7 @@ final class Mbstring
             $convmap[$i + 1] += $convmap[$i + 2];
         }
 
-        $s = preg_replace_callback('/&#(?:0*([0-9]+)|x0*([0-9a-fA-F]+))(?!&);?/', static function (array $m) use ($cnt, $convmap) {
+        $s = preg_replace_callback('/&#(?:0*([0-9]+)|x0*([0-9a-fA-F]+))'.(\PHP_VERSION_ID >= 80200 ? '' : '(?!&)').';?/', static function (array $m) use ($cnt, $convmap) {
             $c = isset($m[2]) ? (int) hexdec($m[2]) : $m[1];
             for ($i = 0; $i < $cnt; $i += 4) {
                 if ($c >= $convmap[$i] && $c <= $convmap[$i + 1]) {
@@ -834,19 +834,32 @@ final class Mbstring
         return $code;
     }
 
-    public static function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = \STR_PAD_RIGHT, ?string $encoding = null): string
+    /** @return string|false */
+    public static function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = \STR_PAD_RIGHT, ?string $encoding = null)
     {
         if (!\in_array($pad_type, [\STR_PAD_RIGHT, \STR_PAD_LEFT, \STR_PAD_BOTH], true)) {
+            if (\PHP_VERSION_ID < 80000) {
+                trigger_error('mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH', \E_USER_WARNING);
+
+                return false;
+            }
+
             throw new \ValueError('mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH');
         }
 
         if (null === $encoding) {
             $encoding = self::mb_internal_encoding();
-        } else {
-            self::assertEncoding($encoding, 'mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "%s" given');
+        } elseif (!self::assertEncoding($encoding, 'mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "%s" given')) {
+            return false;
         }
 
         if (self::mb_strlen($pad_string, $encoding) <= 0) {
+            if (\PHP_VERSION_ID < 80000) {
+                trigger_error('mb_str_pad(): Argument #3 ($pad_string) must be a non-empty string', \E_USER_WARNING);
+
+                return false;
+            }
+
             throw new \ValueError('mb_str_pad(): Argument #3 ($pad_string) must be a non-empty string');
         }
 
@@ -869,12 +882,13 @@ final class Mbstring
         }
     }
 
-    public static function mb_ucfirst(string $string, ?string $encoding = null): string
+    /** @return string|false */
+    public static function mb_ucfirst(string $string, ?string $encoding = null)
     {
         if (null === $encoding) {
             $encoding = self::mb_internal_encoding();
-        } else {
-            self::assertEncoding($encoding, 'mb_ucfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given');
+        } elseif (!self::assertEncoding($encoding, 'mb_ucfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given')) {
+            return false;
         }
 
         $firstChar = mb_substr($string, 0, 1, $encoding);
@@ -883,12 +897,13 @@ final class Mbstring
         return $firstChar.mb_substr($string, 1, null, $encoding);
     }
 
-    public static function mb_lcfirst(string $string, ?string $encoding = null): string
+    /** @return string|false */
+    public static function mb_lcfirst(string $string, ?string $encoding = null)
     {
         if (null === $encoding) {
             $encoding = self::mb_internal_encoding();
-        } else {
-            self::assertEncoding($encoding, 'mb_lcfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given');
+        } elseif (!self::assertEncoding($encoding, 'mb_lcfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given')) {
+            return false;
         }
 
         $firstChar = mb_substr($string, 0, 1, $encoding);
@@ -968,30 +983,42 @@ final class Mbstring
             return 'UTF-8';
         }
 
+        if ('UTF-32' === $encoding) {
+            return 'UTF-32BE';
+        }
+
+        if ('UTF-16' === $encoding) {
+            return 'UTF-16BE';
+        }
+
         return $encoding;
     }
 
-    public static function mb_trim(string $string, ?string $characters = null, ?string $encoding = null): string
+    /** @return string|false */
+    public static function mb_trim(string $string, ?string $characters = null, ?string $encoding = null)
     {
         return self::mb_internal_trim('{^[%s]+|[%1$s]+$}Du', $string, $characters, $encoding, __FUNCTION__);
     }
 
-    public static function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null): string
+    /** @return string|false */
+    public static function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null)
     {
         return self::mb_internal_trim('{^[%s]+}Du', $string, $characters, $encoding, __FUNCTION__);
     }
 
-    public static function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null): string
+    /** @return string|false */
+    public static function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null)
     {
         return self::mb_internal_trim('{[%s]+$}Du', $string, $characters, $encoding, __FUNCTION__);
     }
 
-    private static function mb_internal_trim(string $regex, string $string, ?string $characters, ?string $encoding, string $function): string
+    /** @return string|false */
+    private static function mb_internal_trim(string $regex, string $string, ?string $characters, ?string $encoding, string $function)
     {
         if (null === $encoding) {
             $encoding = self::mb_internal_encoding();
-        } else {
-            self::assertEncoding($encoding, $function.'(): Argument #3 ($encoding) must be a valid encoding, "%s" given');
+        } elseif (!self::assertEncoding($encoding, $function.'(): Argument #3 ($encoding) must be a valid encoding, "%s" given')) {
+            return false;
         }
 
         if ('' === $characters) {
@@ -1029,7 +1056,7 @@ final class Mbstring
         return iconv('UTF-8', $encoding.'//IGNORE', $string);
     }
 
-    private static function assertEncoding(string $encoding, string $errorFormat): void
+    private static function assertEncoding(string $encoding, string $errorFormat): bool
     {
         try {
             $validEncoding = @self::mb_check_encoding('', $encoding);
@@ -1037,9 +1064,14 @@ final class Mbstring
             throw new \ValueError(\sprintf($errorFormat, $encoding));
         }
 
-        // BC for PHP 7.3 and lower
         if (!$validEncoding) {
-            throw new \ValueError(\sprintf($errorFormat, $encoding));
+            if (80000 > \PHP_VERSION_ID) {
+                trigger_error(\sprintf($errorFormat, $encoding), \E_USER_WARNING);
+            } else {
+                throw new \ValueError(\sprintf($errorFormat, $encoding));
+            }
         }
+
+        return $validEncoding;
     }
 }

--- a/src/Mbstring/bootstrap.php
+++ b/src/Mbstring/bootstrap.php
@@ -133,27 +133,27 @@ if (!function_exists('mb_str_split')) {
 }
 
 if (!function_exists('mb_str_pad')) {
-    function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = STR_PAD_RIGHT, ?string $encoding = null): string { return p\Mbstring::mb_str_pad($string, $length, $pad_string, $pad_type, $encoding); }
+    function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = STR_PAD_RIGHT, ?string $encoding = null) { return p\Mbstring::mb_str_pad($string, $length, $pad_string, $pad_type, $encoding); }
 }
 
 if (!function_exists('mb_ucfirst')) {
-    function mb_ucfirst(string $string, ?string $encoding = null): string { return p\Mbstring::mb_ucfirst($string, $encoding); }
+    function mb_ucfirst(string $string, ?string $encoding = null) { return p\Mbstring::mb_ucfirst($string, $encoding); }
 }
 
 if (!function_exists('mb_lcfirst')) {
-    function mb_lcfirst(string $string, ?string $encoding = null): string { return p\Mbstring::mb_lcfirst($string, $encoding); }
+    function mb_lcfirst(string $string, ?string $encoding = null) { return p\Mbstring::mb_lcfirst($string, $encoding); }
 }
 
 if (!function_exists('mb_trim')) {
-    function mb_trim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Mbstring::mb_trim($string, $characters, $encoding); }
+    function mb_trim(string $string, ?string $characters = null, ?string $encoding = null) { return p\Mbstring::mb_trim($string, $characters, $encoding); }
 }
 
 if (!function_exists('mb_ltrim')) {
-    function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Mbstring::mb_ltrim($string, $characters, $encoding); }
+    function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null) { return p\Mbstring::mb_ltrim($string, $characters, $encoding); }
 }
 
 if (!function_exists('mb_rtrim')) {
-    function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Mbstring::mb_rtrim($string, $characters, $encoding); }
+    function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null) { return p\Mbstring::mb_rtrim($string, $characters, $encoding); }
 }
 
 if (extension_loaded('mbstring')) {

--- a/src/Php83/Php83.php
+++ b/src/Php83/Php83.php
@@ -40,7 +40,8 @@ final class Php83
         return \JSON_ERROR_NONE === json_last_error();
     }
 
-    public static function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = \STR_PAD_RIGHT, ?string $encoding = null): string
+    /** @return string|false */
+    public static function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = \STR_PAD_RIGHT, ?string $encoding = null)
     {
         if (!\in_array($pad_type, [\STR_PAD_RIGHT, \STR_PAD_LEFT, \STR_PAD_BOTH], true)) {
             throw new \ValueError('mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH');
@@ -50,19 +51,27 @@ final class Php83
             $encoding = mb_internal_encoding();
         }
 
+        $errorToTrigger = null;
         try {
-            $validEncoding = @mb_check_encoding('', $encoding);
+            if (!@mb_check_encoding('', $encoding)) {
+                $errorToTrigger = \sprintf('mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "%s" given', $encoding);
+            }
         } catch (\ValueError $e) {
-            throw new \ValueError(\sprintf('mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "%s" given', $encoding));
-        }
-
-        // BC for PHP 7.3 and lower
-        if (!$validEncoding) {
-            throw new \ValueError(\sprintf('mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "%s" given', $encoding));
+            $errorToTrigger = \sprintf('mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "%s" given', $encoding);
         }
 
         if (mb_strlen($pad_string, $encoding) <= 0) {
-            throw new \ValueError('mb_str_pad(): Argument #3 ($pad_string) must be a non-empty string');
+            $errorToTrigger = 'mb_str_pad(): Argument #3 ($pad_string) must be a non-empty string';
+        }
+
+        if (null !== $errorToTrigger) {
+            if (80000 > \PHP_VERSION_ID) {
+                trigger_error($errorToTrigger, \E_USER_WARNING);
+
+                return false;
+            }
+
+            throw new \ValueError($errorToTrigger);
         }
 
         $paddingRequired = $length - mb_strlen($string, $encoding);

--- a/src/Php83/bootstrap.php
+++ b/src/Php83/bootstrap.php
@@ -19,12 +19,6 @@ if (!function_exists('json_validate')) {
     function json_validate(string $json, int $depth = 512, int $flags = 0): bool { return p\Php83::json_validate($json, $depth, $flags); }
 }
 
-if (extension_loaded('mbstring')) {
-    if (!function_exists('mb_str_pad')) {
-        function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = STR_PAD_RIGHT, ?string $encoding = null): string { return p\Php83::mb_str_pad($string, $length, $pad_string, $pad_type, $encoding); }
-    }
-}
-
 if (!function_exists('stream_context_set_options')) {
     function stream_context_set_options($context, array $options): bool { return stream_context_set_option($context, $options); }
 }
@@ -37,8 +31,14 @@ if (!function_exists('str_decrement')) {
     function str_decrement(string $string): string { return p\Php83::str_decrement($string); }
 }
 
-if (\PHP_VERSION_ID >= 80100) {
-    return require __DIR__.'/bootstrap81.php';
+if (\PHP_VERSION_ID >= 80000) {
+    return require __DIR__.'/bootstrap80.php';
+}
+
+if (extension_loaded('mbstring')) {
+    if (!function_exists('mb_str_pad')) {
+        function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = STR_PAD_RIGHT, ?string $encoding = null) { return p\Php83::mb_str_pad($string, $length, $pad_string, $pad_type, $encoding); }
+    }
 }
 
 if (!function_exists('ldap_exop_sync') && function_exists('ldap_exop')) {

--- a/src/Php83/bootstrap80.php
+++ b/src/Php83/bootstrap80.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\Php83 as p;
+
+if (extension_loaded('mbstring')) {
+    if (!function_exists('mb_str_pad')) {
+        function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = STR_PAD_RIGHT, ?string $encoding = null): string { return p\Php83::mb_str_pad($string, $length, $pad_string, $pad_type, $encoding); }
+    }
+}
+
+if (\PHP_VERSION_ID >= 80100) {
+    return require __DIR__.'/bootstrap81.php';
+}
+
+if (!function_exists('ldap_exop_sync') && function_exists('ldap_exop')) {
+    function ldap_exop_sync($ldap, string $request_oid, ?string $request_data = null, ?array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $response_oid); }
+}
+
+if (!function_exists('ldap_connect_wallet') && function_exists('ldap_connect')) {
+    function ldap_connect_wallet(?string $uri, string $wallet, string $password, int $auth_mode = \GSLC_SSL_NO_AUTH) { return ldap_connect($uri, $wallet, $password, $auth_mode); }
+}

--- a/src/Php84/Php84.php
+++ b/src/Php84/Php84.php
@@ -19,7 +19,8 @@ namespace Symfony\Polyfill\Php84;
  */
 final class Php84
 {
-    public static function mb_ucfirst(string $string, ?string $encoding = null): string
+    /** @return string|false */
+    public static function mb_ucfirst(string $string, ?string $encoding = null)
     {
         if (null === $encoding) {
             $encoding = mb_internal_encoding();
@@ -31,8 +32,13 @@ final class Php84
             throw new \ValueError(\sprintf('mb_ucfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding));
         }
 
-        // BC for PHP 7.3 and lower
         if (!$validEncoding) {
+            if (80000 > \PHP_VERSION_ID) {
+                trigger_error(\sprintf('mb_ucfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding), \E_USER_WARNING);
+
+                return false;
+            }
+
             throw new \ValueError(\sprintf('mb_ucfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding));
         }
 
@@ -42,7 +48,8 @@ final class Php84
         return $firstChar.mb_substr($string, 1, null, $encoding);
     }
 
-    public static function mb_lcfirst(string $string, ?string $encoding = null): string
+    /** @return string|false */
+    public static function mb_lcfirst(string $string, ?string $encoding = null)
     {
         if (null === $encoding) {
             $encoding = mb_internal_encoding();
@@ -54,8 +61,13 @@ final class Php84
             throw new \ValueError(\sprintf('mb_lcfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding));
         }
 
-        // BC for PHP 7.3 and lower
         if (!$validEncoding) {
+            if (80000 > \PHP_VERSION_ID) {
+                trigger_error(\sprintf('mb_lcfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding), \E_USER_WARNING);
+
+                return false;
+            }
+
             throw new \ValueError(\sprintf('mb_lcfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding));
         }
 
@@ -114,22 +126,26 @@ final class Php84
         return $num ** $exponent;
     }
 
-    public static function mb_trim(string $string, ?string $characters = null, ?string $encoding = null): string
+    /** @return string|false */
+    public static function mb_trim(string $string, ?string $characters = null, ?string $encoding = null)
     {
         return self::mb_internal_trim('{^[%s]+|[%1$s]+$}Du', $string, $characters, $encoding, __FUNCTION__);
     }
 
-    public static function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null): string
+    /** @return string|false */
+    public static function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null)
     {
         return self::mb_internal_trim('{^[%s]+}Du', $string, $characters, $encoding, __FUNCTION__);
     }
 
-    public static function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null): string
+    /** @return string|false */
+    public static function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null)
     {
-        return self::mb_internal_trim('{[%s]+$}Du', $string, $characters, $encoding, __FUNCTION__);
+        return self::mb_internal_trim('{[%s]+$}D', $string, $characters, $encoding, __FUNCTION__);
     }
 
-    private static function mb_internal_trim(string $regex, string $string, ?string $characters, ?string $encoding, string $function): string
+    /** @return string|false */
+    private static function mb_internal_trim(string $regex, string $string, ?string $characters, ?string $encoding, string $function)
     {
         if (null === $encoding) {
             $encoding = mb_internal_encoding();
@@ -141,8 +157,13 @@ final class Php84
             throw new \ValueError(\sprintf('%s(): Argument #3 ($encoding) must be a valid encoding, "%s" given', $function, $encoding));
         }
 
-        // BC for PHP 7.3 and lower
         if (!$validEncoding) {
+            if (80000 > \PHP_VERSION_ID) {
+                trigger_error(\sprintf('%s(): Argument #3 ($encoding) must be a valid encoding, "%s" given', $function, $encoding), \E_USER_WARNING);
+
+                return false;
+            }
+
             throw new \ValueError(\sprintf('%s(): Argument #3 ($encoding) must be a valid encoding, "%s" given', $function, $encoding));
         }
 

--- a/src/Php84/bootstrap.php
+++ b/src/Php84/bootstrap.php
@@ -45,25 +45,29 @@ if (!function_exists('fpow')) {
     function fpow(float $num, float $exponent): float { return p\Php84::fpow($num, $exponent); }
 }
 
+if (\PHP_VERSION_ID >= 80000) {
+    return require __DIR__.'/bootstrap80.php';
+}
+
 if (extension_loaded('mbstring')) {
     if (!function_exists('mb_ucfirst')) {
-        function mb_ucfirst(string $string, ?string $encoding = null): string { return p\Php84::mb_ucfirst($string, $encoding); }
+        function mb_ucfirst(string $string, ?string $encoding = null) { return p\Php84::mb_ucfirst($string, $encoding); }
     }
 
     if (!function_exists('mb_lcfirst')) {
-        function mb_lcfirst(string $string, ?string $encoding = null): string { return p\Php84::mb_lcfirst($string, $encoding); }
+        function mb_lcfirst(string $string, ?string $encoding = null) { return p\Php84::mb_lcfirst($string, $encoding); }
     }
 
     if (!function_exists('mb_trim')) {
-        function mb_trim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Php84::mb_trim($string, $characters, $encoding); }
+        function mb_trim(string $string, ?string $characters = null, ?string $encoding = null) { return p\Php84::mb_trim($string, $characters, $encoding); }
     }
 
     if (!function_exists('mb_ltrim')) {
-        function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Php84::mb_ltrim($string, $characters, $encoding); }
+        function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null) { return p\Php84::mb_ltrim($string, $characters, $encoding); }
     }
 
     if (!function_exists('mb_rtrim')) {
-        function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Php84::mb_rtrim($string, $characters, $encoding); }
+        function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null) { return p\Php84::mb_rtrim($string, $characters, $encoding); }
     }
 }
 
@@ -80,10 +84,6 @@ if (extension_loaded('bcmath')) {
     if (!function_exists('bcround')) {
         function bcround(string $num, int $precision = 0, $mode = RoundingMode::HalfAwayFromZero): string { return p\Php84::bcround($num, $precision, $mode); }
     }
-}
-
-if (\PHP_VERSION_ID >= 80200) {
-    return require __DIR__.'/bootstrap82.php';
 }
 
 if (extension_loaded('intl') && !function_exists('grapheme_str_split')) {

--- a/src/Php84/bootstrap80.php
+++ b/src/Php84/bootstrap80.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\Php84 as p;
+
+if (extension_loaded('mbstring')) {
+    if (!function_exists('mb_ucfirst')) {
+        function mb_ucfirst(string $string, ?string $encoding = null): string { return p\Php84::mb_ucfirst($string, $encoding); }
+    }
+
+    if (!function_exists('mb_lcfirst')) {
+        function mb_lcfirst(string $string, ?string $encoding = null): string { return p\Php84::mb_lcfirst($string, $encoding); }
+    }
+
+    if (!function_exists('mb_trim')) {
+        function mb_trim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Php84::mb_trim($string, $characters, $encoding); }
+    }
+
+    if (!function_exists('mb_ltrim')) {
+        function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Php84::mb_ltrim($string, $characters, $encoding); }
+    }
+
+    if (!function_exists('mb_rtrim')) {
+        function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Php84::mb_rtrim($string, $characters, $encoding); }
+    }
+}
+
+if (extension_loaded('bcmath')) {
+    if (!function_exists('bcceil')) {
+        function bcceil(string $num): string { return p\Php84::bcceil($num); }
+    }
+    if (!function_exists('bcdivmod')) {
+        function bcdivmod(string $num1, string $num2, ?int $scale = null): ?array { return p\Php84::bcdivmod($num1, $num2, $scale); }
+    }
+    if (!function_exists('bcfloor')) {
+        function bcfloor(string $num): string { return p\Php84::bcfloor($num); }
+    }
+    if (!function_exists('bcround')) {
+        function bcround(string $num, int $precision = 0, $mode = RoundingMode::HalfAwayFromZero): string { return p\Php84::bcround($num, $precision, $mode); }
+    }
+}
+
+if (\PHP_VERSION_ID >= 80200) {
+    return require __DIR__.'/bootstrap82.php';
+}
+
+if (extension_loaded('intl') && !function_exists('grapheme_str_split')) {
+    function grapheme_str_split(string $string, int $length = 1) { return p\Php84::grapheme_str_split($string, $length); }
+}

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -121,7 +121,11 @@ class MbstringTest extends TestCase
         $this->assertSame('déjà &#0; â ã', mb_decode_numericentity('déjà &#0; &#225; &#226;', $convmap, 'UTF-8'));
 
         $bogusDecEntities = 'déjà &#0; &#225;&#225; &#&#225&#225 &#225 &#225t';
-        $this->assertSame('déjà &#0; ââ &#&#225â â ât', mb_decode_numericentity($bogusDecEntities, $convmap, 'UTF-8'));
+        if (80200 <= \PHP_VERSION_ID) {
+            $this->assertSame('déjà &#0; ââ &#ââ â ât', mb_decode_numericentity($bogusDecEntities, $convmap, 'UTF-8'));
+        } else {
+            $this->assertSame('déjà &#0; ââ &#&#225â â ât', mb_decode_numericentity($bogusDecEntities, $convmap, 'UTF-8'));
+        }
 
         $bogusHexEntities = 'déjà &#x0; &#xe1;&#xe1; &#xe1 &#xe1t &#xE1 &#xE1t';
         $this->assertSame('déjà &#x0; ââ â ât â ât', mb_decode_numericentity($bogusHexEntities, $convmap, 'UTF-8'));
@@ -648,13 +652,38 @@ class MbstringTest extends TestCase
      * @covers \Symfony\Polyfill\Mbstring\Mbstring::mb_str_pad
      *
      * @dataProvider mbStrPadInvalidArgumentsProvider
+     *
+     * @requires PHP 8
      */
     public function testMbStrPadInvalidArguments(string $expectedError, string $string, int $length, string $padString, int $padType, ?string $encoding = null)
     {
         $this->expectException(\ValueError::class);
-        $this->expectErrorMessage($expectedError);
+        $this->expectExceptionMessage($expectedError);
 
         mb_str_pad($string, $length, $padString, $padType, $encoding);
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Mbstring\Mbstring::mb_str_pad
+     *
+     * @dataProvider mbStrPadInvalidArgumentsProvider
+     *
+     * @requires PHP < 8
+     */
+    public function testMbStrPadInvalidArgumentsOnPhp7(string $expectedError, string $string, int $length, string $padString, int $padType, ?string $encoding = null)
+    {
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessage($expectedError);
+
+        set_error_handler(static function ($errno, $errstr, $errfile, $errline) {
+            throw new \ErrorException($errstr, $errno, $errfile, $errline);
+        });
+
+        try {
+            mb_str_pad($string, $length, $padString, $padType, $encoding);
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**
@@ -815,10 +844,34 @@ class MbstringTest extends TestCase
         $this->assertSame($expected, mb_rtrim($string, $characters, $encoding));
     }
 
+    /**
+     * @requires PHP 8
+     */
     public function testMbTrimException()
     {
         $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('mb_trim(): Argument #3 ($encoding) must be a valid encoding, "NULL" given');
+
         mb_trim("\u{180F}", '', 'NULL');
+    }
+
+    /**
+     * @requires PHP < 8
+     */
+    public function testMbTrimExceptionOnPhp7()
+    {
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessage('mb_trim(): Argument #3 ($encoding) must be a valid encoding, "NULL" given');
+
+        set_error_handler(static function ($errno, $errstr, $errfile, $errline) {
+            throw new \ErrorException($errstr, $errno, $errfile, $errline);
+        });
+
+        try {
+            mb_trim("\u{180F}", '', 'NULL');
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testMbTrimEncoding()

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -42,13 +42,38 @@ class Php83Test extends TestCase
      * @covers \Symfony\Polyfill\Php83\Php83::mb_str_pad
      *
      * @dataProvider mbStrPadInvalidArgumentsProvider
+     *
+     * @requires PHP 8
      */
     public function testMbStrPadInvalidArguments(string $expectedError, string $string, int $length, string $padString, int $padType, ?string $encoding = null)
     {
         $this->expectException(\ValueError::class);
-        $this->expectErrorMessage($expectedError);
+        $this->expectExceptionMessage($expectedError);
 
         mb_str_pad($string, $length, $padString, $padType, $encoding);
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php83\Php83::mb_str_pad
+     *
+     * @dataProvider mbStrPadInvalidArgumentsProvider
+     *
+     * @requires PHP < 8
+     */
+    public function testMbStrPadInvalidArgumentsOnPhp7(string $expectedError, string $string, int $length, string $padString, int $padType, ?string $encoding = null)
+    {
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessage($expectedError);
+
+        set_error_handler(static function ($errno, $errstr, $errfile, $errline) {
+            throw new \ErrorException($errstr, $errno, $errfile, $errline);
+        });
+
+        try {
+            mb_str_pad($string, $length, $padString, $padType, $encoding);
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public static function paddingStringProvider(): iterable

--- a/tests/Php84/Php84Test.php
+++ b/tests/Php84/Php84Test.php
@@ -227,10 +227,34 @@ class Php84Test extends TestCase
         $this->assertSame($expected, mb_rtrim($string, $characters, $encoding));
     }
 
+    /**
+     * @requires PHP 8
+     */
     public function testMbTrimException()
     {
         $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('mb_trim(): Argument #3 ($encoding) must be a valid encoding, "NULL" given');
+
         mb_trim("\u{180F}", '', 'NULL');
+    }
+
+    /**
+     * @requires PHP < 8
+     */
+    public function testMbTrimExceptionOnPhp7()
+    {
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessage('mb_trim(): Argument #3 ($encoding) must be a valid encoding, "NULL" given');
+
+        set_error_handler(static function ($errno, $errstr, $errfile, $errline) {
+            throw new \ErrorException($errstr, $errno, $errfile, $errline);
+        });
+
+        try {
+            mb_trim("\u{180F}", '', 'NULL');
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testMbTrimEncoding()


### PR DESCRIPTION
Fixes #499.

This PR changes all new mbstring polyfills on PHP 7 so that they trigger an oldschool PHP warning instead of raising a `ValueError`. The reason for that is that the `ValueError` class might not be available on PHP 7 and the behavior is more consitent with the other polyfills of the mbstring extension.

The somewhat weird side-effect is that we now polyfill a behavior that was never implemented in PHP.