### PR TITLE
[PHP 8.5]Polyfill: add locale_is_right_to_left() function

### DIFF
--- a/src/Php85/Php85.php
+++ b/src/Php85/Php85.php
@@ -47,4 +47,9 @@ final class Php85
     {
         return $array ? current(array_slice($array, -1)) : null;
     }
+
+    public static function locale_is_right_to_left(string $locale): bool 
+    {
+        return (bool) preg_match('/^(?:ar|he|fa|ur|ps|sd|ug|ckb|yi|dv|ku_arab|ku-arab)(?:[_-].*)?$/i', $locale);
+    }
 }

--- a/src/Php85/bootstrap.php
+++ b/src/Php85/bootstrap.php
@@ -30,3 +30,7 @@ if (!function_exists('array_first')) {
 if (!function_exists('array_last')) {
     function array_last(array $array) { return p\Php85::array_last($array); }
 }
+
+if (!function_exists('locale_is_right_to_left')) {
+    function locale_is_right_to_left(string $locale) { return p\Php85::locale_is_right_to_left($locale); }
+}

--- a/tests/Php85/Php85Test.php
+++ b/tests/Php85/Php85Test.php
@@ -114,6 +114,16 @@ class Php85Test extends TestCase
         $this->assertTrue(array_first([true, new \stdClass()]));
         $this->assertEquals(new \stdClass(), array_last([true, new \stdClass()]));
     }
+
+    public function testLocaleIsRightToLeft()
+    {
+        $this->assertFalse(locale_is_right_to_left('en'));
+        $this->assertFalse(locale_is_right_to_left(''));
+        $this->assertTrue(locale_is_right_to_left('ar'));
+        $this->assertTrue(locale_is_right_to_left('ar-US'));
+        $this->assertTrue(locale_is_right_to_left('he_IL'));
+        $this->assertTrue(locale_is_right_to_left('ar-XY'));
+    }
 }
 
 class TestHandler


### PR DESCRIPTION
Provide a polyfill for the `locale_is_right_to_left(string $locale): bool` function 
introduced in **PHP 8.5.** This ensures compatibility for projects running on older 
PHP versions that rely on the new locale direction detection.