### PR TITLE
Add fallback implementation for Collator::compare()

### DIFF
--- a/src/Intl/Icu/Collator.php
+++ b/src/Intl/Icu/Collator.php
@@ -118,17 +118,15 @@ abstract class Collator
     }
 
     /**
-     * Not supported. Compare two Unicode strings.
+     * Compare two Unicode strings.
      *
      * @return int|false
      *
      * @see https://php.net/collator.compare
-     *
-     * @throws MethodNotImplementedException
      */
     public function compare(string $string1, string $string2)
     {
-        throw new MethodNotImplementedException(__METHOD__);
+        return strcasecmp($string1, $string2) ?: $string2 <=> $string1;
     }
 
     /**

--- a/tests/Intl/Icu/CollatorTest.php
+++ b/tests/Intl/Icu/CollatorTest.php
@@ -29,9 +29,19 @@ class CollatorTest extends AbstractCollatorTest
 
     public function testCompare()
     {
-        $this->expectException(MethodNotImplementedException::class);
         $collator = $this->getCollator('en');
-        $collator->compare('a', 'b');
+        $this->assertEquals(-1, $collator->compare('a', 'b'));
+        $this->assertEquals(0, $collator->compare('a', 'a'));
+        $this->assertEquals(1, $collator->compare('b', 'a'));
+
+        // case-insensitive base ordering
+        $this->assertLessThan(0, $collator->compare('a', 'B'));
+        $this->assertLessThan(0, $collator->compare('A', 'b'));
+        $this->assertGreaterThan(0, $collator->compare('Z', 'a'));
+
+        // lowercase before uppercase tie-breaking
+        $this->assertLessThan(0, $collator->compare('a', 'A'));
+        $this->assertGreaterThan(0, $collator->compare('ABC', 'abc'));
     }
 
     public function testGetAttribute()


### PR DESCRIPTION
Fixes #535

## Summary
Add a fallback implementation for `Collator::compare()` in the polyfill.

## Changes
- Replace `MethodNotImplementedException` with a basic string comparison
- Use the spaceship operator (`<=>`) for consistent behavior
- Update tests accordingly

## Notes
This provides a simple and deterministic fallback without replicating full ICU collation behavior.