### PR TITLE
[DeepClone] Test deepclone of tidyNode (final internal class without serialization API)

### DIFF
--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -25,7 +25,6 @@ final class DeepClone
         'XMLReader' => true,
         'SNMP' => true,
         'tidy' => true,
-        'tidyNode' => true,
     ];
 
     private static array $reflectors = [];

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -1044,6 +1044,31 @@ class DeepCloneTest extends TestCase
         $this->assertSame(1, $c->x);
     }
 
+    // ─────────────────────────────────────────────────────────────────────
+    // deepclone_rule_a_probe.phpt — final internal classes without serialization API
+    // ─────────────────────────────────────────────────────────────────────
+
+    /**
+     * @requires extension tidy
+     */
+    public function testTidyNodeRoundTrip()
+    {
+        $tidy = new \tidy();
+        $tidy->parseString('<p><b>hello</b></p>', [], 'utf8');
+        $b = $tidy->body()->child[0]->child[0]; // <b> node
+
+        $clone = deepclone_from_array(deepclone_to_array($b));
+
+        $this->assertInstanceOf(\tidyNode::class, $clone);
+        $this->assertNotSame($b, $clone);
+        $this->assertSame($b->name, $clone->name);
+        $this->assertSame($b->value, $clone->value);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // deepclone_mongodb.phpt — MongoDB BSON types round-trip
+    // ─────────────────────────────────────────────────────────────────────
+
     /**
      * @requires extension mongodb
      */


### PR DESCRIPTION
`tidyNode` is a final internal PHP class (bundled `tidy` extension) with a C-level constructor but no `__serialize`/`__unserialize`/`__sleep`/`__wakeup`. It was incorrectly rejected by the polyfill as not instantiable.

This PR adds a test covering this class as the PHP-only counterpart of the PHPT test added in symfony/php-ext-deepclone#5.