### PR TITLE
mbstring: Fix mb_rtrim() for UTF-8 text

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -983,7 +983,7 @@ final class Mbstring
 
     public static function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null): string
     {
-        return self::mb_internal_trim('{[%s]+$}D', $string, $characters, $encoding, __FUNCTION__);
+        return self::mb_internal_trim('{[%s]+$}Du', $string, $characters, $encoding, __FUNCTION__);
     }
 
     private static function mb_internal_trim(string $regex, string $string, ?string $characters, ?string $encoding, string $function): string

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -886,6 +886,7 @@ class MbstringTest extends TestCase
         yield [' test ', ' test ', ''];
 
         yield ['いああああ', 'あああああああああああああああああああああああああああああああああいああああ', 'あ'];
+        yield ['あいうえお　', '　あいうえお　'];
 
         yield ['漢字', "\u{FFFE}漢字", "\u{FFFE}\u{FEFF}"];
         yield [' abcd ', ' abcd ', ''];
@@ -902,6 +903,7 @@ class MbstringTest extends TestCase
         yield ['                                                                                                                                 a', str_repeat(' ', 129).'a'];
 
         yield ['あああああああああああああああああああああああああああああああああい', 'あああああああああああああああああああああああああああああああああいああああ', 'あ'];
+        yield ['　あいうえお', '　あいうえお　'];
 
         yield [' abcd ', ' abcd ', ''];
 


### PR DESCRIPTION
# Component

Polyfill-mbstring

# Problem

`mb_rtrim()` returns an empty string for UTF-8 text.

# How to Reproduce

```php
echo \Symfony\Polyfill\Mbstring\Mbstring::mb_rtrim('　あいうえお　');
// => '' (empty string)
```

Expected result: `'　あいうえお'`

# Cause

The regular expression used in `mb_rtrim()` implementation does not have `u` flag.


# Changes

* Add `u` flag to the regular expression used in `mb_rtrim()` implementation as `mb_trim()` and `mb_ltrim()` do.
* Add tests.