### PR TITLE
Add polyfill for PDO driver specific subclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Polyfills are provided for:
 - the `CURL_HTTP_VERSION_3` and `CURL_HTTP_VERSION_3ONLY` constants introduced in PHP 8.4;
 - the `grapheme_str_split` function introduced in PHP 8.4;
 - the `bcceil`, `bcdivmod`, `bcfloor` and `bcround` functions introduced in PHP 8.4;
+- the `PDO` driver specific sub-classes introduced in PHP 8.4;
 - the `get_error_handler` and `get_exception_handler` functions introduced in PHP 8.5;
 - the `NoDiscard` attribute introduced in PHP 8.5;
 - the `array_first` and `array_last` functions introduced in PHP 8.5;

--- a/src/Php84/README.md
+++ b/src/Php84/README.md
@@ -11,6 +11,7 @@ This component provides features added to PHP 8.4 core:
 - [`grapheme_str_split`](https://wiki.php.net/rfc/grapheme_str_split)
 - [`mb_trim`, `mb_ltrim` and `mb_rtrim`](https://wiki.php.net/rfc/mb_trim)
 - [`mb_ucfirst` and `mb_lcfirst`](https://wiki.php.net/rfc/mb_ucfirst)
+- [`PDO` driver specific sub-classes](https://wiki.php.net/rfc/pdo_driver_specific_subclasses)
 - [`ReflectionConstant`](https://github.com/php/php-src/pull/13669)
 
 More information can be found in the

--- a/src/Php84/Resources/stubs/Pdo/Dblib.php
+++ b/src/Php84/Resources/stubs/Pdo/Dblib.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pdo;
+
+if (\PHP_VERSION_ID < 80400 && \extension_loaded('pdo_dblib')) {
+    class Dblib extends \PDO
+    {
+        public const ATTR_CONNECTION_TIMEOUT = \PDO::DBLIB_ATTR_CONNECTION_TIMEOUT;
+        public const ATTR_QUERY_TIMEOUT = \PDO::DBLIB_ATTR_QUERY_TIMEOUT;
+        public const ATTR_STRINGIFY_UNIQUEIDENTIFIER = \PDO::DBLIB_ATTR_STRINGIFY_UNIQUEIDENTIFIER;
+        public const ATTR_VERSION = \PDO::DBLIB_ATTR_VERSION;
+        public const ATTR_TDS_VERSION = \PHP_VERSION_ID >= 70300 ? \PDO::DBLIB_ATTR_TDS_VERSION : 1004;
+        public const ATTR_SKIP_EMPTY_ROWSETS = \PHP_VERSION_ID >= 70300 ? \PDO::DBLIB_ATTR_SKIP_EMPTY_ROWSETS : 1005;
+        public const ATTR_DATETIME_CONVERT = \PHP_VERSION_ID >= 70300 ? \PDO::DBLIB_ATTR_DATETIME_CONVERT : 1006;
+
+        public function __construct(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null)
+        {
+            parent::__construct($dsn, $username, $password, $options);
+
+            if ('dblib' !== $driver = $this->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
+                throw new \PDOException(\sprintf('Pdo\Dblib::__construct() cannot be used for connecting to the "%s" driver', $driver));
+            }
+        }
+
+        public static function connect(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null): self
+        {
+            try {
+                return new self($dsn, $username, $password, $options);
+            } catch (\PDOException $e) {
+                throw preg_match('/^Pdo\\\\Dblib::__construct\(\) cannot be used for connecting to the "([a-z]+)" driver/', $e->getMessage(), $matches) ? new \PDOException(\sprintf('Pdo\Dblib::connect() cannot be used for connecting to the "%s" driver', $matches[1])) : $e;
+            }
+        }
+    }
+}

--- a/src/Php84/Resources/stubs/Pdo/Firebird.php
+++ b/src/Php84/Resources/stubs/Pdo/Firebird.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pdo;
+
+if (\PHP_VERSION_ID < 80400 && \extension_loaded('pdo_firebird')) {
+    class Firebird extends \PDO
+    {
+        public const ATTR_DATE_FORMAT = \PDO::FB_ATTR_DATE_FORMAT;
+        public const ATTR_TIME_FORMAT = \PDO::FB_ATTR_TIME_FORMAT;
+        public const ATTR_TIMESTAMP_FORMAT = \PDO::FB_ATTR_TIMESTAMP_FORMAT;
+
+        public function __construct(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null)
+        {
+            parent::__construct($dsn, $username, $password, $options);
+
+            if ('firebird' !== $driver = $this->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
+                throw new \PDOException(\sprintf('Pdo\Firebird::__construct() cannot be used for connecting to the "%s" driver', $driver));
+            }
+        }
+
+        public static function connect(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null): self
+        {
+            try {
+                return new self($dsn, $username, $password, $options);
+            } catch (\PDOException $e) {
+                throw preg_match('/^Pdo\\\\Firebird::__construct\(\) cannot be used for connecting to the "([a-z]+)" driver/', $e->getMessage(), $matches) ? new \PDOException(\sprintf('Pdo\Firebird::connect() cannot be used for connecting to the "%s" driver', $matches[1])) : $e;
+            }
+        }
+    }
+}

--- a/src/Php84/Resources/stubs/Pdo/Mysql.php
+++ b/src/Php84/Resources/stubs/Pdo/Mysql.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pdo;
+
+use PDO;
+
+if (\PHP_VERSION_ID < 80400 && \extension_loaded('pdo_mysql')) {
+    // Feature detection for non-mysqlnd; see also https://www.php.net/manual/en/class.pdo-mysql.php#pdo-mysql.constants.attr-max-buffer-size
+    if (\defined('PDO::MYSQL_ATTR_MAX_BUFFER_SIZE') && \defined('PDO::MYSQL_ATTR_READ_DEFAULT_FILE') && \defined('PDO::MYSQL_ATTR_READ_DEFAULT_GROUP')) {
+        class Mysql extends \PDO
+        {
+            public const ATTR_COMPRESS = \PDO::MYSQL_ATTR_COMPRESS;
+            public const ATTR_DIRECT_QUERY = \PDO::MYSQL_ATTR_DIRECT_QUERY;
+            public const ATTR_FOUND_ROWS = \PDO::MYSQL_ATTR_FOUND_ROWS;
+            public const ATTR_IGNORE_SPACE = \PDO::MYSQL_ATTR_IGNORE_SPACE;
+            public const ATTR_INIT_COMMAND = \PDO::MYSQL_ATTR_INIT_COMMAND;
+            public const ATTR_LOCAL_INFILE = \PDO::MYSQL_ATTR_LOCAL_INFILE;
+            public const ATTR_LOCAL_INFILE_DIRECTORY = \PHP_VERSION_ID >= 80100 ? \PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY : 1015;
+            public const ATTR_MAX_BUFFER_SIZE = \PDO::MYSQL_ATTR_MAX_BUFFER_SIZE;
+            public const ATTR_MULTI_STATEMENTS = \PDO::MYSQL_ATTR_MULTI_STATEMENTS;
+            public const ATTR_READ_DEFAULT_FILE = \PDO::MYSQL_ATTR_READ_DEFAULT_FILE;
+            public const ATTR_READ_DEFAULT_GROUP = \PDO::MYSQL_ATTR_READ_DEFAULT_GROUP;
+            public const ATTR_SERVER_PUBLIC_KEY = \PDO::MYSQL_ATTR_SERVER_PUBLIC_KEY;
+            public const ATTR_SSL_CA = \PDO::MYSQL_ATTR_SSL_CA;
+            public const ATTR_SSL_CAPATH = \PDO::MYSQL_ATTR_SSL_CAPATH;
+            public const ATTR_SSL_CERT = \PDO::MYSQL_ATTR_SSL_CERT;
+            public const ATTR_SSL_CIPHER = \PDO::MYSQL_ATTR_SSL_CIPHER;
+            public const ATTR_SSL_KEY = \PDO::MYSQL_ATTR_SSL_KEY;
+            public const ATTR_SSL_VERIFY_SERVER_CERT = \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
+            public const ATTR_USE_BUFFERED_QUERY = \PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
+
+            public function __construct(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null)
+            {
+                parent::__construct($dsn, $username, $password, $options);
+
+                if ('mysql' !== $driver = $this->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
+                    throw new \PDOException(\sprintf('Pdo\Mysql::__construct() cannot be used for connecting to the "%s" driver', $driver));
+                }
+            }
+
+            public static function connect(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null): self
+            {
+                try {
+                    return new self($dsn, $username, $password, $options);
+                } catch (\PDOException $e) {
+                    throw preg_match('/^Pdo\\\\Mysql::__construct\(\) cannot be used for connecting to the "([a-z]+)" driver/', $e->getMessage(), $matches) ? new \PDOException(\sprintf('Pdo\Mysql::connect() cannot be used for connecting to the "%s" driver', $matches[1])) : $e;
+                }
+            }
+        }
+    } else {
+        class Mysql extends \PDO
+        {
+            public const ATTR_COMPRESS = \PDO::MYSQL_ATTR_COMPRESS;
+            public const ATTR_DIRECT_QUERY = \PDO::MYSQL_ATTR_DIRECT_QUERY;
+            public const ATTR_FOUND_ROWS = \PDO::MYSQL_ATTR_FOUND_ROWS;
+            public const ATTR_IGNORE_SPACE = \PDO::MYSQL_ATTR_IGNORE_SPACE;
+            public const ATTR_INIT_COMMAND = \PDO::MYSQL_ATTR_INIT_COMMAND;
+            public const ATTR_LOCAL_INFILE = \PDO::MYSQL_ATTR_LOCAL_INFILE;
+            public const ATTR_LOCAL_INFILE_DIRECTORY = \PHP_VERSION_ID >= 80100 ? \PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY : 1015;
+            // public const ATTR_MAX_BUFFER_SIZE = PDO::MYSQL_ATTR_MAX_BUFFER_SIZE; // disabled for mysqlnd
+            public const ATTR_MULTI_STATEMENTS = \PDO::MYSQL_ATTR_MULTI_STATEMENTS;
+            // public const ATTR_READ_DEFAULT_FILE = PDO::MYSQL_ATTR_READ_DEFAULT_FILE; // disabled for mysqlnd
+            // public const ATTR_READ_DEFAULT_GROUP = PDO::MYSQL_ATTR_READ_DEFAULT_GROUP; // disabled for mysqlnd
+            public const ATTR_SERVER_PUBLIC_KEY = \PDO::MYSQL_ATTR_SERVER_PUBLIC_KEY;
+            public const ATTR_SSL_CA = \PDO::MYSQL_ATTR_SSL_CA;
+            public const ATTR_SSL_CAPATH = \PDO::MYSQL_ATTR_SSL_CAPATH;
+            public const ATTR_SSL_CERT = \PDO::MYSQL_ATTR_SSL_CERT;
+            public const ATTR_SSL_CIPHER = \PDO::MYSQL_ATTR_SSL_CIPHER;
+            public const ATTR_SSL_KEY = \PDO::MYSQL_ATTR_SSL_KEY;
+            public const ATTR_SSL_VERIFY_SERVER_CERT = \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
+            public const ATTR_USE_BUFFERED_QUERY = \PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
+
+            public function __construct(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null)
+            {
+                parent::__construct($dsn, $username, $password, $options);
+
+                if ('mysql' !== $driver = $this->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
+                    throw new \PDOException(\sprintf('Pdo\Mysql::__construct() cannot be used for connecting to the "%s" driver', $driver));
+                }
+            }
+
+            public static function connect(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null): self
+            {
+                try {
+                    return new self($dsn, $username, $password, $options);
+                } catch (\PDOException $e) {
+                    throw preg_match('/^Pdo\\\\Mysql::__construct\(\) cannot be used for connecting to the "([a-z]+)" driver/', $e->getMessage(), $matches) ? new \PDOException(\sprintf('Pdo\Mysql::connect() cannot be used for connecting to the "%s" driver', $matches[1])) : $e;
+                }
+            }
+        }
+    }
+}

--- a/src/Php84/Resources/stubs/Pdo/Odbc.php
+++ b/src/Php84/Resources/stubs/Pdo/Odbc.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pdo;
+
+if (\PHP_VERSION_ID < 80400 && \extension_loaded('pdo_odbc')) {
+    class Odbc extends \PDO
+    {
+        public const ATTR_USE_CURSOR_LIBRARY = \PDO::ODBC_ATTR_USE_CURSOR_LIBRARY;
+        public const ATTR_ASSUME_UTF8 = \PDO::ODBC_ATTR_ASSUME_UTF8;
+        public const SQL_USE_IF_NEEDED = \PDO::ODBC_SQL_USE_IF_NEEDED;
+        public const SQL_USE_DRIVER = \PDO::ODBC_SQL_USE_DRIVER;
+        public const SQL_USE_ODBC = \PDO::ODBC_SQL_USE_ODBC;
+
+        public function __construct(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null)
+        {
+            parent::__construct($dsn, $username, $password, $options);
+
+            if ('odbc' !== $driver = $this->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
+                throw new \PDOException(\sprintf('Pdo\Odbc::__construct() cannot be used for connecting to the "%s" driver', $driver));
+            }
+        }
+
+        public static function connect(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null): self
+        {
+            try {
+                return new self($dsn, $username, $password, $options);
+            } catch (\PDOException $e) {
+                throw preg_match('/^Pdo\\\\Odbc::__construct\(\) cannot be used for connecting to the "([a-z]+)" driver/', $e->getMessage(), $matches) ? new \PDOException(\sprintf('Pdo\Odbc::connect() cannot be used for connecting to the "%s" driver', $matches[1])) : $e;
+            }
+        }
+    }
+}

--- a/src/Php84/Resources/stubs/Pdo/Pgsql.php
+++ b/src/Php84/Resources/stubs/Pdo/Pgsql.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pdo;
+
+if (\PHP_VERSION_ID < 80400 && \extension_loaded('pdo_pgsql')) {
+    class Pgsql extends \PDO
+    {
+        public const ATTR_DISABLE_PREPARES = \PDO::PGSQL_ATTR_DISABLE_PREPARES;
+
+        public function __construct(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null)
+        {
+            parent::__construct($dsn, $username, $password, $options);
+
+            if ('pgsql' !== $driver = $this->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
+                throw new \PDOException(\sprintf('Pdo\Pgsql::__construct() cannot be used for connecting to the "%s" driver', $driver));
+            }
+        }
+
+        public static function connect(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null): self
+        {
+            try {
+                return new self($dsn, $username, $password, $options);
+            } catch (\PDOException $e) {
+                throw preg_match('/^Pdo\\\\Pgsql::__construct\(\) cannot be used for connecting to the "([a-z]+)" driver/', $e->getMessage(), $matches) ? new \PDOException(\sprintf('Pdo\Pgsql::connect() cannot be used for connecting to the "%s" driver', $matches[1])) : $e;
+            }
+        }
+
+        public function copyFromArray(string $tableName, array $rows, string $separator = "\t", string $nullAs = '\\\\N', ?string $fields = null): bool
+        {
+            return $this->pgsqlCopyFromArray($tableName, $rows, $separator, $nullAs, $fields);
+        }
+
+        public function copyFromFile(string $tableName, string $filename, string $separator = "\t", string $nullAs = '\\\\N', ?string $fields = null): bool
+        {
+            return $this->pgsqlCopyFromFile($tableName, $filename, $separator, $nullAs, $fields);
+        }
+
+        /**
+         * @return array|false
+         */
+        public function copyToArray(string $tableName, string $separator = "\t", string $nullAs = '\\\\N', ?string $fields = null)
+        {
+            return $this->pgsqlCopyToArray($tableName, $separator, $nullAs, $fields);
+        }
+
+        public function copyToFile(string $tableName, string $filename, string $separator = "\t", string $nullAs = '\\\\N', ?string $fields = null): bool
+        {
+            return $this->pgsqlCopyToFile($tableName, $filename, $separator, $nullAs, $fields);
+        }
+
+        /**
+         * @return array|false
+         */
+        public function getNotify(int $fetchMode = \PDO::FETCH_DEFAULT, int $timeoutMilliseconds = 0)
+        {
+            return $this->pgsqlGetNotify($fetchMode, $timeoutMilliseconds);
+        }
+
+        public function getPid(): int
+        {
+            return $this->pgsqlGetPid();
+        }
+
+        /**
+         * @return string|false
+         */
+        public function lobCreate()
+        {
+            return $this->pgsqlLOBCreate();
+        }
+
+        /**
+         * @return resource|false
+         */
+        public function lobOpen(string $oid, string $mode = 'rb')
+        {
+            return $this->pgsqlLOBOpen($oid, $mode);
+        }
+
+        public function lobUnlink(string $oid): bool
+        {
+            return $this->pgsqlLOBUnlink($oid);
+        }
+    }
+}

--- a/src/Php84/Resources/stubs/Pdo/Sqlite.php
+++ b/src/Php84/Resources/stubs/Pdo/Sqlite.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pdo;
+
+if (\PHP_VERSION_ID < 80400 && \extension_loaded('pdo_sqlite')) {
+    class Sqlite extends \PDO
+    {
+        public const ATTR_EXTENDED_RESULT_CODES = \PHP_VERSION_ID >= 70400 ? \PDO::SQLITE_ATTR_EXTENDED_RESULT_CODES : 1002;
+        public const ATTR_OPEN_FLAGS = \PHP_VERSION_ID >= 70300 ? \PDO::SQLITE_ATTR_OPEN_FLAGS : 1000;
+        public const ATTR_READONLY_STATEMENT = \PHP_VERSION_ID >= 70400 ? \PDO::SQLITE_ATTR_READONLY_STATEMENT : 1001;
+        public const DETERMINISTIC = \PDO::SQLITE_DETERMINISTIC;
+        public const OPEN_READONLY = \PHP_VERSION_ID >= 70300 ? \PDO::SQLITE_OPEN_READONLY : 1;
+        public const OPEN_READWRITE = \PHP_VERSION_ID >= 70300 ? \PDO::SQLITE_OPEN_READWRITE : 2;
+        public const OPEN_CREATE = \PHP_VERSION_ID >= 70300 ? \PDO::SQLITE_OPEN_CREATE : 4;
+
+        public function __construct(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null)
+        {
+            parent::__construct($dsn, $username, $password, $options);
+
+            if ('sqlite' !== $driver = $this->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
+                throw new \PDOException(\sprintf('Pdo\Sqlite::__construct() cannot be used for connecting to the "%s" driver', $driver));
+            }
+        }
+
+        public static function connect(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null): self
+        {
+            try {
+                return new self($dsn, $username, $password, $options);
+            } catch (\PDOException $e) {
+                throw preg_match('/^Pdo\\\\Sqlite::__construct\(\) cannot be used for connecting to the "([a-z]+)" driver/', $e->getMessage(), $matches) ? new \PDOException(\sprintf('Pdo\Sqlite::connect() cannot be used for connecting to the "%s" driver', $matches[1])) : $e;
+            }
+        }
+
+        public function createAggregate(string $name, callable $step, callable $finalize, int $numArgs = -1): bool
+        {
+            return $this->sqliteCreateAggregate($name, $step, $finalize, $numArgs);
+        }
+
+        public function createCollation(string $name, callable $callback): bool
+        {
+            return $this->sqliteCreateCollation($name, $callback);
+        }
+
+        public function createFunction(string $function_name, callable $callback, int $num_args = -1, int $flags = 0): bool
+        {
+            return $this->sqliteCreateFunction($function_name, $callback, $num_args, $flags);
+        }
+    }
+}

--- a/tests/Php84/PdoTest.php
+++ b/tests/Php84/PdoTest.php
@@ -1,0 +1,244 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Php84;
+
+use PHPUnit\Framework\TestCase;
+
+class PdoTest extends TestCase
+{
+    /**
+     * @requires extension pdo_dblib
+     * @requires extension pdo_sqlite
+     */
+    public function testDblibConstructor()
+    {
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessage("Pdo\Dblib::__construct() cannot be used for connecting to the \"sqlite\" driver");
+        new \Pdo\Dblib('sqlite:');
+    }
+
+    /**
+     * @requires extension pdo_firebird
+     * @requires extension pdo_sqlite
+     */
+    public function testFirebirdConstructor()
+    {
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessage("Pdo\Firebird::__construct() cannot be used for connecting to the \"sqlite\" driver");
+        new \Pdo\Firebird('sqlite:');
+    }
+
+    /**
+     * @requires extension pdo_mysql
+     * @requires extension pdo_sqlite
+     */
+    public function testMysqlConstructor()
+    {
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessage("Pdo\Mysql::__construct() cannot be used for connecting to the \"sqlite\" driver");
+        new \Pdo\Mysql('sqlite:');
+    }
+
+    /**
+     * @requires extension pdo_odbc
+     * @requires extension pdo_sqlite
+     */
+    public function testOdbcConstructor()
+    {
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessage("Pdo\Odbc::__construct() cannot be used for connecting to the \"sqlite\" driver");
+        new \Pdo\Odbc('sqlite:');
+    }
+
+    /**
+     * @requires extension pdo_pgsql
+     * @requires extension pdo_sqlite
+     */
+    public function testPgsqlConstructor()
+    {
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessage("Pdo\Pgsql::__construct() cannot be used for connecting to the \"sqlite\" driver");
+        new \Pdo\Pgsql('sqlite:');
+    }
+
+    /**
+     * @requires extension pdo_sqlite
+     */
+    public function testSqliteConstructor()
+    {
+        $sqlite = new \Pdo\Sqlite('sqlite:');
+        $this->assertInstanceOf(\Pdo\Sqlite::class, $sqlite);
+    }
+
+    /**
+     * @requires extension pdo_dblib
+     * @requires extension pdo_sqlite
+     */
+    public function testDblibConnect()
+    {
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessage("Pdo\Dblib::connect() cannot be used for connecting to the \"sqlite\" driver");
+        \Pdo\Dblib::connect('sqlite:');
+    }
+
+    /**
+     * @requires extension pdo_firebird
+     * @requires extension pdo_sqlite
+     */
+    public function testFirebirdConnect()
+    {
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessage("Pdo\Firebird::connect() cannot be used for connecting to the \"sqlite\" driver");
+        \Pdo\Firebird::connect('sqlite:');
+    }
+
+    /**
+     * @requires extension pdo_mysql
+     * @requires extension pdo_sqlite
+     */
+    public function testMysqlConnect()
+    {
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessage("Pdo\Mysql::connect() cannot be used for connecting to the \"sqlite\" driver");
+        \Pdo\Mysql::connect('sqlite:');
+    }
+
+    /**
+     * @requires extension pdo_odbc
+     * @requires extension pdo_sqlite
+     */
+    public function testOdbcConnect()
+    {
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessage("Pdo\Odbc::connect() cannot be used for connecting to the \"sqlite\" driver");
+        \Pdo\Odbc::connect('sqlite:');
+    }
+
+    /**
+     * @requires extension pdo_pgsql
+     * @requires extension pdo_sqlite
+     */
+    public function testPgsqlConnect()
+    {
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessage("Pdo\Pgsql::connect() cannot be used for connecting to the \"sqlite\" driver");
+        \Pdo\Pgsql::connect('sqlite:');
+    }
+
+    /**
+     * @requires extension pdo_sqlite
+     */
+    public function testSqliteConnect()
+    {
+        $sqlite = \Pdo\Sqlite::connect('sqlite:');
+        $this->assertInstanceOf(\Pdo\Sqlite::class, $sqlite);
+    }
+
+    /**
+     * @requires extension pdo_sqlite
+     */
+    public function testSqliteConnectOnClassExtensions()
+    {
+        $sqlite = ExtendedPdoSqlite::connect('sqlite:');
+        $this->assertInstanceOf(\Pdo\Sqlite::class, $sqlite);
+    }
+
+    /**
+     * @requires extension pdo_dblib
+     */
+    public function testDblibConstants()
+    {
+        $this->assertSame(1000, \Pdo\Dblib::ATTR_CONNECTION_TIMEOUT);
+        $this->assertSame(1001, \Pdo\Dblib::ATTR_QUERY_TIMEOUT);
+        $this->assertSame(1002, \Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER);
+        $this->assertSame(1003, \Pdo\Dblib::ATTR_VERSION);
+        $this->assertSame(1004, \Pdo\Dblib::ATTR_TDS_VERSION);
+        $this->assertSame(1005, \Pdo\Dblib::ATTR_SKIP_EMPTY_ROWSETS);
+        $this->assertSame(1006, \Pdo\Dblib::ATTR_DATETIME_CONVERT);
+    }
+
+    /**
+     * @requires extension pdo_firebird
+     */
+    public function testFirebirdConstants()
+    {
+        $this->assertSame(1000, \Pdo\Firebird::ATTR_DATE_FORMAT);
+        $this->assertSame(1001, \Pdo\Firebird::ATTR_TIME_FORMAT);
+        $this->assertSame(1002, \Pdo\Firebird::ATTR_TIMESTAMP_FORMAT);
+    }
+
+    /**
+     * @requires extension pdo_mysql
+     */
+    public function testMysqlConstants()
+    {
+        $this->assertSame(1000, \Pdo\Mysql::ATTR_USE_BUFFERED_QUERY);
+        $this->assertSame(1001, \Pdo\Mysql::ATTR_LOCAL_INFILE);
+        $this->assertSame(1002, \Pdo\Mysql::ATTR_INIT_COMMAND);
+        $this->assertSame(1003, \Pdo\Mysql::ATTR_COMPRESS);
+        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1004 : 20, \Pdo\Mysql::ATTR_DIRECT_QUERY);
+        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1005 : 1004, \Pdo\Mysql::ATTR_FOUND_ROWS);
+        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1006 : 1005, \Pdo\Mysql::ATTR_IGNORE_SPACE);
+        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1007 : 1006, \Pdo\Mysql::ATTR_SSL_KEY);
+        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1008 : 1007, \Pdo\Mysql::ATTR_SSL_CERT);
+        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1009 : 1008, \Pdo\Mysql::ATTR_SSL_CA);
+        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1010 : 1009, \Pdo\Mysql::ATTR_SSL_CAPATH);
+        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1011 : 1010, \Pdo\Mysql::ATTR_SSL_CIPHER);
+        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1012 : 1011, \Pdo\Mysql::ATTR_SERVER_PUBLIC_KEY);
+        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1013 : 1012, \Pdo\Mysql::ATTR_MULTI_STATEMENTS);
+        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1014 : 1013, \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT);
+        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1015 : 1014, \Pdo\Mysql::ATTR_LOCAL_INFILE_DIRECTORY);
+        if (\defined('PDO::MYSQL_ATTR_MAX_BUFFER_SIZE') && \defined('PDO::MYSQL_ATTR_READ_DEFAULT_FILE') && \defined('PDO::MYSQL_ATTR_READ_DEFAULT_GROUP')) {
+            $this->assertSame(1003, \Pdo\Mysql::ATTR_READ_DEFAULT_FILE);
+            $this->assertSame(1004, \Pdo\Mysql::ATTR_READ_DEFAULT_GROUP);
+            $this->assertSame(1005, \Pdo\Mysql::ATTR_MAX_BUFFER_SIZE);
+        }
+    }
+
+    /**
+     * @requires extension pdo_odbc
+     */
+    public function testOdbcConstants()
+    {
+        $this->assertSame(0, \Pdo\Odbc::SQL_USE_IF_NEEDED);
+        $this->assertSame(1, \Pdo\Odbc::SQL_USE_ODBC);
+        $this->assertSame(2, \Pdo\Odbc::SQL_USE_DRIVER);
+        $this->assertSame(1000, \Pdo\Odbc::ATTR_USE_CURSOR_LIBRARY);
+        $this->assertSame(1001, \Pdo\Odbc::ATTR_ASSUME_UTF8);
+    }
+
+    /**
+     * @requires extension pdo_pgsql
+     */
+    public function testPgsqlConstants()
+    {
+        $this->assertSame(1000, \Pdo\Pgsql::ATTR_DISABLE_PREPARES);
+    }
+
+    /**
+     * @requires extension pdo_sqlite
+     */
+    public function testSqliteConstants()
+    {
+        $this->assertSame(1, \Pdo\Sqlite::OPEN_READONLY);
+        $this->assertSame(2, \Pdo\Sqlite::OPEN_READWRITE);
+        $this->assertSame(4, \Pdo\Sqlite::OPEN_CREATE);
+        $this->assertSame(1000, \Pdo\Sqlite::ATTR_OPEN_FLAGS);
+        $this->assertSame(1001, \Pdo\Sqlite::ATTR_READONLY_STATEMENT);
+        $this->assertSame(1002, \Pdo\Sqlite::ATTR_EXTENDED_RESULT_CODES);
+        $this->assertSame(2048, \Pdo\Sqlite::DETERMINISTIC);
+    }
+}
+
+class ExtendedPdoSqlite extends \Pdo\Sqlite
+{
+}


### PR DESCRIPTION
As a follow-up to #547, this PR aims to implement a full-fledged set of polyfills for the driver specific PDO subclasses introduced in PHP 8.4; see also https://wiki.php.net/rfc/pdo_driver_specific_subclasses.

As of PHP 8.5, the driver specific constants and methods available on the base `PDO` class will be deprecated, to be removed in PHP 9.0. See also https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_driver_specific_pdo_constants_and_methods.

This PR adds a polyfill to use the driver-specific child classes for PHP versions prior to PHP 8.4. This in turn allows one to already refer to the 'new' constant, to prevent deprecation errors on PHP 8.5, while retaining backwards compatibility. This can be particularly useful for code requiring support for multiple versions; see e.g. https://github.com/laravel/framework/issues/57141.

The classes should be suitable for constructing on older PHP versions.

Note the `PDO::connect` static method that has been introduced simultaneously has not been polyfilled, as I can't think of a proper way to do such a thing currently.