### PR TITLE
Fix constants being redefined in PHP 8.4 polyfill

### DIFF
--- a/src/Php84/bootstrap.php
+++ b/src/Php84/bootstrap.php
@@ -16,9 +16,11 @@ if (\PHP_VERSION_ID >= 80400) {
 }
 
 if (defined('CURL_VERSION_HTTP3') || PHP_VERSION_ID < 80200 && function_exists('curl_version') && curl_version()['version'] >= 0x074200) { // libcurl >= 7.66.0
-    define('CURL_HTTP_VERSION_3', 30);
+    if (!defined('CURL_HTTP_VERSION_3')) {
+        define('CURL_HTTP_VERSION_3', 30);
+    }
 
-    if (defined('CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256')) { // libcurl >= 7.80.0 (7.88 would be better but is slow to check)
+    if (!defined('CURL_HTTP_VERSION_3ONLY') && defined('CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256')) { // libcurl >= 7.80.0 (7.88 would be better but is slow to check)
         define('CURL_HTTP_VERSION_3ONLY', 31);
     }
 }

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class BootstrapTest extends TestCase
+{
+    /**
+     * Test including the PHP polyfills does not try to redefine any symbols.
+     */
+    public function testIncludingTwice()
+    {
+        $this->expectNotToPerformAssertions();
+
+        // File should already be loaded once by Composer.
+        require __DIR__.'/../src/bootstrap.php';
+    }
+}


### PR DESCRIPTION
Tracked down this error to this library:

```
In bootstrap.php line 19:

  [ErrorException]
  Constant CURL_HTTP_VERSION_3 already defined
```

It appears to me the standard is to conditionally define symbols so these two were missing a check. I've also added a basic test which should prevent this happening again.
