### PR TITLE
Ctype: Give the correct deprecations for PHP 8.1+

### DIFF
--- a/src/Ctype/Ctype.php
+++ b/src/Ctype/Ctype.php
@@ -211,16 +211,16 @@ final class Ctype
      */
     private static function convert_int_to_char_for_ctype($int, $function)
     {
+        if (\PHP_VERSION_ID >= 80100 && !\is_string($int)) {
+            @trigger_error($function.'(): Argument of type '.get_debug_type($int).' will be interpreted as string in the future', \E_USER_DEPRECATED);
+        }
+        
         if (!\is_int($int)) {
             return $int;
         }
 
         if ($int < -128 || $int > 255) {
             return (string) $int;
-        }
-
-        if (\PHP_VERSION_ID >= 80100) {
-            @trigger_error($function.'(): Argument of type int will be interpreted as string in the future', \E_USER_DEPRECATED);
         }
 
         if ($int < 0) {


### PR DESCRIPTION
This deprecation isn't just for integers that are outside the integer range of -128, 255.

https://3v4l.org/PgZ6c