### PR TITLE
[DeepClone] Support internal final classes with __unserialize (e.g. MongoDB BSON types)

### DIFF
--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -32,6 +32,7 @@ final class DeepClone
     private static array $prototypes = [];
     private static array $cloneable = [];
     private static array $instantiableWithoutConstructor = [];
+    private static array $needsFullUnserialize = [];
     private static array $hydrators = [];
     private static array $scopeMaps = [];
     private static array $protos = [];
@@ -651,7 +652,9 @@ final class DeepClone
                 throw new \DeepClone\ClassNotFoundException('Class "'.$class.'" not found.');
             }
 
-            if (self::$cloneable[$class]) {
+            if (self::$needsFullUnserialize[$class] ?? false) {
+                $objects[$id] = null; // placeholder — finalized below or in states loop
+            } elseif (self::$cloneable[$class]) {
                 $objects[$id] = clone self::$prototypes[$class];
             } elseif (self::$instantiableWithoutConstructor[$class]) {
                 $objects[$id] = self::$reflectors[$class]->newInstanceWithoutConstructor();
@@ -662,6 +665,21 @@ final class DeepClone
             } else {
                 $objects[$id] = unserialize('O:'.\strlen($class).':"'.$class.'":0:{}');
             }
+        }
+
+        // Eagerly finalize deferred objects whose state has no object-ref masks,
+        // so they are real instances when the properties loop resolves references to them.
+        foreach ($states as $state) {
+            if (!\is_array($state) || null !== $objects[$state[0]] || isset($state[2])) {
+                continue;
+            }
+            $class = $objectMeta[$state[0]][0];
+            $ser = serialize($state[1] ?? []);
+            $obj = unserialize('O:'.\strlen($class).':"'.$class.'"'.substr($ser, strpos($ser, ':', 1)));
+            if (false === $obj) {
+                throw new \ValueError('deepclone_from_array(): could not reconstruct "'.$class.'" via __unserialize()');
+            }
+            $objects[$state[0]] = $obj;
         }
 
         foreach ($refMasks as $k => $m) {
@@ -736,6 +754,19 @@ final class DeepClone
                     throw new \ValueError('deepclone_from_array(): Argument #1 ($data) "states" entry references unknown object id '.$zid);
                 }
                 $obj = $objects[$zid];
+                if (null === $obj) {
+                    // Internal final class with __unserialize that rejects empty unserialize —
+                    // reconstruct via the full O: serialization form (same as PHP's unserialize).
+                    $class = $objectMeta[$zid][0];
+                    $resolvedProps = isset($state[2]) ? self::resolveWithMask($sprops, $state[2], $objects, $refs) : $sprops;
+                    $ser = serialize($resolvedProps);
+                    $obj = unserialize('O:'.\strlen($class).':"'.$class.'"'.substr($ser, strpos($ser, ':', 1)));
+                    if (false === $obj) {
+                        throw new \ValueError('deepclone_from_array(): could not reconstruct "'.$class.'" via __unserialize()');
+                    }
+                    $objects[$zid] = $obj;
+                    continue;
+                }
                 $objClass = $obj::class;
                 if (!method_exists($obj, '__unserialize')) {
                     throw new \ValueError('deepclone_from_array(): Argument #1 ($data) "states" entry references object id '.$zid.' whose class '.$objClass.' has no __unserialize() method');
@@ -993,10 +1024,18 @@ final class DeepClone
                         if (__FILE__ !== $e->getFile()) {
                             throw $e;
                         }
-                        throw new \DeepClone\NotInstantiableException('Type "'.$class.'" is not instantiable.', 0, $e);
+                        if (!method_exists($class, '__unserialize')) {
+                            throw new \DeepClone\NotInstantiableException('Type "'.$class.'" is not instantiable.', 0, $e);
+                        }
+                        self::$needsFullUnserialize[$class] = true;
+                        $proto = null;
                     }
                     if (false === $proto) {
-                        throw new \DeepClone\NotInstantiableException('Type "'.$class.'" is not instantiable.');
+                        if (!method_exists($class, '__unserialize')) {
+                            throw new \DeepClone\NotInstantiableException('Type "'.$class.'" is not instantiable.');
+                        }
+                        self::$needsFullUnserialize[$class] = true;
+                        $proto = null;
                     }
                 }
             }

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -1041,6 +1041,44 @@ class DeepCloneTest extends TestCase
         $c = deepclone_from_array($d, ['stdClass']);
         $this->assertSame(1, $c->x);
     }
+
+    /**
+     * @requires extension mongodb
+     */
+    public function testMongoDbBsonRoundTrip()
+    {
+        $roundtrip = static function (mixed $value): bool {
+            $clone = deepclone_from_array(deepclone_to_array($value));
+            return serialize($clone) === serialize($value);
+        };
+
+        // Stateless types
+        $this->assertTrue($roundtrip(new \MongoDB\BSON\MinKey()));
+        $this->assertTrue($roundtrip(new \MongoDB\BSON\MaxKey()));
+
+        // Value types carrying state via __serialize / __unserialize
+        $this->assertTrue($roundtrip(new \MongoDB\BSON\ObjectId('507f1f77bcf86cd799439011')));
+        $this->assertTrue($roundtrip(new \MongoDB\BSON\Binary("\x00\x01\x02\x03", \MongoDB\BSON\Binary::TYPE_GENERIC)));
+        $this->assertTrue($roundtrip(new \MongoDB\BSON\Binary(random_bytes(16), \MongoDB\BSON\Binary::TYPE_UUID)));
+        $this->assertTrue($roundtrip(new \MongoDB\BSON\UTCDateTime(1000)));
+        $this->assertTrue($roundtrip(new \MongoDB\BSON\Regex('^foo', 'i')));
+        $this->assertTrue($roundtrip(new \MongoDB\BSON\Decimal128('3.14159265358979323846')));
+        $this->assertTrue($roundtrip(new \MongoDB\BSON\Int64(\PHP_INT_MAX)));
+        $this->assertTrue($roundtrip(new \MongoDB\BSON\Timestamp(1, 1234567890)));
+        $this->assertTrue($roundtrip(new \MongoDB\BSON\Javascript('function(x) { return x; }')));
+        $this->assertTrue($roundtrip(\MongoDB\BSON\Document::fromPHP(['_id' => new \MongoDB\BSON\ObjectId('507f1f77bcf86cd799439011'), 'n' => 1])));
+        $this->assertTrue($roundtrip(\MongoDB\BSON\PackedArray::fromPHP([new \MongoDB\BSON\ObjectId('507f1f77bcf86cd799439011'), 42])));
+
+        // Shared references: two properties pointing to the same BSON object
+        $oid = new \MongoDB\BSON\ObjectId('507f1f77bcf86cd799439011');
+        $obj = new \stdClass();
+        $obj->a = $oid;
+        $obj->b = $oid;
+        $clone = deepclone_from_array(deepclone_to_array($obj));
+        $this->assertEquals($clone->a, $clone->b);   // same value
+        $this->assertSame($clone->a, $clone->b);     // object identity preserved in the graph
+        $this->assertNotSame($clone->a, $oid);       // but distinct from the original
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Polyfill for symfony/php-ext-deepclone#4.

The pure-PHP implementation requires an extra step: since we cannot use `newInstanceWithoutConstructor()` and the empty-state `unserialize('O:...:0:{}')` is rejected (e.g. MongoDB's `__unserialize([])` throws on missing keys), we build the full serialized payload from the object's state before calling `unserialize()`.

When the object's state contains no object-reference masks it can be finalized before the properties loop, so that other objects can hold references to it normally.