### PR TITLE
[8.4] implement bcround, bcceil and bcfloor

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Polyfills are provided for:
 - the `ReflectionConstant` class introduced in PHP 8.4
 - the `CURL_HTTP_VERSION_3` and `CURL_HTTP_VERSION_3ONLY` constants introduced in PHP 8.4;
 - the `grapheme_str_split` function introduced in PHP 8.4;
-- the `bcdivmod` function introduced in PHP 8.4;
+- the `bcceil`, `bcdivmod`, `bcfloor` and `bcround` functions introduced in PHP 8.4;
 - the `get_error_handler` and `get_exception_handler` functions introduced in PHP 8.5;
 - the `NoDiscard` attribute introduced in PHP 8.5;
 - the `array_first` and `array_last` functions introduced in PHP 8.5;

--- a/src/Php84/Php84.php
+++ b/src/Php84/Php84.php
@@ -28,12 +28,12 @@ final class Php84
         try {
             $validEncoding = @mb_check_encoding('', $encoding);
         } catch (\ValueError $e) {
-            throw new \ValueError(sprintf('mb_ucfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding));
+            throw new \ValueError(\sprintf('mb_ucfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding));
         }
 
         // BC for PHP 7.3 and lower
         if (!$validEncoding) {
-            throw new \ValueError(sprintf('mb_ucfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding));
+            throw new \ValueError(\sprintf('mb_ucfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding));
         }
 
         $firstChar = mb_substr($string, 0, 1, $encoding);
@@ -51,12 +51,12 @@ final class Php84
         try {
             $validEncoding = @mb_check_encoding('', $encoding);
         } catch (\ValueError $e) {
-            throw new \ValueError(sprintf('mb_lcfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding));
+            throw new \ValueError(\sprintf('mb_lcfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding));
         }
 
         // BC for PHP 7.3 and lower
         if (!$validEncoding) {
-            throw new \ValueError(sprintf('mb_lcfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding));
+            throw new \ValueError(\sprintf('mb_lcfirst(): Argument #2 ($encoding) must be a valid encoding, "%s" given', $encoding));
         }
 
         $firstChar = mb_substr($string, 0, 1, $encoding);
@@ -138,12 +138,12 @@ final class Php84
         try {
             $validEncoding = @mb_check_encoding('', $encoding);
         } catch (\ValueError $e) {
-            throw new \ValueError(sprintf('%s(): Argument #3 ($encoding) must be a valid encoding, "%s" given', $function, $encoding));
+            throw new \ValueError(\sprintf('%s(): Argument #3 ($encoding) must be a valid encoding, "%s" given', $function, $encoding));
         }
 
         // BC for PHP 7.3 and lower
         if (!$validEncoding) {
-            throw new \ValueError(sprintf('%s(): Argument #3 ($encoding) must be a valid encoding, "%s" given', $function, $encoding));
+            throw new \ValueError(\sprintf('%s(): Argument #3 ($encoding) must be a valid encoding, "%s" given', $function, $encoding));
         }
 
         if ('' === $characters) {
@@ -166,7 +166,7 @@ final class Php84
             $characters = preg_quote($characters);
         }
 
-        $string = preg_replace(sprintf($regex, $characters), '', $string);
+        $string = preg_replace(\sprintf($regex, $characters), '', $string);
 
         if ('UTF-8' === $encoding) {
             return $string;
@@ -189,7 +189,7 @@ final class Php84
             ? '\X'
             : '(?:\r\n|(?:[ -~\x{200C}\x{200D}]|[ᆨ-ᇹ]+|[ᄀ-ᅟ]*(?:[가개갸걔거게겨계고과괘괴교구궈궤귀규그긔기까깨꺄꺠꺼께껴꼐꼬꽈꽤꾀꾜꾸꿔꿰뀌뀨끄끠끼나내냐냬너네녀녜노놔놰뇌뇨누눠눼뉘뉴느늬니다대댜댸더데뎌뎨도돠돼되됴두둬뒈뒤듀드듸디따때땨떄떠떼뗘뗴또똬뙈뙤뚀뚜뚸뛔뛰뜌뜨띄띠라래랴럐러레려례로롸뢔뢰료루뤄뤠뤼류르릐리마매먀먜머메며몌모뫄뫠뫼묘무뭐뭬뮈뮤므믜미바배뱌뱨버베벼볘보봐봬뵈뵤부붜붸뷔뷰브븨비빠빼뺘뺴뻐뻬뼈뼤뽀뽜뽸뾔뾰뿌뿨쀄쀠쀼쁘쁴삐사새샤섀서세셔셰소솨쇄쇠쇼수숴쉐쉬슈스싀시싸쌔쌰썌써쎄쎠쎼쏘쏴쐐쐬쑈쑤쒀쒜쒸쓔쓰씌씨아애야얘어에여예오와왜외요우워웨위유으의이자재쟈쟤저제져졔조좌좨죄죠주줘줴쥐쥬즈즤지짜째쨔쨰쩌쩨쪄쪠쪼쫘쫴쬐쬬쭈쭤쮀쮜쮸쯔쯰찌차채챠챼처체쳐쳬초촤쵀최쵸추춰췌취츄츠츼치카캐캬컈커케켜켸코콰쾌쾨쿄쿠쿼퀘퀴큐크킈키타태탸턔터테텨톄토톼퇘퇴툐투퉈퉤튀튜트틔티파패퍄퍠퍼페펴폐포퐈퐤푀표푸풔풰퓌퓨프픠피하해햐햬허헤혀혜호화홰회효후훠훼휘휴흐희히]?[ᅠ-ᆢ]+|[가-힣])[ᆨ-ᇹ]*|[ᄀ-ᅟ]+|[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}])[\p{Mn}\p{Me}\x{09BE}\x{09D7}\x{0B3E}\x{0B57}\x{0BBE}\x{0BD7}\x{0CC2}\x{0CD5}\x{0CD6}\x{0D3E}\x{0D57}\x{0DCF}\x{0DDF}\x{200C}\x{200D}\x{1D165}\x{1D16E}-\x{1D172}]*|[\p{Cc}\p{Cf}\p{Zl}\p{Zp}])';
 
-        if (!preg_match_all('/'. $regex .'/u', $string, $matches)) {
+        if (!preg_match_all('/'.$regex.'/u', $string, $matches)) {
             return false;
         }
 
@@ -205,13 +205,219 @@ final class Php84
         return $chunks;
     }
 
+    public static function bcceil(string $num): string
+    {
+        if (!is_numeric($num)) {
+            throw new \ValueError('bcceil(): Argument #1 ($num) is not well-formed');
+        }
+
+        return self::bcround($num, 0, \RoundingMode::PositiveInfinity);
+    }
+
     public static function bcdivmod(string $num1, string $num2, ?int $scale = null): ?array
     {
-        if (null === $quot = \bcdiv($num1, $num2, 0)) {
+        if (null === $quot = bcdiv($num1, $num2, 0)) {
             return null;
         }
-        $scale = $scale ?? (\PHP_VERSION_ID >= 70300 ? \bcscale() : (ini_get('bcmath.scale') ?: 0));
+        $scale = $scale ?? (\PHP_VERSION_ID >= 70300 ? bcscale() : (\ini_get('bcmath.scale') ?: 0));
 
-        return [$quot, \bcmod($num1, $num2, $scale)];
+        return [$quot, bcmod($num1, $num2, $scale)];
+    }
+
+    public static function bcfloor(string $num): string
+    {
+        if (!is_numeric($num)) {
+            throw new \ValueError('bcfloor(): Argument #1 ($num) is not well-formed');
+        }
+
+        return self::bcround($num, 0, \RoundingMode::NegativeInfinity);
+    }
+
+    /**
+     * @param \RoundingMode|\RoundingMode::* $mode
+     */
+    public static function bcround(string $num, int $precision = 0, $mode = \RoundingMode::HalfAwayFromZero): string
+    {
+        if (!is_numeric($num)) {
+            throw new \ValueError('bcround(): Argument #1 ($num) is not well-formed');
+        }
+
+        $sign = 1;
+        if ('' !== $num && ('-' === $num[0] || '+' === $num[0])) {
+            if ('-' === $num[0]) {
+                $sign = -1;
+            }
+
+            $num = substr($num, 1);
+        }
+
+        if (false !== strpos($num, '.')) {
+            [$intPart, $fracPart] = array_pad(explode('.', $num, 2), 2, '');
+        } else {
+            $intPart = $num;
+            $fracPart = '';
+        }
+
+        if ('' === $intPart) {
+            $intPart = '0';
+        }
+
+        $intPart = self::trimLeadingZeros($intPart);
+        $fracPart = (string) $fracPart;
+
+        if ($precision >= 0) {
+            $fracLength = \strlen($fracPart);
+
+            if ($precision <= $fracLength) {
+                $scaledInt = $intPart.(string) substr($fracPart, 0, $precision);
+                $scaledFrac = (string) substr($fracPart, $precision);
+            } else {
+                $scaledInt = $intPart.$fracPart.str_repeat('0', $precision - $fracLength);
+                $scaledFrac = '';
+            }
+        } else {
+            $shift = -$precision;
+            $intLength = \strlen($intPart);
+
+            if ($shift <= $intLength) {
+                $splitPos = $intLength - $shift;
+                $scaledInt = substr($intPart, 0, $splitPos);
+                $scaledInt = '' === $scaledInt ? '0' : $scaledInt;
+                $scaledFrac = substr($intPart, $splitPos).$fracPart;
+            } else {
+                $scaledInt = '0';
+                $scaledFrac = str_repeat('0', $shift - $intLength).$intPart.$fracPart;
+            }
+        }
+
+        $roundedInt = self::roundIntegerPart($scaledInt, $scaledFrac, $sign, $mode);
+        $isZero = '' === trim($roundedInt, '0');
+        $absResult = self::formatRoundedDigits($roundedInt, $precision);
+
+        if (-1 === $sign && !$isZero) {
+            $absResult = '-'.$absResult;
+        }
+
+        return $absResult;
+    }
+
+    private static function roundIntegerPart(string $intPart, string $fracPart, int $sign, $mode): string
+    {
+        $intPart = self::trimLeadingZeros($intPart);
+
+        if ('' === $fracPart || '' === trim($fracPart, '0')) {
+            return $intPart;
+        }
+
+        $firstDigit = $fracPart[0];
+        $tail = (string) substr($fracPart, 1);
+        $tailNonZero = '' !== trim($tail, '0');
+        $isGreaterThanHalf = $firstDigit > '5' || ('5' === $firstDigit && $tailNonZero);
+        $isExactlyHalf = '5' === $firstDigit && !$tailNonZero;
+        $shouldIncrease = false;
+
+        switch ($mode) {
+            case \RoundingMode::TowardsZero:
+                break;
+
+            case \RoundingMode::AwayFromZero:
+                $shouldIncrease = true;
+                break;
+
+            case \RoundingMode::PositiveInfinity:
+                $shouldIncrease = $sign > 0;
+                break;
+
+            case \RoundingMode::NegativeInfinity:
+                $shouldIncrease = $sign < 0;
+                break;
+
+            case \RoundingMode::HalfAwayFromZero:
+                $shouldIncrease = $isGreaterThanHalf || $isExactlyHalf;
+                break;
+
+            case \RoundingMode::HalfTowardsZero:
+                $shouldIncrease = $isGreaterThanHalf;
+                break;
+
+            case \RoundingMode::HalfEven:
+                if ($isGreaterThanHalf) {
+                    $shouldIncrease = true;
+                } elseif ($isExactlyHalf && 1 === self::lastDigit($intPart) % 2) {
+                    $shouldIncrease = true;
+                }
+                break;
+
+            case \RoundingMode::HalfOdd:
+                if ($isGreaterThanHalf) {
+                    $shouldIncrease = true;
+                } elseif ($isExactlyHalf && 0 === self::lastDigit($intPart) % 2) {
+                    $shouldIncrease = true;
+                }
+                break;
+        }
+
+        if ($shouldIncrease) {
+            $intPart = self::incrementDigits($intPart);
+        }
+
+        return self::trimLeadingZeros($intPart);
+    }
+
+    private static function formatRoundedDigits(string $roundedInt, int $precision): string
+    {
+        if ($precision > 0) {
+            if (\strlen($roundedInt) <= $precision) {
+                $roundedInt = str_pad($roundedInt, $precision + 1, '0', \STR_PAD_LEFT);
+            }
+
+            $intDigits = substr($roundedInt, 0, -$precision);
+            $fracDigits = substr($roundedInt, -$precision);
+
+            $intDigits = self::trimLeadingZeros('' === $intDigits ? '0' : $intDigits);
+            $fracDigits = str_pad($fracDigits, $precision, '0', \STR_PAD_LEFT);
+
+            return $intDigits.'.'.$fracDigits;
+        }
+
+        if (0 === $precision) {
+            return self::trimLeadingZeros($roundedInt);
+        }
+
+        $shift = -$precision;
+        $digits = $roundedInt.str_repeat('0', $shift);
+
+        return self::trimLeadingZeros($digits);
+    }
+
+    private static function incrementDigits(string $digits): string
+    {
+        $digits = '' === $digits ? '0' : $digits;
+        $index = \strlen($digits) - 1;
+        $result = $digits;
+        $carry = 1;
+
+        while ($index >= 0 && $carry) {
+            $value = \ord($result[$index]) - 48 + $carry;
+            $carry = $value >= 10 ? 1 : 0;
+            $result[$index] = \chr(48 + ($value % 10));
+            --$index;
+        }
+
+        return $carry ? '1'.$result : $result;
+    }
+
+    private static function trimLeadingZeros(string $digits): string
+    {
+        $digits = ltrim($digits, '0');
+
+        return '' === $digits ? '0' : $digits;
+    }
+
+    private static function lastDigit(string $digits): int
+    {
+        $length = \strlen($digits);
+
+        return $length ? \ord($digits[$length - 1]) - 48 : 0;
     }
 }

--- a/src/Php84/Resources/RoundingMode.php
+++ b/src/Php84/Resources/RoundingMode.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80400) {
+    enum RoundingMode
+    {
+        case HalfAwayFromZero;
+        case HalfTowardsZero;
+        case HalfEven;
+        case HalfOdd;
+        case TowardsZero;
+        case AwayFromZero;
+        case NegativeInfinity;
+        case PositiveInfinity;
+    }
+}

--- a/src/Php84/Resources/stubs/RoundingMode.php
+++ b/src/Php84/Resources/stubs/RoundingMode.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80100) {
+    final class RoundingMode
+    {
+        const HalfAwayFromZero = 0;
+        const HalfTowardsZero = 1;
+        const HalfEven = 2;
+        const HalfOdd = 3;
+        const TowardsZero = 4;
+        const AwayFromZero = 5;
+        const NegativeInfinity = 6;
+        const PositiveInfinity = 7;
+
+        private function __construct()
+        {
+        }
+
+        public static function cases(): array
+        {
+            return [
+                self::HalfAwayFromZero,
+                self::HalfTowardsZero,
+                self::HalfEven,
+                self::HalfOdd,
+                self::TowardsZero,
+                self::AwayFromZero,
+                self::NegativeInfinity,
+                self::PositiveInfinity,
+            ];
+        }
+    }
+} elseif (\PHP_VERSION_ID < 80400) {
+    require dirname(__DIR__).'/RoundingMode.php';
+}

--- a/src/Php84/bootstrap.php
+++ b/src/Php84/bootstrap.php
@@ -15,7 +15,7 @@ if (\PHP_VERSION_ID >= 80400) {
     return;
 }
 
-if (defined('CURL_VERSION_HTTP3') || PHP_VERSION_ID < 80200 && function_exists('curl_version') && curl_version()['version'] >= 0x074200) { // libcurl >= 7.66.0
+if (defined('CURL_VERSION_HTTP3') || \PHP_VERSION_ID < 80200 && function_exists('curl_version') && curl_version()['version'] >= 0x074200) { // libcurl >= 7.66.0
     if (!defined('CURL_HTTP_VERSION_3')) {
         define('CURL_HTTP_VERSION_3', 30);
     }
@@ -68,8 +68,20 @@ if (extension_loaded('mbstring')) {
 }
 
 if (extension_loaded('bcmath')) {
+    if (!function_exists('bcceil')) {
+        function bcceil(string $num): string { return p\Php84::bcceil($num); }
+    }
     if (!function_exists('bcdivmod')) {
         function bcdivmod(string $num1, string $num2, ?int $scale = null): ?array { return p\Php84::bcdivmod($num1, $num2, $scale); }
+    }
+    if (!function_exists('bcfloor')) {
+        function bcfloor(string $num): string { return p\Php84::bcfloor($num); }
+    }
+    if (!function_exists('bcround')) {
+        /**
+         * @param \RoundingMode|\RoundingMode::* $mode
+         */
+        function bcround(string $num, int $precision = 0, $mode = RoundingMode::HalfAwayFromZero): string { return p\Php84::bcround($num, $precision, $mode); }
     }
 }
 

--- a/tests/Php84/Php84Test.php
+++ b/tests/Php84/Php84Test.php
@@ -760,4 +760,930 @@ class Php84Test extends TestCase
         yield ['5', '2', 2, ['2', '1.00']];
         yield ['7.2', '3', 2, ['2', '1.20']];
     }
+
+    /**
+     * @dataProvider bcCeilProvider
+     *
+     * @requires extension bcmath
+     */
+    public function testBcCeil(string $expected, string $num)
+    {
+        $result = \bcceil($num);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function bcCeilProvider(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcceil.phpt
+        yield ['0', '0'];
+        yield ['0', '0.00'];
+        yield ['0', '-0'];
+        yield ['0', '-0.00'];
+        yield ['1', '0.01'];
+        yield ['1', '0.000000000000000000000000000000000000000001'];
+        yield ['0', '-0.01'];
+        yield ['0', '-0.000000000000000000000000000000000000000001'];
+        yield ['1', '1'];
+        yield ['1', '1.0000'];
+        yield ['2', '1.0001'];
+        yield ['100001', '100000.000000000000000000000000000000000000000001'];
+        yield ['-1', '-1'];
+        yield ['-1', '-1.0000'];
+        yield ['-1', '-1.0001'];
+        yield ['-100000', '-100000.000000000000000000000000000000000000000001'];
+    }
+
+    /**
+     * @dataProvider bcCeilProviderError
+     *
+     * @requires extension bcmath
+     */
+    public function testBcCeilError(string $num)
+    {
+        $this->expectError();
+        $this->expectErrorMessage('bcceil(): Argument #1 ($num) is not well-formed');
+        \bcceil($num);
+    }
+
+    public static function bcCeilProviderError(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcceil_error.phpt
+        yield ['hoge'];
+        yield ['0.00.1'];
+    }
+
+    /**
+     * @dataProvider bcFloorProvider
+     *
+     * @requires extension bcmath
+     */
+    public function testBcFloor(string $expected, string $num)
+    {
+        $result = \bcfloor($num);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function bcFloorProvider(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcfloor.phpt
+        yield ['0', '0'];
+        yield ['0', '0.00'];
+        yield ['0', '-0'];
+        yield ['0', '-0.00'];
+        yield ['0', '0.01'];
+        yield ['0', '0.000000000000000000000000000000000000000001'];
+        yield ['-1', '-0.01'];
+        yield ['-1', '-0.000000000000000000000000000000000000000001'];
+        yield ['1', '1'];
+        yield ['1', '1.0000'];
+        yield ['1', '1.0001'];
+        yield ['100000', '100000.000000000000000000000000000000000000000001'];
+        yield ['-1', '-1'];
+        yield ['-1', '-1.0000'];
+        yield ['-2', '-1.0001'];
+        yield ['-100001', '-100000.000000000000000000000000000000000000000001'];
+    }
+
+    /**
+     * @dataProvider bcFloorProviderError
+     *
+     * @requires extension bcmath
+     */
+    public function testBcFloorError(string $num)
+    {
+        $this->expectError();
+        $this->expectErrorMessage('bcfloor(): Argument #1 ($num) is not well-formed');
+        \bcfloor($num);
+    }
+
+    public static function bcFloorProviderError(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcfloor_error.phpt
+        yield ['hoge'];
+        yield ['0.00.1'];
+    }
+
+    /**
+     * @dataProvider bcRoundAllProvider
+     *
+     * @requires extension bcmath
+     */
+    public function testBcRoundAll($mode, string $num, string $expected)
+    {
+        $result = \bcround($num, 0, $mode);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function bcRoundAllProvider(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcround_all.phpt
+        yield [\RoundingMode::HalfAwayFromZero, '1.0', '1'];
+        yield [\RoundingMode::HalfAwayFromZero, '-1.0', '-1'];
+        yield [\RoundingMode::HalfAwayFromZero, '1.2', '1'];
+        yield [\RoundingMode::HalfAwayFromZero, '-1.2', '-1'];
+        yield [\RoundingMode::HalfAwayFromZero, '1.7', '2'];
+        yield [\RoundingMode::HalfAwayFromZero, '-1.7', '-2'];
+        yield [\RoundingMode::HalfAwayFromZero, '1.5', '2'];
+        yield [\RoundingMode::HalfAwayFromZero, '-1.5', '-2'];
+        yield [\RoundingMode::HalfAwayFromZero, '2.5', '3'];
+        yield [\RoundingMode::HalfAwayFromZero, '-2.5', '-3'];
+        yield [\RoundingMode::HalfTowardsZero, '1.0', '1'];
+        yield [\RoundingMode::HalfTowardsZero, '-1.0', '-1'];
+        yield [\RoundingMode::HalfTowardsZero, '1.2', '1'];
+        yield [\RoundingMode::HalfTowardsZero, '-1.2', '-1'];
+        yield [\RoundingMode::HalfTowardsZero, '1.7', '2'];
+        yield [\RoundingMode::HalfTowardsZero, '-1.7', '-2'];
+        yield [\RoundingMode::HalfTowardsZero, '1.5', '1'];
+        yield [\RoundingMode::HalfTowardsZero, '-1.5', '-1'];
+        yield [\RoundingMode::HalfTowardsZero, '2.5', '2'];
+        yield [\RoundingMode::HalfTowardsZero, '-2.5', '-2'];
+        yield [\RoundingMode::HalfEven, '1.0', '1'];
+        yield [\RoundingMode::HalfEven, '-1.0', '-1'];
+        yield [\RoundingMode::HalfEven, '1.2', '1'];
+        yield [\RoundingMode::HalfEven, '-1.2', '-1'];
+        yield [\RoundingMode::HalfEven, '1.7', '2'];
+        yield [\RoundingMode::HalfEven, '-1.7', '-2'];
+        yield [\RoundingMode::HalfEven, '1.5', '2'];
+        yield [\RoundingMode::HalfEven, '-1.5', '-2'];
+        yield [\RoundingMode::HalfEven, '2.5', '2'];
+        yield [\RoundingMode::HalfEven, '-2.5', '-2'];
+        yield [\RoundingMode::HalfOdd, '1.0', '1'];
+        yield [\RoundingMode::HalfOdd, '-1.0', '-1'];
+        yield [\RoundingMode::HalfOdd, '1.2', '1'];
+        yield [\RoundingMode::HalfOdd, '-1.2', '-1'];
+        yield [\RoundingMode::HalfOdd, '1.7', '2'];
+        yield [\RoundingMode::HalfOdd, '-1.7', '-2'];
+        yield [\RoundingMode::HalfOdd, '1.5', '1'];
+        yield [\RoundingMode::HalfOdd, '-1.5', '-1'];
+        yield [\RoundingMode::HalfOdd, '2.5', '3'];
+        yield [\RoundingMode::HalfOdd, '-2.5', '-3'];
+        yield [\RoundingMode::TowardsZero, '1.0', '1'];
+        yield [\RoundingMode::TowardsZero, '-1.0', '-1'];
+        yield [\RoundingMode::TowardsZero, '1.2', '1'];
+        yield [\RoundingMode::TowardsZero, '-1.2', '-1'];
+        yield [\RoundingMode::TowardsZero, '1.7', '1'];
+        yield [\RoundingMode::TowardsZero, '-1.7', '-1'];
+        yield [\RoundingMode::TowardsZero, '1.5', '1'];
+        yield [\RoundingMode::TowardsZero, '-1.5', '-1'];
+        yield [\RoundingMode::TowardsZero, '2.5', '2'];
+        yield [\RoundingMode::TowardsZero, '-2.5', '-2'];
+        yield [\RoundingMode::AwayFromZero, '1.0', '1'];
+        yield [\RoundingMode::AwayFromZero, '-1.0', '-1'];
+        yield [\RoundingMode::AwayFromZero, '1.2', '2'];
+        yield [\RoundingMode::AwayFromZero, '-1.2', '-2'];
+        yield [\RoundingMode::AwayFromZero, '1.7', '2'];
+        yield [\RoundingMode::AwayFromZero, '-1.7', '-2'];
+        yield [\RoundingMode::AwayFromZero, '1.5', '2'];
+        yield [\RoundingMode::AwayFromZero, '-1.5', '-2'];
+        yield [\RoundingMode::AwayFromZero, '2.5', '3'];
+        yield [\RoundingMode::AwayFromZero, '-2.5', '-3'];
+        yield [\RoundingMode::NegativeInfinity, '1.0', '1'];
+        yield [\RoundingMode::NegativeInfinity, '-1.0', '-1'];
+        yield [\RoundingMode::NegativeInfinity, '1.2', '1'];
+        yield [\RoundingMode::NegativeInfinity, '-1.2', '-2'];
+        yield [\RoundingMode::NegativeInfinity, '1.7', '1'];
+        yield [\RoundingMode::NegativeInfinity, '-1.7', '-2'];
+        yield [\RoundingMode::NegativeInfinity, '1.5', '1'];
+        yield [\RoundingMode::NegativeInfinity, '-1.5', '-2'];
+        yield [\RoundingMode::NegativeInfinity, '2.5', '2'];
+        yield [\RoundingMode::NegativeInfinity, '-2.5', '-3'];
+        yield [\RoundingMode::PositiveInfinity, '1.0', '1'];
+        yield [\RoundingMode::PositiveInfinity, '-1.0', '-1'];
+        yield [\RoundingMode::PositiveInfinity, '1.2', '2'];
+        yield [\RoundingMode::PositiveInfinity, '-1.2', '-1'];
+        yield [\RoundingMode::PositiveInfinity, '1.7', '2'];
+        yield [\RoundingMode::PositiveInfinity, '-1.7', '-1'];
+        yield [\RoundingMode::PositiveInfinity, '1.5', '2'];
+        yield [\RoundingMode::PositiveInfinity, '-1.5', '-1'];
+        yield [\RoundingMode::PositiveInfinity, '2.5', '3'];
+        yield [\RoundingMode::PositiveInfinity, '-2.5', '-2'];
+    }
+
+    /**
+     * @dataProvider bcRoundAwayFromZeroProvider
+     *
+     * @requires extension bcmath
+     */
+    public function testBcRoundAwayFromZero(string $num, int $precision, string $expected)
+    {
+        $result = \bcround($num, $precision, \RoundingMode::AwayFromZero);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function bcRoundAwayFromZeroProvider(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcround_away_from_zero.phpt
+        yield ['1.1', 0, '2'];
+        yield ['1.2', 0, '2'];
+        yield ['1.3', 0, '2'];
+        yield ['1.4', 0, '2'];
+        yield ['1.6', 0, '2'];
+        yield ['1.7', 0, '2'];
+        yield ['1.8', 0, '2'];
+        yield ['1.9', 0, '2'];
+        yield ['-1.1', 0, '-2'];
+        yield ['-1.2', 0, '-2'];
+        yield ['-1.3', 0, '-2'];
+        yield ['-1.4', 0, '-2'];
+        yield ['-1.6', 0, '-2'];
+        yield ['-1.7', 0, '-2'];
+        yield ['-1.8', 0, '-2'];
+        yield ['-1.9', 0, '-2'];
+        yield ['0', -3, '0'];
+        yield ['0.01', -3, '1000'];
+        yield ['-0.01', -3, '-1000'];
+        yield ['50', -2, '100'];
+        yield ['-50', -2, '-100'];
+        yield ['1230', -1, '1230'];
+        yield ['1235', -1, '1240'];
+        yield ['-1230', -1, '-1230'];
+        yield ['-1235', -1, '-1240'];
+        yield ['3400.0000', -2, '3400'];
+        yield ['3400.0001', -2, '3500'];
+        yield ['3450.0000', -2, '3500'];
+        yield ['3450.0001', -2, '3500'];
+        yield ['-3400.0000', -2, '-3400'];
+        yield ['-3400.0001', -2, '-3500'];
+        yield ['-3450.0000', -2, '-3500'];
+        yield ['-3450.0001', -2, '-3500'];
+        yield ['1235', 0, '1235'];
+        yield ['1235.0', 0, '1235'];
+        yield ['1235.000001', 0, '1236'];
+        yield ['1235.5', 0, '1236'];
+        yield ['1235.500001', 0, '1236'];
+        yield ['-1235', 0, '-1235'];
+        yield ['-1235.0', 0, '-1235'];
+        yield ['-1235.000001', 0, '-1236'];
+        yield ['-1235.5', 0, '-1236'];
+        yield ['-1235.500001', 0, '-1236'];
+        yield ['0.0001', 0, '1'];
+        yield ['0.5', 0, '1'];
+        yield ['0.5000', 0, '1'];
+        yield ['0.5001', 0, '1'];
+        yield ['-0.0001', 0, '-1'];
+        yield ['-0.5', 0, '-1'];
+        yield ['-0.5000', 0, '-1'];
+        yield ['-0.5001', 0, '-1'];
+        yield ['28.40', 1, '28.4'];
+        yield ['28.4000001', 1, '28.5'];
+        yield ['28.45', 1, '28.5'];
+        yield ['28.4500001', 1, '28.5'];
+        yield ['-28.40', 1, '-28.4'];
+        yield ['-28.4000001', 1, '-28.5'];
+        yield ['-28.45', 1, '-28.5'];
+        yield ['-28.4500001', 1, '-28.5'];
+        yield ['153.90', 1, '153.9'];
+        yield ['153.9000001', 1, '154.0'];
+        yield ['153.95', 1, '154.0'];
+        yield ['153.9500001', 1, '154.0'];
+        yield ['-153.90', 1, '-153.9'];
+        yield ['-153.9000001', 1, '-154.0'];
+        yield ['-153.95', 1, '-154.0'];
+        yield ['-153.9500001', 1, '-154.0'];
+        yield ['0.000001', 3, '0.001'];
+        yield ['0.0005', 3, '0.001'];
+        yield ['0.000500', 3, '0.001'];
+        yield ['0.000501', 3, '0.001'];
+        yield ['-0.000001', 3, '-0.001'];
+        yield ['-0.0005', 3, '-0.001'];
+        yield ['-0.000500', 3, '-0.001'];
+        yield ['-0.000501', 3, '-0.001'];
+    }
+
+    /**
+     * @dataProvider bcRoundCeilingProvider
+     *
+     * @requires extension bcmath
+     */
+    public function testBcRoundCeiling(string $num, int $precision, string $expected)
+    {
+        $result = \bcround($num, $precision, \RoundingMode::PositiveInfinity);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function bcRoundCeilingProvider(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcround_ceiling.phpt
+        yield ['1.1', 0, '2'];
+        yield ['1.2', 0, '2'];
+        yield ['1.3', 0, '2'];
+        yield ['1.4', 0, '2'];
+        yield ['1.6', 0, '2'];
+        yield ['1.7', 0, '2'];
+        yield ['1.8', 0, '2'];
+        yield ['1.9', 0, '2'];
+        yield ['-1.1', 0, '-1'];
+        yield ['-1.2', 0, '-1'];
+        yield ['-1.3', 0, '-1'];
+        yield ['-1.4', 0, '-1'];
+        yield ['-1.6', 0, '-1'];
+        yield ['-1.7', 0, '-1'];
+        yield ['-1.8', 0, '-1'];
+        yield ['-1.9', 0, '-1'];
+        yield ['0', -3, '0'];
+        yield ['0.01', -3, '1000'];
+        yield ['-0.01', -3, '0'];
+        yield ['50', -2, '100'];
+        yield ['-50', -2, '0'];
+        yield ['1230', -1, '1230'];
+        yield ['1235', -1, '1240'];
+        yield ['-1230', -1, '-1230'];
+        yield ['-1235', -1, '-1230'];
+        yield ['3400.0000', -2, '3400'];
+        yield ['3400.0001', -2, '3500'];
+        yield ['3450.0000', -2, '3500'];
+        yield ['3450.0001', -2, '3500'];
+        yield ['-3400.0000', -2, '-3400'];
+        yield ['-3400.0001', -2, '-3400'];
+        yield ['-3450.0000', -2, '-3400'];
+        yield ['-3450.0001', -2, '-3400'];
+        yield ['1235', 0, '1235'];
+        yield ['1235.0', 0, '1235'];
+        yield ['1235.000001', 0, '1236'];
+        yield ['1235.5', 0, '1236'];
+        yield ['1235.500001', 0, '1236'];
+        yield ['-1235', 0, '-1235'];
+        yield ['-1235.0', 0, '-1235'];
+        yield ['-1235.000001', 0, '-1235'];
+        yield ['-1235.5', 0, '-1235'];
+        yield ['-1235.500001', 0, '-1235'];
+        yield ['0.0001', 0, '1'];
+        yield ['0.5', 0, '1'];
+        yield ['0.5000', 0, '1'];
+        yield ['0.5001', 0, '1'];
+        yield ['-0.0001', 0, '0'];
+        yield ['-0.5', 0, '0'];
+        yield ['-0.5000', 0, '0'];
+        yield ['-0.5001', 0, '0'];
+        yield ['28.40', 1, '28.4'];
+        yield ['28.4000001', 1, '28.5'];
+        yield ['28.45', 1, '28.5'];
+        yield ['28.4500001', 1, '28.5'];
+        yield ['-28.40', 1, '-28.4'];
+        yield ['-28.4000001', 1, '-28.4'];
+        yield ['-28.45', 1, '-28.4'];
+        yield ['-28.4500001', 1, '-28.4'];
+        yield ['153.90', 1, '153.9'];
+        yield ['153.9000001', 1, '154.0'];
+        yield ['153.95', 1, '154.0'];
+        yield ['153.9500001', 1, '154.0'];
+        yield ['-153.90', 1, '-153.9'];
+        yield ['-153.9000001', 1, '-153.9'];
+        yield ['-153.95', 1, '-153.9'];
+        yield ['-153.9500001', 1, '-153.9'];
+        yield ['0.000001', 3, '0.001'];
+        yield ['0.0005', 3, '0.001'];
+        yield ['0.000500', 3, '0.001'];
+        yield ['0.000501', 3, '0.001'];
+        yield ['-0.000001', 3, '0.000'];
+        yield ['-0.0005', 3, '0.000'];
+        yield ['-0.000500', 3, '0.000'];
+        yield ['-0.000501', 3, '0.000'];
+    }
+
+    /**
+     * @dataProvider bcRoundFloorProvider
+     *
+     * @requires extension bcmath
+     */
+    public function testBcRoundFloor(string $num, int $precision, string $expected)
+    {
+        $result = \bcround($num, $precision, \RoundingMode::NegativeInfinity);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function bcRoundFloorProvider(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcround_floor.phpt
+        yield ['1.1', 0, '1'];
+        yield ['1.2', 0, '1'];
+        yield ['1.3', 0, '1'];
+        yield ['1.4', 0, '1'];
+        yield ['1.6', 0, '1'];
+        yield ['1.7', 0, '1'];
+        yield ['1.8', 0, '1'];
+        yield ['1.9', 0, '1'];
+        yield ['-1.1', 0, '-2'];
+        yield ['-1.2', 0, '-2'];
+        yield ['-1.3', 0, '-2'];
+        yield ['-1.4', 0, '-2'];
+        yield ['-1.6', 0, '-2'];
+        yield ['-1.7', 0, '-2'];
+        yield ['-1.8', 0, '-2'];
+        yield ['-1.9', 0, '-2'];
+        yield ['0', -3, '0'];
+        yield ['0.01', -3, '0'];
+        yield ['-0.01', -3, '-1000'];
+        yield ['50', -2, '0'];
+        yield ['-50', -2, '-100'];
+        yield ['1230', -1, '1230'];
+        yield ['1235', -1, '1230'];
+        yield ['-1230', -1, '-1230'];
+        yield ['-1235', -1, '-1240'];
+        yield ['3400.0000', -2, '3400'];
+        yield ['3400.0001', -2, '3400'];
+        yield ['3450.0000', -2, '3400'];
+        yield ['3450.0001', -2, '3400'];
+        yield ['-3400.0000', -2, '-3400'];
+        yield ['-3400.0001', -2, '-3500'];
+        yield ['-3450.0000', -2, '-3500'];
+        yield ['-3450.0001', -2, '-3500'];
+        yield ['1235', 0, '1235'];
+        yield ['1235.0', 0, '1235'];
+        yield ['1235.000001', 0, '1235'];
+        yield ['1235.5', 0, '1235'];
+        yield ['1235.500001', 0, '1235'];
+        yield ['-1235', 0, '-1235'];
+        yield ['-1235.0', 0, '-1235'];
+        yield ['-1235.000001', 0, '-1236'];
+        yield ['-1235.5', 0, '-1236'];
+        yield ['-1235.500001', 0, '-1236'];
+        yield ['0.0001', 0, '0'];
+        yield ['0.5', 0, '0'];
+        yield ['0.5000', 0, '0'];
+        yield ['0.5001', 0, '0'];
+        yield ['-0.0001', 0, '-1'];
+        yield ['-0.5', 0, '-1'];
+        yield ['-0.5000', 0, '-1'];
+        yield ['-0.5001', 0, '-1'];
+        yield ['28.40', 1, '28.4'];
+        yield ['28.4000001', 1, '28.4'];
+        yield ['28.45', 1, '28.4'];
+        yield ['28.4500001', 1, '28.4'];
+        yield ['-28.40', 1, '-28.4'];
+        yield ['-28.4000001', 1, '-28.5'];
+        yield ['-28.45', 1, '-28.5'];
+        yield ['-28.4500001', 1, '-28.5'];
+        yield ['153.90', 1, '153.9'];
+        yield ['153.9000001', 1, '153.9'];
+        yield ['153.95', 1, '153.9'];
+        yield ['153.9500001', 1, '153.9'];
+        yield ['-153.90', 1, '-153.9'];
+        yield ['-153.9000001', 1, '-154.0'];
+        yield ['-153.95', 1, '-154.0'];
+        yield ['-153.9500001', 1, '-154.0'];
+        yield ['0.000001', 3, '0.000'];
+        yield ['0.0005', 3, '0.000'];
+        yield ['0.000500', 3, '0.000'];
+        yield ['0.000501', 3, '0.000'];
+        yield ['-0.000001', 3, '-0.001'];
+        yield ['-0.0005', 3, '-0.001'];
+        yield ['-0.000500', 3, '-0.001'];
+        yield ['-0.000501', 3, '-0.001'];
+    }
+
+    /**
+     * @dataProvider bcRoundHalfDownProvider
+     *
+     * @requires extension bcmath
+     */
+    public function testBcRoundHalfDownFloor(string $num, int $precision, string $expected)
+    {
+        $result = \bcround($num, $precision, \RoundingMode::HalfTowardsZero);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function bcRoundHalfDownProvider(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcround_half_down.phpt
+        yield ['1.1', 0, '1'];
+        yield ['1.2', 0, '1'];
+        yield ['1.3', 0, '1'];
+        yield ['1.4', 0, '1'];
+        yield ['1.6', 0, '2'];
+        yield ['1.7', 0, '2'];
+        yield ['1.8', 0, '2'];
+        yield ['1.9', 0, '2'];
+        yield ['-1.1', 0, '-1'];
+        yield ['-1.2', 0, '-1'];
+        yield ['-1.3', 0, '-1'];
+        yield ['-1.4', 0, '-1'];
+        yield ['-1.6', 0, '-2'];
+        yield ['-1.7', 0, '-2'];
+        yield ['-1.8', 0, '-2'];
+        yield ['-1.9', 0, '-2'];
+        yield ['0', -3, '0'];
+        yield ['0.01', -3, '0'];
+        yield ['-0.01', -3, '0'];
+        yield ['50', -2, '0'];
+        yield ['-50', -2, '0'];
+        yield ['1230', -1, '1230'];
+        yield ['1235', -1, '1230'];
+        yield ['-1230', -1, '-1230'];
+        yield ['-1235', -1, '-1230'];
+        yield ['3400.0000', -2, '3400'];
+        yield ['3400.0001', -2, '3400'];
+        yield ['3450.0000', -2, '3400'];
+        yield ['3450.0001', -2, '3500'];
+        yield ['-3400.0000', -2, '-3400'];
+        yield ['-3400.0001', -2, '-3400'];
+        yield ['-3450.0000', -2, '-3400'];
+        yield ['-3450.0001', -2, '-3500'];
+        yield ['1235', 0, '1235'];
+        yield ['1235.0', 0, '1235'];
+        yield ['1235.000001', 0, '1235'];
+        yield ['1235.5', 0, '1235'];
+        yield ['1235.500001', 0, '1236'];
+        yield ['-1235', 0, '-1235'];
+        yield ['-1235.0', 0, '-1235'];
+        yield ['-1235.000001', 0, '-1235'];
+        yield ['-1235.5', 0, '-1235'];
+        yield ['-1235.500001', 0, '-1236'];
+        yield ['0.0001', 0, '0'];
+        yield ['0.5', 0, '0'];
+        yield ['0.5000', 0, '0'];
+        yield ['0.5001', 0, '1'];
+        yield ['-0.0001', 0, '0'];
+        yield ['-0.5', 0, '0'];
+        yield ['-0.5000', 0, '0'];
+        yield ['-0.5001', 0, '-1'];
+        yield ['28.40', 1, '28.4'];
+        yield ['28.4000001', 1, '28.4'];
+        yield ['28.45', 1, '28.4'];
+        yield ['28.4500001', 1, '28.5'];
+        yield ['-28.40', 1, '-28.4'];
+        yield ['-28.4000001', 1, '-28.4'];
+        yield ['-28.45', 1, '-28.4'];
+        yield ['-28.4500001', 1, '-28.5'];
+        yield ['153.90', 1, '153.9'];
+        yield ['153.9000001', 1, '153.9'];
+        yield ['153.95', 1, '153.9'];
+        yield ['153.9500001', 1, '154.0'];
+        yield ['-153.90', 1, '-153.9'];
+        yield ['-153.9000001', 1, '-153.9'];
+        yield ['-153.95', 1, '-153.9'];
+        yield ['-153.9500001', 1, '-154.0'];
+        yield ['0.000001', 3, '0.000'];
+        yield ['0.0005', 3, '0.000'];
+        yield ['0.000500', 3, '0.000'];
+        yield ['0.000501', 3, '0.001'];
+        yield ['-0.000001', 3, '0.000'];
+        yield ['-0.0005', 3, '0.000'];
+        yield ['-0.000500', 3, '0.000'];
+        yield ['-0.000501', 3, '-0.001'];
+    }
+
+    /**
+     * @dataProvider bcRoundHalfEvenProvider
+     *
+     * @requires extension bcmath
+     */
+    public function testBcRoundHalfEvenFloor(string $num, int $precision, string $expected)
+    {
+        $result = \bcround($num, $precision, \RoundingMode::HalfEven);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function bcRoundHalfEvenProvider(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcround_half_even.phpt
+        yield ['1.1', 0, '1'];
+        yield ['1.2', 0, '1'];
+        yield ['1.3', 0, '1'];
+        yield ['1.4', 0, '1'];
+        yield ['1.6', 0, '2'];
+        yield ['1.7', 0, '2'];
+        yield ['1.8', 0, '2'];
+        yield ['1.9', 0, '2'];
+        yield ['-1.1', 0, '-1'];
+        yield ['-1.2', 0, '-1'];
+        yield ['-1.3', 0, '-1'];
+        yield ['-1.4', 0, '-1'];
+        yield ['-1.6', 0, '-2'];
+        yield ['-1.7', 0, '-2'];
+        yield ['-1.8', 0, '-2'];
+        yield ['-1.9', 0, '-2'];
+        yield ['0', -3, '0'];
+        yield ['0.01', -3, '0'];
+        yield ['-0.01', -3, '0'];
+        yield ['50', -2, '0'];
+        yield ['-50', -2, '0'];
+        yield ['1230', -1, '1230'];
+        yield ['1235', -1, '1240'];
+        yield ['-1230', -1, '-1230'];
+        yield ['-1235', -1, '-1240'];
+        yield ['3400.0000', -2, '3400'];
+        yield ['3400.0001', -2, '3400'];
+        yield ['3450.0000', -2, '3400'];
+        yield ['3450.0001', -2, '3500'];
+        yield ['-3400.0000', -2, '-3400'];
+        yield ['-3400.0001', -2, '-3400'];
+        yield ['-3450.0000', -2, '-3400'];
+        yield ['-3450.0001', -2, '-3500'];
+        yield ['1235', 0, '1235'];
+        yield ['1235.0', 0, '1235'];
+        yield ['1235.000001', 0, '1235'];
+        yield ['1235.5', 0, '1236'];
+        yield ['1235.500001', 0, '1236'];
+        yield ['-1235', 0, '-1235'];
+        yield ['-1235.0', 0, '-1235'];
+        yield ['-1235.000001', 0, '-1235'];
+        yield ['-1235.5', 0, '-1236'];
+        yield ['-1235.500001', 0, '-1236'];
+        yield ['0.0001', 0, '0'];
+        yield ['0.5', 0, '0'];
+        yield ['0.5000', 0, '0'];
+        yield ['0.5001', 0, '1'];
+        yield ['-0.0001', 0, '0'];
+        yield ['-0.5', 0, '0'];
+        yield ['-0.5000', 0, '0'];
+        yield ['-0.5001', 0, '-1'];
+        yield ['28.40', 1, '28.4'];
+        yield ['28.4000001', 1, '28.4'];
+        yield ['28.45', 1, '28.4'];
+        yield ['28.4500001', 1, '28.5'];
+        yield ['-28.40', 1, '-28.4'];
+        yield ['-28.4000001', 1, '-28.4'];
+        yield ['-28.45', 1, '-28.4'];
+        yield ['-28.4500001', 1, '-28.5'];
+        yield ['153.90', 1, '153.9'];
+        yield ['153.9000001', 1, '153.9'];
+        yield ['153.95', 1, '154.0'];
+        yield ['153.9500001', 1, '154.0'];
+        yield ['-153.90', 1, '-153.9'];
+        yield ['-153.9000001', 1, '-153.9'];
+        yield ['-153.95', 1, '-154.0'];
+        yield ['-153.9500001', 1, '-154.0'];
+        yield ['0.000001', 3, '0.000'];
+        yield ['0.0005', 3, '0.000'];
+        yield ['0.000500', 3, '0.000'];
+        yield ['0.000501', 3, '0.001'];
+        yield ['-0.000001', 3, '0.000'];
+        yield ['-0.0005', 3, '0.000'];
+        yield ['-0.000500', 3, '0.000'];
+        yield ['-0.000501', 3, '-0.001'];
+    }
+
+    /**
+     * @dataProvider bcRoundHalfOddProvider
+     *
+     * @requires extension bcmath
+     */
+    public function testBcRoundHalfOddFloor(string $num, int $precision, string $expected)
+    {
+        $result = \bcround($num, $precision, \RoundingMode::HalfOdd);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function bcRoundHalfOddProvider(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcround_half_odd.phpt
+        yield ['1.1', 0, '1'];
+        yield ['1.2', 0, '1'];
+        yield ['1.3', 0, '1'];
+        yield ['1.4', 0, '1'];
+        yield ['1.6', 0, '2'];
+        yield ['1.7', 0, '2'];
+        yield ['1.8', 0, '2'];
+        yield ['1.9', 0, '2'];
+        yield ['-1.1', 0, '-1'];
+        yield ['-1.2', 0, '-1'];
+        yield ['-1.3', 0, '-1'];
+        yield ['-1.4', 0, '-1'];
+        yield ['-1.6', 0, '-2'];
+        yield ['-1.7', 0, '-2'];
+        yield ['-1.8', 0, '-2'];
+        yield ['-1.9', 0, '-2'];
+        yield ['0', -3, '0'];
+        yield ['0.01', -3, '0'];
+        yield ['-0.01', -3, '0'];
+        yield ['50', -2, '100'];
+        yield ['-50', -2, '-100'];
+        yield ['1230', -1, '1230'];
+        yield ['1235', -1, '1230'];
+        yield ['-1230', -1, '-1230'];
+        yield ['-1235', -1, '-1230'];
+        yield ['3400.0000', -2, '3400'];
+        yield ['3400.0001', -2, '3400'];
+        yield ['3450.0000', -2, '3500'];
+        yield ['3450.0001', -2, '3500'];
+        yield ['-3400.0000', -2, '-3400'];
+        yield ['-3400.0001', -2, '-3400'];
+        yield ['-3450.0000', -2, '-3500'];
+        yield ['-3450.0001', -2, '-3500'];
+        yield ['1235', 0, '1235'];
+        yield ['1235.0', 0, '1235'];
+        yield ['1235.000001', 0, '1235'];
+        yield ['1235.5', 0, '1235'];
+        yield ['1235.500001', 0, '1236'];
+        yield ['-1235', 0, '-1235'];
+        yield ['-1235.0', 0, '-1235'];
+        yield ['-1235.000001', 0, '-1235'];
+        yield ['-1235.5', 0, '-1235'];
+        yield ['-1235.500001', 0, '-1236'];
+        yield ['0.0001', 0, '0'];
+        yield ['0.5', 0, '1'];
+        yield ['0.5000', 0, '1'];
+        yield ['0.5001', 0, '1'];
+        yield ['-0.0001', 0, '0'];
+        yield ['-0.5', 0, '-1'];
+        yield ['-0.5000', 0, '-1'];
+        yield ['-0.5001', 0, '-1'];
+        yield ['28.40', 1, '28.4'];
+        yield ['28.4000001', 1, '28.4'];
+        yield ['28.45', 1, '28.5'];
+        yield ['28.4500001', 1, '28.5'];
+        yield ['-28.40', 1, '-28.4'];
+        yield ['-28.4000001', 1, '-28.4'];
+        yield ['-28.45', 1, '-28.5'];
+        yield ['-28.4500001', 1, '-28.5'];
+        yield ['153.90', 1, '153.9'];
+        yield ['153.9000001', 1, '153.9'];
+        yield ['153.95', 1, '153.9'];
+        yield ['153.9500001', 1, '154.0'];
+        yield ['-153.90', 1, '-153.9'];
+        yield ['-153.9000001', 1, '-153.9'];
+        yield ['-153.95', 1, '-153.9'];
+        yield ['-153.9500001', 1, '-154.0'];
+        yield ['0.000001', 3, '0.000'];
+        yield ['0.0005', 3, '0.001'];
+        yield ['0.000500', 3, '0.001'];
+        yield ['0.000501', 3, '0.001'];
+        yield ['-0.000001', 3, '0.000'];
+        yield ['-0.0005', 3, '-0.001'];
+        yield ['-0.000500', 3, '-0.001'];
+        yield ['-0.000501', 3, '-0.001'];
+    }
+
+    /**
+     * @dataProvider bcRoundHalfUpProvider
+     *
+     * @requires extension bcmath
+     */
+    public function testBcRoundHalfUpFloor(string $num, int $precision, string $expected)
+    {
+        $result = \bcround($num, $precision, \RoundingMode::HalfAwayFromZero);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function bcRoundHalfUpProvider(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcround_half_up.phpt
+        yield ['1.1', 0, '1'];
+        yield ['1.2', 0, '1'];
+        yield ['1.3', 0, '1'];
+        yield ['1.4', 0, '1'];
+        yield ['1.6', 0, '2'];
+        yield ['1.7', 0, '2'];
+        yield ['1.8', 0, '2'];
+        yield ['1.9', 0, '2'];
+        yield ['-1.1', 0, '-1'];
+        yield ['-1.2', 0, '-1'];
+        yield ['-1.3', 0, '-1'];
+        yield ['-1.4', 0, '-1'];
+        yield ['-1.6', 0, '-2'];
+        yield ['-1.7', 0, '-2'];
+        yield ['-1.8', 0, '-2'];
+        yield ['-1.9', 0, '-2'];
+        yield ['0', -3, '0'];
+        yield ['0.01', -3, '0'];
+        yield ['-0.01', -3, '0'];
+        yield ['50', -2, '100'];
+        yield ['-50', -2, '-100'];
+        yield ['1230', -1, '1230'];
+        yield ['1235', -1, '1240'];
+        yield ['-1230', -1, '-1230'];
+        yield ['-1235', -1, '-1240'];
+        yield ['3400.0000', -2, '3400'];
+        yield ['3400.0001', -2, '3400'];
+        yield ['3450.0000', -2, '3500'];
+        yield ['3450.0001', -2, '3500'];
+        yield ['-3400.0000', -2, '-3400'];
+        yield ['-3400.0001', -2, '-3400'];
+        yield ['-3450.0000', -2, '-3500'];
+        yield ['-3450.0001', -2, '-3500'];
+        yield ['1235', 0, '1235'];
+        yield ['1235.0', 0, '1235'];
+        yield ['1235.000001', 0, '1235'];
+        yield ['1235.5', 0, '1236'];
+        yield ['1235.500001', 0, '1236'];
+        yield ['-1235', 0, '-1235'];
+        yield ['-1235.0', 0, '-1235'];
+        yield ['-1235.000001', 0, '-1235'];
+        yield ['-1235.5', 0, '-1236'];
+        yield ['-1235.500001', 0, '-1236'];
+        yield ['0.0001', 0, '0'];
+        yield ['0.5', 0, '1'];
+        yield ['0.5000', 0, '1'];
+        yield ['0.5001', 0, '1'];
+        yield ['-0.0001', 0, '0'];
+        yield ['-0.5', 0, '-1'];
+        yield ['-0.5000', 0, '-1'];
+        yield ['-0.5001', 0, '-1'];
+        yield ['28.40', 1, '28.4'];
+        yield ['28.4000001', 1, '28.4'];
+        yield ['28.45', 1, '28.5'];
+        yield ['28.4500001', 1, '28.5'];
+        yield ['-28.40', 1, '-28.4'];
+        yield ['-28.4000001', 1, '-28.4'];
+        yield ['-28.45', 1, '-28.5'];
+        yield ['-28.4500001', 1, '-28.5'];
+        yield ['153.90', 1, '153.9'];
+        yield ['153.9000001', 1, '153.9'];
+        yield ['153.95', 1, '154.0'];
+        yield ['153.9500001', 1, '154.0'];
+        yield ['-153.90', 1, '-153.9'];
+        yield ['-153.9000001', 1, '-153.9'];
+        yield ['-153.95', 1, '-154.0'];
+        yield ['-153.9500001', 1, '-154.0'];
+        yield ['0.000001', 3, '0.000'];
+        yield ['0.0005', 3, '0.001'];
+        yield ['0.000500', 3, '0.001'];
+        yield ['0.000501', 3, '0.001'];
+        yield ['-0.000001', 3, '0.000'];
+        yield ['-0.0005', 3, '-0.001'];
+        yield ['-0.000500', 3, '-0.001'];
+        yield ['-0.000501', 3, '-0.001'];
+    }
+
+    /**
+     * @dataProvider bcRoundTowardZeroProvider
+     *
+     * @requires extension bcmath
+     */
+    public function testBcRoundTowardZeroFloor(string $num, int $precision, string $expected)
+    {
+        $result = \bcround($num, $precision, \RoundingMode::TowardsZero);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function bcRoundTowardZeroProvider(): iterable
+    {
+        // Tests cases from https://github.com/php/php-src/blob/php-8.4.4/ext/bcmath/tests/bcround_toward_zero.phpt
+        yield ['1.1', 0, '1'];
+        yield ['1.2', 0, '1'];
+        yield ['1.3', 0, '1'];
+        yield ['1.4', 0, '1'];
+        yield ['1.6', 0, '1'];
+        yield ['1.7', 0, '1'];
+        yield ['1.8', 0, '1'];
+        yield ['1.9', 0, '1'];
+        yield ['-1.1', 0, '-1'];
+        yield ['-1.2', 0, '-1'];
+        yield ['-1.3', 0, '-1'];
+        yield ['-1.4', 0, '-1'];
+        yield ['-1.6', 0, '-1'];
+        yield ['-1.7', 0, '-1'];
+        yield ['-1.8', 0, '-1'];
+        yield ['-1.9', 0, '-1'];
+        yield ['0', -3, '0'];
+        yield ['0.01', -3, '0'];
+        yield ['-0.01', -3, '0'];
+        yield ['50', -2, '0'];
+        yield ['-50', -2, '0'];
+        yield ['1230', -1, '1230'];
+        yield ['1235', -1, '1230'];
+        yield ['-1230', -1, '-1230'];
+        yield ['-1235', -1, '-1230'];
+        yield ['3400.0000', -2, '3400'];
+        yield ['3400.0001', -2, '3400'];
+        yield ['3450.0000', -2, '3400'];
+        yield ['3450.0001', -2, '3400'];
+        yield ['-3400.0000', -2, '-3400'];
+        yield ['-3400.0001', -2, '-3400'];
+        yield ['-3450.0000', -2, '-3400'];
+        yield ['-3450.0001', -2, '-3400'];
+        yield ['1235', 0, '1235'];
+        yield ['1235.0', 0, '1235'];
+        yield ['1235.000001', 0, '1235'];
+        yield ['1235.5', 0, '1235'];
+        yield ['1235.500001', 0, '1235'];
+        yield ['-1235', 0, '-1235'];
+        yield ['-1235.0', 0, '-1235'];
+        yield ['-1235.000001', 0, '-1235'];
+        yield ['-1235.5', 0, '-1235'];
+        yield ['-1235.500001', 0, '-1235'];
+        yield ['0.0001', 0, '0'];
+        yield ['0.5', 0, '0'];
+        yield ['0.5000', 0, '0'];
+        yield ['0.5001', 0, '0'];
+        yield ['-0.0001', 0, '0'];
+        yield ['-0.5', 0, '0'];
+        yield ['-0.5000', 0, '0'];
+        yield ['-0.5001', 0, '0'];
+        yield ['28.40', 1, '28.4'];
+        yield ['28.4000001', 1, '28.4'];
+        yield ['28.45', 1, '28.4'];
+        yield ['28.4500001', 1, '28.4'];
+        yield ['-28.40', 1, '-28.4'];
+        yield ['-28.4000001', 1, '-28.4'];
+        yield ['-28.45', 1, '-28.4'];
+        yield ['-28.4500001', 1, '-28.4'];
+        yield ['153.90', 1, '153.9'];
+        yield ['153.9000001', 1, '153.9'];
+        yield ['153.95', 1, '153.9'];
+        yield ['153.9500001', 1, '153.9'];
+        yield ['-153.90', 1, '-153.9'];
+        yield ['-153.9000001', 1, '-153.9'];
+        yield ['-153.95', 1, '-153.9'];
+        yield ['-153.9500001', 1, '-153.9'];
+        yield ['0.000001', 3, '0.000'];
+        yield ['0.0005', 3, '0.000'];
+        yield ['0.000500', 3, '0.000'];
+        yield ['0.000501', 3, '0.000'];
+        yield ['-0.000001', 3, '0.000'];
+        yield ['-0.0005', 3, '0.000'];
+        yield ['-0.000500', 3, '0.000'];
+        yield ['-0.000501', 3, '0.000'];
+    }
 }


### PR DESCRIPTION
- introduced `bcround`, `bcfloor` and `bcceil` polyfills
- RoundingMode cannot be an enum, and const cannot contain an object. This is the best pick I got to simulate an enum for PHP < 8.1
- Tests are based on PHP bcmath extension official tests: https://github.com/php/php-src/tree/master/ext/bcmath/tests