### PR TITLE
[PHP 8.5] Add new `\Filter\FilterException` and `Filter\FilterFailedException`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Polyfills are provided for:
 - the `NoDiscard` attribute introduced in PHP 8.5;
 - the `array_first` and `array_last` functions introduced in PHP 8.5;
 - the `DelayedTargetValidation` attribute introduced in PHP 8.5;
+- the `Filter\FilterException` class introduced in PHP 8.5;
+- the `Filter\FilterFailedException` class introduced in PHP 8.5;
 - the `clamp` function introduced in PHP 8.6;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing

--- a/src/Php85/Php85.php
+++ b/src/Php85/Php85.php
@@ -45,6 +45,6 @@ final class Php85
 
     public static function array_last(array $array)
     {
-        return $array ? current(array_slice($array, -1)) : null;
+        return $array ? current(\array_slice($array, -1)) : null;
     }
 }

--- a/src/Php85/README.md
+++ b/src/Php85/README.md
@@ -7,6 +7,8 @@ This component provides features added to PHP 8.5 core:
 - [`NoDiscard`](https://wiki.php.net/rfc/marking_return_value_as_important)
 - [`array_first` and `array_last`](https://wiki.php.net/rfc/array_first_last)
 - [`DelayedTargetValidation`](https://wiki.php.net/rfc/delayedtargetvalidation_attribute)
+- [`Filter\FilterException class`](https://wiki.php.net/rfc/filter_throw_on_failure)
+- [`Filter\FilterFailedException class`](https://wiki.php.net/rfc/filter_throw_on_failure)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).

--- a/src/Php85/Resources/stubs/Filter/FilterException.php
+++ b/src/Php85/Resources/stubs/Filter/FilterException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Filter;
+
+if (\PHP_VERSION_ID < 80500) {
+    class FilterException extends \Exception
+    {
+    }
+}

--- a/src/Php85/Resources/stubs/Filter/FilterFailedException.php
+++ b/src/Php85/Resources/stubs/Filter/FilterFailedException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Filter;
+
+if (\PHP_VERSION_ID < 80500) {
+    class FilterFailedException extends FilterException
+    {
+    }
+}

--- a/tests/Php85/Php85Test.php
+++ b/tests/Php85/Php85Test.php
@@ -114,6 +114,12 @@ class Php85Test extends TestCase
         $this->assertTrue(array_first([true, new \stdClass()]));
         $this->assertEquals(new \stdClass(), array_last([true, new \stdClass()]));
     }
+
+    public function testFilterExceptionClassesExist()
+    {
+        $this->assertTrue(class_exists(\Filter\FilterException::class));
+        $this->assertTrue(class_exists(\Filter\FilterFailedException::class));
+    }
 }
 
 class TestHandler


### PR DESCRIPTION
PHP 8.5 adds two new exception classes, along with the new `FILTER_THROW_ON_FAILURE` flag. We can not polyfill the exception behavior (which is activated with the `FILTER_THROW_ON_FAILURE` flag), but we can still polyfill the exception classes.

 - [RFC](https://wiki.php.net/rfc/filter_throw_on_failure)
 - [PR](https://github.com/php/php-src/pull/18896)
 - [`Filter\FilterException`](https://php.watch/versions/8.5/filter-validation-throw-exception#FilterException), [codex](https://php.watch/codex/Filter/FilterException)
 - [`Filter\FilterFailedException`](https://php.watch/versions/8.5/filter-validation-throw-exception#FilterFailedException), [codex](https://php.watch/codex/Filter/FilterFailedException)