### PR TITLE
[Intl] Add PHP 8.5 `IntlListFormatter` to ICU polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Polyfills are provided for:
 - the `MessageFormatter` class and the `msgfmt_format_message` functions;
 - the `Normalizer` class and the `grapheme_*` functions;
 - the `utf8_encode` and `utf8_decode` functions from the `xml` extension or PHP-7.2 core;
-- the `Collator`, `NumberFormatter`, `Locale` and `IntlDateFormatter` classes,
-  limited to the "en" locale;
+- the `Collator`, `NumberFormatter`, `Locale`, `IntlDateFormatter` and
+  `IntlListFormatter` classes, limited to the "en" locale;
 - the `intl_error_name`, `intl_get_error_code`, `intl_get_error_message` and
   `intl_is_failure` functions;
 - the `idn_to_ascii` and `idn_to_utf8` functions;

--- a/src/Intl/Icu/IntlListFormatter.php
+++ b/src/Intl/Icu/IntlListFormatter.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Intl\Icu;
+
+/**
+ * @author Ayesh Karunaratne <ayesh@aye.sh>
+ *
+ * @internal
+ */
+class IntlListFormatter
+{
+    public const TYPE_AND = 0;
+    public const TYPE_OR = 1;
+    public const TYPE_UNITS = 2;
+
+    public const WIDTH_WIDE = 0;
+    public const WIDTH_SHORT = 1;
+    public const WIDTH_NARROW = 2;
+
+    private $type;
+    private $width;
+
+    private const TYPE_MAP = [
+        self::TYPE_AND => 'standard',
+        self::TYPE_OR => 'or',
+        self::TYPE_UNITS => 'unit',
+    ];
+
+    private const WIDTH_MAP = [
+        self::WIDTH_WIDE => '',
+        self::WIDTH_SHORT => '-short',
+        self::WIDTH_NARROW => '-narrow',
+    ];
+
+    private const EN_LIST_PATTERNS = [
+        'listPattern-type-standard' => [
+            'start' => '{0}, {1}',
+            'middle' => '{0}, {1}',
+            'end' => '{0}, and {1}',
+            2 => '{0} and {1}',
+        ],
+        'listPattern-type-or' => [
+            'start' => '{0}, {1}',
+            'middle' => '{0}, {1}',
+            'end' => '{0}, or {1}',
+            2 => '{0} or {1}',
+        ],
+        'listPattern-type-or-narrow' => [
+            'start' => '{0}, {1}',
+            'middle' => '{0}, {1}',
+            'end' => '{0}, or {1}',
+            2 => '{0} or {1}',
+        ],
+        'listPattern-type-or-short' => [
+            'start' => '{0}, {1}',
+            'middle' => '{0}, {1}',
+            'end' => '{0}, or {1}',
+            2 => '{0} or {1}',
+        ],
+        'listPattern-type-standard-narrow' => [
+            'start' => '{0}, {1}',
+            'middle' => '{0}, {1}',
+            'end' => '{0}, {1}',
+            2 => '{0}, {1}',
+        ],
+        'listPattern-type-standard-short' => [
+            'start' => '{0}, {1}',
+            'middle' => '{0}, {1}',
+            'end' => '{0}, & {1}',
+            2 => '{0} & {1}',
+        ],
+        'listPattern-type-unit' => [
+            'start' => '{0}, {1}',
+            'middle' => '{0}, {1}',
+            'end' => '{0}, {1}',
+            2 => '{0}, {1}',
+        ],
+        'listPattern-type-unit-narrow' => [
+            'start' => '{0} {1}',
+            'middle' => '{0} {1}',
+            'end' => '{0} {1}',
+            2 => '{0} {1}',
+        ],
+        'listPattern-type-unit-short' => [
+            'start' => '{0}, {1}',
+            'middle' => '{0}, {1}',
+            'end' => '{0}, {1}',
+            2 => '{0}, {1}',
+        ],
+    ];
+
+    public function __construct(string $locale, int $type = self::TYPE_AND, int $width = self::WIDTH_WIDE)
+    {
+        if ('en' !== $locale && 0 !== strpos($locale, 'en')) {
+            if (80000 > \PHP_VERSION_ID) {
+                throw new \InvalidArgumentException('Invalid locale, only "en" and "en-*" locales are supported.');
+            }
+
+            throw new \ValueError('Invalid locale, only "en" and "en-*" locales are supported.');
+        }
+
+        if (!isset(self::TYPE_MAP[$type])) {
+            if (80000 > \PHP_VERSION_ID) {
+                throw new \InvalidArgumentException('Argument #2 ($type) must be one of IntlListFormatter::TYPE_AND, IntlListFormatter::TYPE_OR, or IntlListFormatter::TYPE_UNITS.');
+            }
+
+            throw new \ValueError('Argument #2 ($type) must be one of IntlListFormatter::TYPE_AND, IntlListFormatter::TYPE_OR, or IntlListFormatter::TYPE_UNITS.');
+        }
+
+        if (!isset(self::WIDTH_MAP[$width])) {
+            if (80000 > \PHP_VERSION_ID) {
+                throw new \InvalidArgumentException('Argument #3 ($width) must be one of IntlListFormatter::WIDTH_WIDE, IntlListFormatter::WIDTH_SHORT, or IntlListFormatter::WIDTH_NARROW.');
+            }
+
+            throw new \ValueError('Argument #3 ($width) must be one of IntlListFormatter::WIDTH_WIDE, IntlListFormatter::WIDTH_SHORT, or IntlListFormatter::WIDTH_NARROW.');
+        }
+
+        $this->type = $type;
+        $this->width = $width;
+    }
+
+    public function format(array $strings): string
+    {
+        $count = \count($strings);
+
+        if (0 === $count) {
+            return '';
+        }
+
+        $strings = array_values($strings);
+
+        if (1 === $count) {
+            return (string) $strings[0];
+        }
+
+        $pattern = self::EN_LIST_PATTERNS['listPattern-type-'.self::TYPE_MAP[$this->type].self::WIDTH_MAP[$this->width]];
+
+        if (2 === $count) {
+            return strtr($pattern[2], ['{0}' => (string) $strings[0], '{1}' => (string) $strings[1]]);
+        }
+
+        $result = strtr($pattern['start'], ['{0}' => (string) $strings[0], '{1}' => (string) $strings[1]]);
+
+        for ($i = 2; $i < $count - 1; ++$i) {
+            $result = strtr($pattern['middle'], ['{0}' => $result, '{1}' => (string) $strings[$i]]);
+        }
+
+        return strtr($pattern['end'], ['{0}' => $result, '{1}' => (string) $strings[$count - 1]]);
+    }
+
+    public function getErrorCode(): int
+    {
+        return 0;
+    }
+
+    public function getErrorMessage(): string
+    {
+        return '';
+    }
+}

--- a/src/Intl/Icu/README.md
+++ b/src/Intl/Icu/README.md
@@ -13,6 +13,7 @@ It is limited to the "en" locale and to:
 - [`NumberFormatter`](https://php.net/NumberFormatter)
 - [`Locale`](https://php.net/Locale)
 - [`IntlDateFormatter`](https://php.net/IntlDateFormatter)
+- [`IntlListFormatter`](https://php.net/IntlListFormatter)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).

--- a/src/Intl/Icu/Resources/stubs/IntlListFormatter.php
+++ b/src/Intl/Icu/Resources/stubs/IntlListFormatter.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\Intl\Icu\IntlListFormatter as IntlListFormatterPolyfill;
+
+/**
+ * Stub implementation for the IntlListFormatter class of the intl extension.
+ *
+ * @author Ayesh Karunaratne <ayesh@aye.sh>
+ */
+final class IntlListFormatter extends IntlListFormatterPolyfill
+{
+}

--- a/tests/Intl/Icu/IntlListFormatterTest.php
+++ b/tests/Intl/Icu/IntlListFormatterTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Intl\Icu;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Ayesh Karunaratne <ayesh@aye.sh>
+ *
+ * @group class-polyfill
+ */
+class IntlListFormatterTest extends TestCase
+{
+    public function testSupportedLocales()
+    {
+        $this->expectNotToPerformAssertions();
+        new \IntlListFormatter('en');
+        new \IntlListFormatter('en-US');
+        new \IntlListFormatter('en_US');
+        new \IntlListFormatter('en-LK');
+    }
+
+    public function testUnsupportedLocales()
+    {
+        if (80000 <= \PHP_VERSION_ID) {
+            $this->expectException(\ValueError::class);
+        } else {
+            $this->expectException(\InvalidArgumentException::class);
+        }
+
+        new \IntlListFormatter('ja');
+    }
+
+    public function testUnsupportedType()
+    {
+        if (80000 <= \PHP_VERSION_ID) {
+            $this->expectException(\ValueError::class);
+        } else {
+            $this->expectException(\InvalidArgumentException::class);
+        }
+        $this->expectExceptionMessage('must be one of IntlListFormatter::TYPE_AND, IntlListFormatter::TYPE_OR, or IntlListFormatter::TYPE_UNITS');
+        new \IntlListFormatter('en', 42);
+    }
+
+    public function testUnsupportedWidth()
+    {
+        if (80000 <= \PHP_VERSION_ID) {
+            $this->expectException(\ValueError::class);
+        } else {
+            $this->expectException(\InvalidArgumentException::class);
+        }
+        $this->expectExceptionMessage('must be one of IntlListFormatter::WIDTH_WIDE, IntlListFormatter::WIDTH_SHORT, or IntlListFormatter::WIDTH_NARROW');
+        new \IntlListFormatter('en', \IntlListFormatter::TYPE_AND, 42);
+    }
+
+    /**
+     * @dataProvider provideFormattingLists
+     */
+    public function testFormatting(int $type, int $width, array $strings, string $expected)
+    {
+        $formatter = new \IntlListFormatter('en', $type, $width);
+        $this->assertSame($expected, $formatter->format($strings));
+    }
+
+    public static function provideFormattingLists()
+    {
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_WIDE, [], ''];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_WIDE, [1], '1'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_WIDE, ['1'], '1'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_WIDE, ['apple'], 'apple'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_WIDE, ['apple', 'banana', 'strawberry'], 'apple, banana, and strawberry'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_WIDE, ['apple', 'banana', 'strawberry', 'orange'], 'apple, banana, strawberry, and orange'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_WIDE, ['apple', 'banana', 'strawberry', 'orange', 16], 'apple, banana, strawberry, orange, and 16'];
+
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_SHORT, [], ''];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_SHORT, [1], '1'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_SHORT, ['1'], '1'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_SHORT, ['apple'], 'apple'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_SHORT, ['apple', 'banana', 'strawberry'], 'apple, banana, & strawberry'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_SHORT, ['apple', 'banana', 'strawberry', 'orange'], 'apple, banana, strawberry, & orange'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_SHORT, ['apple', 'banana', 'strawberry', 'orange', 16], 'apple, banana, strawberry, orange, & 16'];
+
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_NARROW, [], ''];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_NARROW, [1], '1'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_NARROW, ['1'], '1'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_NARROW, ['apple'], 'apple'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_NARROW, ['apple', 'banana', 'strawberry'], 'apple, banana, strawberry'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_NARROW, ['apple', 'banana', 'strawberry', 'orange'], 'apple, banana, strawberry, orange'];
+        yield [\IntlListFormatter::TYPE_AND, \IntlListFormatter::WIDTH_NARROW, ['apple', 'banana', 'strawberry', 'orange', 16], 'apple, banana, strawberry, orange, 16'];
+
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_WIDE, [], ''];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_WIDE, [1], '1'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_WIDE, ['1'], '1'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_WIDE, ['apple'], 'apple'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_WIDE, ['apple', 'banana', 'strawberry'], 'apple, banana, or strawberry'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_WIDE, ['apple', 'banana', 'strawberry', 'orange'], 'apple, banana, strawberry, or orange'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_WIDE, ['apple', 'banana', 'strawberry', 'orange', 16], 'apple, banana, strawberry, orange, or 16'];
+
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_SHORT, [], ''];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_SHORT, [1], '1'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_SHORT, ['1'], '1'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_SHORT, ['apple'], 'apple'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_SHORT, ['apple', 'banana', 'strawberry'], 'apple, banana, or strawberry'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_SHORT, ['apple', 'banana', 'strawberry', 'orange'], 'apple, banana, strawberry, or orange'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_SHORT, ['apple', 'banana', 'strawberry', 'orange', 16], 'apple, banana, strawberry, orange, or 16'];
+
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_NARROW, [], ''];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_NARROW, [1], '1'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_NARROW, ['1'], '1'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_NARROW, ['apple'], 'apple'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_NARROW, ['apple', 'banana', 'strawberry', 'orange'], 'apple, banana, strawberry, or orange'];
+        yield [\IntlListFormatter::TYPE_OR, \IntlListFormatter::WIDTH_NARROW, ['apple', 'banana', 'strawberry', 'orange', 16], 'apple, banana, strawberry, orange, or 16'];
+
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_WIDE, [], ''];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_WIDE, [1], '1'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_WIDE, ['1'], '1'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_WIDE, ['apple'], 'apple'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_WIDE, ['apple', 'banana', 'strawberry'], 'apple, banana, strawberry'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_WIDE, ['apple', 'banana', 'strawberry', 'orange'], 'apple, banana, strawberry, orange'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_WIDE, ['apple', 'banana', 'strawberry', 'orange', 16], 'apple, banana, strawberry, orange, 16'];
+
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_SHORT, [], ''];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_SHORT, [1], '1'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_SHORT, ['1'], '1'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_SHORT, ['apple'], 'apple'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_SHORT, ['apple', 'banana', 'strawberry'], 'apple, banana, strawberry'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_SHORT, ['apple', 'banana', 'strawberry', 'orange'], 'apple, banana, strawberry, orange'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_SHORT, ['apple', 'banana', 'strawberry', 'orange', 16], 'apple, banana, strawberry, orange, 16'];
+
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_NARROW, [], ''];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_NARROW, [1], '1'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_NARROW, ['1'], '1'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_NARROW, ['apple'], 'apple'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_NARROW, ['apple', 'banana', 'strawberry'], 'apple banana strawberry'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_NARROW, ['apple', 'banana', 'strawberry', 'orange'], 'apple banana strawberry orange'];
+        yield [\IntlListFormatter::TYPE_UNITS, \IntlListFormatter::WIDTH_NARROW, ['apple', 'banana', 'strawberry', 'orange', 16], 'apple banana strawberry orange 16'];
+    }
+}


### PR DESCRIPTION
Adds a new polyfill to `symfony/polyfill-intl-icu` that provides the functionality of the new `IntlListFormatter` to PHP 7.2 and later.

 - [ICU listPatterns](https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-misc-full/main/en/listPatterns.json)
 - [php-src commit](https://github.com/php/php-src/commit/3f7545245)
 - [PHP.Watch: IntlListFormatter](https://php.watch/versions/8.5/IntlListFormatter)

Closes GH-530.