### PR TITLE
[PHP 8.6] Add `ARRAY_FILTER_USE_VALUE` constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Polyfills are provided for:
 - the `grapheme_levenshtein` function introduced in PHP 8.5;
 - the `locale_is_right_to_left` function introduced in PHP 8.5;
 - the `clamp` function introduced in PHP 8.6;
+- the `ARRAY_FILTER_USE_VALUE` constant introduced in PHP 8.6;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no

--- a/src/Php86/README.md
+++ b/src/Php86/README.md
@@ -4,6 +4,7 @@ Symfony Polyfill / Php86
 This component provides features added to PHP 8.6 core:
 
 - [`clamp`](https://wiki.php.net/rfc/clamp_v2)
+- [`ARRAY_FILTER_USE_VALUE`] constant
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).

--- a/src/Php86/bootstrap.php
+++ b/src/Php86/bootstrap.php
@@ -15,6 +15,10 @@ if (\PHP_VERSION_ID >= 80600) {
     return;
 }
 
+if (!defined('ARRAY_FILTER_USE_VALUE')) {
+    define('ARRAY_FILTER_USE_VALUE', 0);
+}
+
 if (\PHP_VERSION_ID >= 80000) {
     return require __DIR__.'/bootstrap80.php';
 }


### PR DESCRIPTION
Adds the `ARRAY_FILTER_USE_VALUE` constant added as the defualt value for the `array_filter` function's `$mode` parameter in PHP 8.6.

 - [`array_filter`](https://php.watch/codex/array_filter)
 - [`ARRAY_FILTER_USE_VALUE`](https://php.watch/codex/array_filter)
 - [`UPGRADING` entry](https://github.com/php/php-src/blob/3c68fa9adc2b2989483738980d47052b03d82420/UPGRADING#L225)