### PR TITLE
Require iconv for mbstring

### DIFF
--- a/src/Mbstring/composer.json
+++ b/src/Mbstring/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=7.2"
+        "php": ">=7.2",
+        "ext-iconv": "*"
     },
     "provide": {
         "ext-mbstring": "*"


### PR DESCRIPTION
As the mbstring polyfill using the iconv functions a lot, if not in all calls being done, code without iconv using this polyfill will break. 

As this repo also provides a polyfill for iconv I don't think this will be a breaking change.