### PR TITLE
Pin ICU version to prevent unexpected breakage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     coverage: "none"
-                    extensions: "apcu, intl, mbstring, odbc, uuid"
+                    extensions: "apcu, intl-73.2, mbstring, odbc, uuid"
                     ini-values: "memory_limit=-1, session.gc_probability=0, apc.enable_cli=1"
                     php-version: "${{ matrix.php }}"
                     tools: "composer:v2"


### PR DESCRIPTION
Pinning the ICU version will prevent unexpected breakage from the Unicode version changing before we update the data files and polyfills