### PR TITLE
[8.3] Fix json_validate edge case

### DIFF
--- a/src/Php83/Php83.php
+++ b/src/Php83/Php83.php
@@ -35,7 +35,7 @@ final class Php83
             throw new \ValueError(sprintf('json_validate(): Argument #2 ($depth) must be less than %d', self::JSON_MAX_DEPTH));
         }
 
-        json_decode($json, null, $depth, $flags);
+        json_decode($json, true, $depth, $flags);
 
         return \JSON_ERROR_NONE === json_last_error();
     }

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -141,6 +141,7 @@ class Php83Test extends TestCase
         yield [true, '{ "": { "": "" } }'];
         yield [true, '{ "test": {"foo": "bar"}, "test2": {"foo" : "bar" }, "test2": {"foo" : "bar" } }'];
         yield [true, '{ "test": {"foo": "bar"}, "test2": {"foo" : "bar" }, "test3": {"foo" : "bar" } }'];
+        yield [true, '{ "\u0000null": "test" }'];
         yield [false, '{"key1":"value1", "key2":"value2"}', 'Maximum stack depth exceeded', 1];
         yield [false, "\"a\xb0b\"", 'Malformed UTF-8 characters, possibly incorrectly encoded'];
         yield [true, '{ "test": { "foo": "bar" } }', 'No error', 2147483647];


### PR DESCRIPTION
Fixes an edge case where using a property containing a `\x00` character in property name produces incorrect result in `json_validate()`.

Fixes #533 