### PR TITLE
PHP 8.5 - add `PHP_BUILD_DATE` constant

### DIFF
--- a/src/Php85/Php85.php
+++ b/src/Php85/Php85.php
@@ -47,4 +47,15 @@ final class Php85
     {
         return $array ? current(array_slice($array, -1)) : null;
     }
+
+    public static function php_build_date()
+    {
+        ob_start();
+        phpinfo(INFO_GENERAL);
+        $info = ob_get_clean();
+
+        preg_match('@Build Date(?:( => | </td><td class="v">))(?<buildtime>[A-Za-z]{3} (?: \d|\d\d) \d{4} \d{2}:\d{2}:\d{2})@', $info, $matches);
+
+        return $matches['buildtime'];
+    }
 }

--- a/src/Php85/Php85.php
+++ b/src/Php85/Php85.php
@@ -56,6 +56,6 @@ final class Php85
 
         preg_match('@Build Date(?:( => | </td><td class="v">))(?<buildtime>[A-Za-z]{3} (?: \d|\d\d) \d{4} \d{2}:\d{2}:\d{2})@', $info, $matches);
 
-        return $matches['buildtime'];
+        return $matches['buildtime'] ?? '';
     }
 }

--- a/src/Php85/bootstrap.php
+++ b/src/Php85/bootstrap.php
@@ -15,6 +15,10 @@ if (\PHP_VERSION_ID >= 80500) {
     return;
 }
 
+if(!defined('PHP_BUILD_DATE')){
+    define('PHP_BUILD_DATE', p\Php85::php_build_date());
+}
+
 if (!function_exists('get_error_handler')) {
     function get_error_handler(): ?callable { return p\Php85::get_error_handler(); }
 }

--- a/tests/Php85/Php85Test.php
+++ b/tests/Php85/Php85Test.php
@@ -115,7 +115,8 @@ class Php85Test extends TestCase
         $this->assertEquals(new \stdClass(), array_last([true, new \stdClass()]));
     }
 
-    public function testPhpBuildDate(){
+    public function testPhpBuildDate()
+    {
         $date = PHP_BUILD_DATE;
         $this->assertMatchesRegularExpression(
             '/^[A-Za-z]{3} \d{1,2} \d{4} \d{2}:\d{2}:\d{2}$/',

--- a/tests/Php85/Php85Test.php
+++ b/tests/Php85/Php85Test.php
@@ -114,6 +114,15 @@ class Php85Test extends TestCase
         $this->assertTrue(array_first([true, new \stdClass()]));
         $this->assertEquals(new \stdClass(), array_last([true, new \stdClass()]));
     }
+
+    public function testPhpBuildDate(){
+        $date = PHP_BUILD_DATE;
+        $this->assertMatchesRegularExpression(
+            '/^[A-Za-z]{3} \d{1,2} \d{4} \d{2}:\d{2}:\d{2}$/',
+            $date,
+            "The build date format is invalid: $date"
+        );
+    }
 }
 
 class TestHandler

--- a/tests/Php85/PhpBuildDateTest.php
+++ b/tests/Php85/PhpBuildDateTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Php85;
+
+use PHPUnit\Framework\TestCase;
+
+class PhpFinfoPhpBuildDateTest extends TestCase
+{
+    public function serverConfigProvider(): array
+    {
+        return [
+            'expose_php=1' => ['-d expose_php=1'],
+            'expose_php=0' => ['-d expose_php=0'],
+        ];
+    }
+
+    /**
+     * @dataProvider serverConfigProvider
+     */
+    public function testFinfoPhpBuildDate(string $iniSetting)
+    {
+        $spec = [
+            1 => ['file', '/dev/null', 'w'],
+            2 => ['file', '/dev/null', 'w'],
+        ];
+
+        $cmd = sprintf(
+            '%s %s -S localhost:8086 -t %s',
+            \PHP_BINARY,
+            $iniSetting,
+            escapeshellarg(__DIR__ . '/fixtures')
+        );
+
+        $server = @proc_open(('\\' === \DIRECTORY_SEPARATOR ? '' : 'exec ') . $cmd, $spec, $pipes);
+        if (!$server) {
+            self::markTestSkipped("Unable to start PHP server with $iniSetting");
+        }
+        sleep(1);
+
+        $ch = curl_init('http://localhost:8086/server-finifo.php');
+        curl_setopt($ch, \CURLOPT_RETURNTRANSFER, 1);
+        $response = curl_exec($ch);
+        curl_close($ch);
+
+        $this->assertMatchesRegularExpression(
+            '/^[A-Za-z]{3} \d{1,2} \d{4} \d{2}:\d{2}:\d{2}$/',
+            trim($response),
+            "The build date format is invalid with $iniSetting: $response"
+        );
+
+        proc_terminate($server);
+        proc_close($server);
+    }
+}

--- a/tests/Php85/fixtures/server-finifo.php
+++ b/tests/Php85/fixtures/server-finifo.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require __DIR__ . '/../../../vendor/autoload.php';
+echo PHP_BUILD_DATE;


### PR DESCRIPTION
Provide a polyfill for the `PHP_BUILD_DATE` constant (added in PHP 8.5).
- Define `PHP_BUILD_DATE` if not already defined, using `Php85::php_build_date()`
- Introduce `php_build_date()` helper to extract the build timestamp from `phpinfo()`
- Add `PHPUnit` test to ensure the helper returns a valid and parseable build date string