### PR TITLE
[DeepClone] Add deepclone_hydrate() polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.35.0
+
+  * Add polyfill for `deepclone_hydrate()`
+
 # 1.34.0
 
   * Add polyfill for the `symfony/deepclone` extension

--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -33,16 +33,17 @@ final class DeepClone
     private static array $instantiableWithoutConstructor = [];
     private static array $needsFullUnserialize = [];
     private static array $hydrators = [];
+    private static array $simpleHydrators = [];
     private static array $scopeMaps = [];
     private static array $protos = [];
     private static array $classInfo = [];
     private static \stdClass $sentinel;
 
     /**
-     * @param list<string>|null $allowedClasses Classes that may be serialized
-     *                                          (null = all, [] = none)
+     * @param list<string>|null $allowed_classes Classes that may be serialized
+     *                                           (null = all, [] = none)
      */
-    public static function deepclone_to_array(mixed $value, ?array $allowedClasses = null): array
+    public static function deepclone_to_array(mixed $value, ?array $allowed_classes = null): array
     {
         if (\is_resource($value)) {
             throw new \DeepClone\NotInstantiableException('Type "'.get_resource_type($value).' resource" is not instantiable.');
@@ -53,11 +54,11 @@ final class DeepClone
         }
 
         $allowedSet = null;
-        if (null !== $allowedClasses) {
+        if (null !== $allowed_classes) {
             $allowedSet = [];
-            foreach ($allowedClasses as $cls) {
+            foreach ($allowed_classes as $cls) {
                 if (!\is_string($cls)) {
-                    throw new \ValueError('deepclone_to_array(): Argument $allowedClasses must be an array of class names, '.self::valueName($cls).' given');
+                    throw new \ValueError('deepclone_to_array(): Argument $allowed_classes must be an array of class names, '.self::valueName($cls).' given');
                 }
                 $allowedSet[strtolower($cls)] = true;
             }
@@ -242,10 +243,10 @@ final class DeepClone
     }
 
     /**
-     * @param list<string>|null $allowedClasses Classes that may be instantiated
-     *                                          (null = all, [] = none)
+     * @param list<string>|null $allowed_classes Classes that may be instantiated
+     *                                           (null = all, [] = none)
      */
-    public static function deepclone_from_array(array $data, ?array $allowedClasses = null): mixed
+    public static function deepclone_from_array(array $data, ?array $allowed_classes = null): mixed
     {
         if (\array_key_exists('value', $data)) {
             return $data['value'];
@@ -286,8 +287,8 @@ final class DeepClone
         }
         $numClasses = \count($classes);
 
-        if (null !== $allowedClasses) {
-            $allowed = array_change_key_case(array_flip($allowedClasses));
+        if (null !== $allowed_classes) {
+            $allowed = array_change_key_case(array_flip($allowed_classes));
             foreach ($classes as $cls) {
                 if (!isset($allowed[strtolower($cls)])) {
                     throw new \ValueError('deepclone_from_array(): class "'.$cls.'" is not allowed');
@@ -365,8 +366,104 @@ final class DeepClone
             $data['refs'] ?? [],
             $data['mask'] ?? null,
             $data['refMasks'] ?? [],
-            $allowedClasses,
+            $allowed_classes,
         );
+    }
+
+    public static function deepclone_hydrate(object|string $object_or_class, array $scoped_vars = [], array $mangled_vars = []): object
+    {
+        if (\is_string($object_or_class)) {
+            if (!\array_key_exists($object_or_class, self::$cloneable)) {
+                self::getClassReflector($object_or_class);
+            }
+            $r = self::$reflectors[$object_or_class] ?? new \ReflectionClass($object_or_class);
+            if (self::$cloneable[$object_or_class]) {
+                $object = clone self::$prototypes[$object_or_class];
+            } elseif (self::$instantiableWithoutConstructor[$object_or_class]) {
+                $object = $r->newInstanceWithoutConstructor();
+            } elseif (null === self::$prototypes[$object_or_class]) {
+                throw new \DeepClone\NotInstantiableException('Class "'.$object_or_class.'" is not instantiable.');
+            } elseif ($r->implementsInterface('Serializable') && !method_exists($object_or_class, '__unserialize')) {
+                $object = unserialize('C:'.\strlen($object_or_class).':"'.$object_or_class.'":0:{}');
+            } else {
+                $object = unserialize('O:'.\strlen($object_or_class).':"'.$object_or_class.'":0:{}');
+            }
+        } else {
+            $r = null;
+            $object = $object_or_class;
+        }
+
+        if ($mangled_vars) {
+            $class = $object::class;
+            $r ??= new \ReflectionClass($class);
+
+            foreach ($mangled_vars as $name => &$value) {
+                if (!\is_string($name)) {
+                    throw new \ValueError('deepclone_hydrate(): Argument #3 ($mangled_vars) must have only string keys');
+                }
+                if ("\0" === $name) {
+                    $scoped_vars[$class][$name] = &$value;
+                    continue;
+                }
+                if (str_starts_with($name, "\0")) {
+                    $sep = strpos($name, "\0", 1);
+                    if (false === $sep) {
+                        continue;
+                    }
+                    $scopeName = substr($name, 1, $sep - 1);
+                    $realName = substr($name, $sep + 1);
+
+                    if (\str_contains($realName, "\0")) {
+                        throw new \ValueError('deepclone_hydrate(): Argument #3 ($mangled_vars) contains an invalid mangled key');
+                    }
+
+                    if ('*' === $scopeName) {
+                        $scopeName = $r->hasProperty($realName) ? $r->getProperty($realName)->class : $class;
+                    }
+                } else {
+                    $realName = $name;
+                    $scopeName = $r->hasProperty($name) ? $r->getProperty($name)->class : $class;
+                }
+
+                $scoped_vars[$scopeName][$realName] = &$value;
+            }
+            unset($value);
+        }
+
+        $obj_class = $object::class;
+        foreach ($scoped_vars as $scope => $properties) {
+            if (!\is_array($properties)) {
+                throw new \ValueError(\sprintf('deepclone_hydrate(): Argument #2 ($scoped_vars) must have only array values, %s given for key "%s"', get_debug_type($properties), $scope));
+            }
+            if ('stdClass' !== $scope && $scope !== $obj_class && (!is_a($obj_class, $scope, true) || interface_exists($scope, false))) {
+                throw new \ValueError(\sprintf('deepclone_hydrate(): Argument #2 ($scoped_vars) scope "%s" is not a parent of "%s"', $scope, $obj_class));
+            }
+            if (isset($properties["\0"]) && \is_array($properties["\0"])) {
+                $special = $properties["\0"];
+                unset($properties["\0"]);
+
+                if ($object instanceof \SplObjectStorage) {
+                    for ($i = 0, $c = \count($special); $i + 1 < $c; $i += 2) {
+                        $object[$special[$i]] = $special[$i + 1];
+                    }
+                } elseif ($object instanceof \ArrayObject || $object instanceof \ArrayIterator) {
+                    (new \ReflectionClass($object))->getConstructor()->invokeArgs($object, $special);
+                }
+            }
+            foreach ($properties as $name => $v) {
+                if (!\is_string($name)) {
+                    throw new \ValueError(\sprintf('deepclone_hydrate(): Argument #2 ($scoped_vars) scope "%s" must have only string keys', $scope));
+                }
+                if (\str_contains($name, "\0")) {
+                    throw new \ValueError(\sprintf('deepclone_hydrate(): Argument #2 ($scoped_vars) scope "%s" contains an invalid property name; use bare property names in $scoped_vars, or pass mangled keys via $mangled_vars', $scope));
+                }
+            }
+            if ($properties) {
+                (self::$simpleHydrators[$scope] ??= self::getSimpleHydrator($scope))($properties, $object);
+            }
+        }
+
+        return $object;
     }
 
     /**
@@ -1002,7 +1099,7 @@ final class DeepClone
 
         if ($instantiableWithoutConstructor) {
             $proto = $reflector->newInstanceWithoutConstructor();
-        } elseif (!$isClass || $reflector->isAbstract()) {
+        } elseif (!$isClass || $reflector->isAbstract() || $reflector->isEnum()) {
             throw new \DeepClone\NotInstantiableException('Type "'.$class.'" is not instantiable.');
         } elseif ($reflector->name !== $class) {
             $reflector = self::$reflectors[$name = $reflector->name] ??= self::getClassReflector($name, false, $cloneable);
@@ -1180,6 +1277,123 @@ final class DeepClone
                 foreach ($values as $i => $v) {
                     $objects[$i]->$name = $v;
                 }
+            }
+        };
+    }
+
+    private static function getSimpleHydrator(string $class): \Closure
+    {
+        $baseHydrator = self::$simpleHydrators['stdClass'] ??= static function ($properties, $object) {
+            foreach ($properties as $name => &$value) {
+                $object->$name = $value;
+                $object->$name = &$value;
+            }
+        };
+
+        switch ($class) {
+            case 'stdClass':
+                return $baseHydrator;
+
+            case 'TypeError':
+                $class = 'Error';
+                break;
+
+            case 'ErrorException':
+                $class = 'Exception';
+                break;
+
+            case 'SplObjectStorage':
+                return static function ($properties, $object) {
+                    foreach ($properties as $name => &$value) {
+                        if ("\0" !== $name) {
+                            $object->$name = $value;
+                            $object->$name = &$value;
+                            continue;
+                        }
+                        for ($i = 0; $i < \count($value); ++$i) {
+                            $object[$value[$i]] = $value[++$i];
+                        }
+                    }
+                };
+        }
+
+        if (!class_exists($class) && !interface_exists($class, false) && !trait_exists($class, false)) {
+            throw new \DeepClone\ClassNotFoundException('Class "'.$class.'" not found.');
+        }
+        $classReflector = new \ReflectionClass($class);
+
+        switch ($class) {
+            case 'ArrayIterator':
+            case 'ArrayObject':
+                $constructor = $classReflector->getConstructor()->invokeArgs(...);
+
+                return static function ($properties, $object) use ($constructor) {
+                    foreach ($properties as $name => &$value) {
+                        if ("\0" === $name) {
+                            $constructor($object, $value);
+                        } else {
+                            $object->$name = $value;
+                            $object->$name = &$value;
+                        }
+                    }
+                };
+        }
+
+        if (!$classReflector->isInternal()) {
+            $notByRef = new \stdClass();
+            foreach ($classReflector->getProperties() as $propertyReflector) {
+                if ($propertyReflector->isStatic()) {
+                    continue;
+                }
+                if (\PHP_VERSION_ID >= 80400 && !$propertyReflector->isAbstract() && $propertyReflector->getHooks()) {
+                    $notByRef->{$propertyReflector->name} = $propertyReflector->setRawValue(...);
+                } elseif ($propertyReflector->isReadOnly()) {
+                    $notByRef->{$propertyReflector->name} = static function ($object, $value) use ($propertyReflector) {
+                        if (!$propertyReflector->isInitialized($object)) {
+                            $propertyReflector->setValue($object, $value);
+                        }
+                    };
+                }
+            }
+
+            return (function ($properties, $object) {
+                $notByRef = (array) $this;
+
+                foreach ($properties as $name => &$value) {
+                    if (!$noRef = $notByRef[$name] ?? false) {
+                        $object->$name = $value;
+                        $object->$name = &$value;
+                    } elseif (true !== $noRef) {
+                        $noRef($object, $value);
+                    } else {
+                        $object->$name = $value;
+                    }
+                }
+            })->bindTo($notByRef, $class);
+        }
+
+        if ($classReflector->name !== $class) {
+            return self::$simpleHydrators[$classReflector->name] ??= self::getSimpleHydrator($classReflector->name);
+        }
+
+        $propertySetters = [];
+        foreach ($classReflector->getProperties() as $propertyReflector) {
+            if (!$propertyReflector->isStatic()) {
+                $propertySetters[$propertyReflector->name] = $propertyReflector->setValue(...);
+            }
+        }
+
+        if (!$propertySetters) {
+            return $baseHydrator;
+        }
+
+        return static function ($properties, $object) use ($propertySetters) {
+            foreach ($properties as $name => $value) {
+                if ($setValue = $propertySetters[$name] ?? null) {
+                    $setValue($object, $value);
+                    continue;
+                }
+                $object->$name = $value;
             }
         };
     }

--- a/src/DeepClone/bootstrap.php
+++ b/src/DeepClone/bootstrap.php
@@ -15,9 +15,6 @@ if (extension_loaded('deepclone')) {
     return;
 }
 
-if (!function_exists('deepclone_to_array')) {
-    function deepclone_to_array(mixed $value, ?array $allowedClasses = null): array { return p\DeepClone::deepclone_to_array($value, $allowedClasses); }
-}
-if (!function_exists('deepclone_from_array')) {
-    function deepclone_from_array(array $data, ?array $allowedClasses = null): mixed { return p\DeepClone::deepclone_from_array($data, $allowedClasses); }
+if (\PHP_VERSION_ID >= 80200) {
+    require __DIR__.'/bootstrap82.php';
 }

--- a/src/DeepClone/bootstrap82.php
+++ b/src/DeepClone/bootstrap82.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\DeepClone as p;
+
+if (extension_loaded('deepclone')) {
+    return;
+}
+
+if (!function_exists('deepclone_to_array')) {
+    function deepclone_to_array(mixed $value, ?array $allowed_classes = null): array { return p\DeepClone::deepclone_to_array($value, $allowed_classes); }
+}
+if (!function_exists('deepclone_from_array')) {
+    function deepclone_from_array(array $data, ?array $allowed_classes = null): mixed { return p\DeepClone::deepclone_from_array($data, $allowed_classes); }
+}
+if (!function_exists('deepclone_hydrate')) {
+    function deepclone_hydrate(object|string $object_or_class, array $scoped_vars = [], array $mangled_vars = []): object { return p\DeepClone::deepclone_hydrate($object_or_class, $scoped_vars, $mangled_vars); }
+}

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -22,10 +22,6 @@ if (\PHP_VERSION_ID >= 80100) {
  */
 class DeepCloneTest extends TestCase
 {
-    // ─────────────────────────────────────────────────────────────────────
-    // deepclone_to_array.phpt — wire-format shape assertions
-    // ─────────────────────────────────────────────────────────────────────
-
     public function testToArrayIntIsStatic()
     {
         $this->assertSame(['value' => 42], deepclone_to_array(42));
@@ -161,10 +157,6 @@ class DeepCloneTest extends TestCase
 
         $this->assertSame($big, $d['properties']['stdClass']['data'][0]);
     }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // deepclone_from_array.phpt — happy-path reconstruction
-    // ─────────────────────────────────────────────────────────────────────
 
     public function testFromArrayScalarInt()
     {
@@ -314,10 +306,6 @@ class DeepCloneTest extends TestCase
         $this->assertSame(1, $c2[1]);
     }
 
-    // ─────────────────────────────────────────────────────────────────────
-    // deepclone_from_array_validation.phpt — malformed-payload rejection
-    // ─────────────────────────────────────────────────────────────────────
-
     public function testFromArrayRejectsMissingClasses()
     {
         $this->expectException(\ValueError::class);
@@ -437,10 +425,6 @@ class DeepCloneTest extends TestCase
         deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => -99]);
     }
 
-    // ─────────────────────────────────────────────────────────────────────
-    // deepclone_closures.phpt
-    // ─────────────────────────────────────────────────────────────────────
-
     public function testClosureGlobalFunctionWireFormat()
     {
         $d = deepclone_to_array(\Closure::fromCallable('strlen'));
@@ -497,10 +481,6 @@ class DeepCloneTest extends TestCase
         $this->assertSame('private', $clone());
     }
 
-    // ─────────────────────────────────────────────────────────────────────
-    // deepclone_datetime.phpt
-    // ─────────────────────────────────────────────────────────────────────
-
     public function testDateTimeRoundTrip()
     {
         $dt = \DateTime::createFromFormat('U', '0');
@@ -543,10 +523,6 @@ class DeepCloneTest extends TestCase
         $this->assertInstanceOf(\DateInterval::class, $clone);
         $this->assertSame(7, $clone->d);
     }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // deepclone_enums.phpt
-    // ─────────────────────────────────────────────────────────────────────
 
     public function testEnumIsStaticValue()
     {
@@ -595,10 +571,6 @@ class DeepCloneTest extends TestCase
         $this->assertSame(DeepCloneColor::Blue, $clone[1]);
     }
 
-    // ─────────────────────────────────────────────────────────────────────
-    // deepclone_error_scope.phpt
-    // ─────────────────────────────────────────────────────────────────────
-
     public function testErrorPropertiesStayUnderErrorScope()
     {
         $e = new \Error('test');
@@ -636,10 +608,6 @@ class DeepCloneTest extends TestCase
         $this->assertSame('round-trip', $clone->getMessage());
     }
 
-    // ─────────────────────────────────────────────────────────────────────
-    // deepclone_serialize.phpt — __serialize / __unserialize / __wakeup / __sleep
-    // ─────────────────────────────────────────────────────────────────────
-
     public function testSerializeMethodWireFormatAndRoundTrip()
     {
         $o = new DeepCloneSerializeFixture('test', 42);
@@ -676,10 +644,6 @@ class DeepCloneTest extends TestCase
         $this->assertArrayHasKey('keep', $d['properties']['stdClass']);
         $this->assertArrayNotHasKey('skip', $d['properties']['stdClass']);
     }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // deepclone_serialize_edge.phpt
-    // ─────────────────────────────────────────────────────────────────────
 
     public function testSerializeWithoutUnserializeScopedProperties()
     {
@@ -751,10 +715,6 @@ class DeepCloneTest extends TestCase
         $this->assertArrayNotHasKey('Symfony\\Polyfill\\Tests\\DeepClone\\DeepCloneParentSleep', $d['properties'] ?? []);
     }
 
-    // ─────────────────────────────────────────────────────────────────────
-    // deepclone_typed_objects.phpt — visibility + inheritance + readonly
-    // ─────────────────────────────────────────────────────────────────────
-
     public function testTypedObjectParentClass()
     {
         $o = new DeepCloneParentClass();
@@ -800,10 +760,6 @@ class DeepCloneTest extends TestCase
         $this->assertSame('test', $clone->name);
         $this->assertSame(42, $clone->value);
     }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // deepclone_doc_behaviors.phpt
-    // ─────────────────────────────────────────────────────────────────────
 
     public function testDocBehaviorsMissingClassThrowsClassNotFound()
     {
@@ -1102,5 +1058,328 @@ class DeepCloneTest extends TestCase
         $this->assertNotSame($b, $clone);
         $this->assertSame($b->name, $clone->name);
         $this->assertSame($b->value, $clone->value);
+    }
+
+    public function testHydrateScopedInstantiate()
+    {
+        $obj = deepclone_hydrate(HydrateChild::class, [
+            HydrateBase::class => ['secret' => 'hidden'],
+            HydrateChild::class => ['num' => 42],
+            'stdClass' => ['pub' => 'visible'],
+        ]);
+
+        $this->assertInstanceOf(HydrateChild::class, $obj);
+        $this->assertSame('hidden', $obj->getSecret());
+        $this->assertSame(42, $obj->getNum());
+        $this->assertSame('visible', $obj->pub);
+    }
+
+    public function testHydrateScopedExistingObject()
+    {
+        $existing = new HydrateChild();
+        $result = deepclone_hydrate($existing, [
+            HydrateBase::class => ['secret' => 'updated'],
+            'stdClass' => ['pub' => 'changed'],
+        ]);
+
+        $this->assertSame($existing, $result);
+        $this->assertSame('updated', $result->getSecret());
+        $this->assertSame('changed', $result->pub);
+        $this->assertSame(0, $result->getNum());
+    }
+
+    public function testHydrateScopedStdClass()
+    {
+        $o = deepclone_hydrate('stdClass', ['stdClass' => ['x' => 1, 'y' => 'hi']]);
+
+        $this->assertSame(1, $o->x);
+        $this->assertSame('hi', $o->y);
+    }
+
+    public function testHydrateSplObjectStorage()
+    {
+        $s = new \SplObjectStorage();
+        $o1 = new \stdClass();
+        $o2 = new \stdClass();
+
+        $result = deepclone_hydrate($s, ['stdClass' => ["\0" => [$o1, 'info1', $o2, 'info2']]]);
+
+        $this->assertSame($s, $result);
+        $this->assertSame(2, $result->count());
+        $result->rewind();
+        $this->assertSame($o1, $result->current());
+        $this->assertSame('info1', $result->getInfo());
+    }
+
+    public function testHydrateArrayObject()
+    {
+        $ao = deepclone_hydrate('ArrayObject', [
+            'stdClass' => ["\0" => [['x' => 1, 'y' => 2], \ArrayObject::ARRAY_AS_PROPS]],
+        ]);
+
+        $this->assertInstanceOf(\ArrayObject::class, $ao);
+        $this->assertSame(1, $ao['x']);
+        $this->assertTrue($ao->getFlags() === \ArrayObject::ARRAY_AS_PROPS);
+    }
+
+    public function testHydrateArrayIterator()
+    {
+        $ai = deepclone_hydrate('ArrayIterator', [
+            'stdClass' => ["\0" => [['a', 'b', 'c']]],
+        ]);
+
+        $this->assertInstanceOf(\ArrayIterator::class, $ai);
+        $this->assertCount(3, $ai);
+    }
+
+    public function testHydrateFlatStdClass()
+    {
+        $this->assertEquals((object) ['p' => 123], deepclone_hydrate('stdClass', [], ['p' => 123]));
+    }
+
+    public function testHydrateFlatCaseInsensitiveClass()
+    {
+        $this->assertEquals((object) ['p' => 123], deepclone_hydrate('STDcLASS', [], ['p' => 123]));
+    }
+
+    public function testHydrateFlatArrayObject()
+    {
+        $this->assertEquals(new \ArrayObject([123]), deepclone_hydrate(\ArrayObject::class, [], ["\0" => [[123]]]));
+    }
+
+    public function testHydrateFlatSplObjectStorage()
+    {
+        $o1 = new \stdClass();
+        $s = deepclone_hydrate('SplObjectStorage', [], ["\0" => [$o1, 'data']]);
+
+        $this->assertSame(1, $s->count());
+    }
+
+    public function testHydrateFlatInheritanceMixed()
+    {
+        $actual = (array) deepclone_hydrate(HydrateBar::class, [HydrateFoo::class => ['priv' => 234]], [
+            'dyn' => 456, 'ro' => 567, 'prot' => 345, 'priv' => 123,
+        ]);
+        ksort($actual);
+
+        $expected = [
+            "\0*\0prot" => 345,
+            "\0".HydrateBar::class."\0priv" => 123,
+            "\0".HydrateFoo::class."\0priv" => 234,
+            'dyn' => 456,
+            'ro' => 567,
+        ];
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testHydrateFlatMangledKeys()
+    {
+        $expected = [
+            "\0*\0prot" => 345,
+            "\0".HydrateBar::class."\0priv" => 123,
+            "\0".HydrateFoo::class."\0priv" => 234,
+            'dyn' => 456,
+            'ro' => 567,
+        ];
+
+        $actual = (array) deepclone_hydrate(HydrateBar::class, [], $expected);
+        ksort($actual);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testHydrateFlatExceptionTrace()
+    {
+        $e = deepclone_hydrate('Exception', [], ['trace' => [234]]);
+
+        $this->assertSame([234], $e->getTrace());
+    }
+
+    public function testHydrateFlatReadonlyInitialized()
+    {
+        $obj = new HydrateReadonly(123);
+        $obj = deepclone_hydrate($obj, [], ['value' => 456, 'status' => 'hydrated']);
+
+        // C ext overwrites via OBJ_PROP; polyfill respects readonly
+        if (\extension_loaded('deepclone')) {
+            $this->assertSame(456, $obj->getValue());
+        } else {
+            $this->assertSame(123, $obj->getValue());
+        }
+        $this->assertSame('hydrated', $obj->status);
+    }
+
+    public function testHydrateFlatReadonlyUninitialized()
+    {
+        $obj = deepclone_hydrate(HydrateReadonly::class, [HydrateReadonly::class => ['value' => 456]]);
+
+        $this->assertSame(456, $obj->getValue());
+    }
+
+    public function testHydratePhpReferences()
+    {
+        $properties = ['p1' => 1];
+        $properties['p2'] = &$properties['p1'];
+
+        $obj = deepclone_hydrate('stdClass', [], $properties);
+
+        $this->assertSame(1, $obj->p1);
+        $this->assertSame(1, $obj->p2);
+
+        $properties['p1'] = 2;
+        $this->assertSame(2, $obj->p1);
+        $this->assertSame(2, $obj->p2);
+    }
+
+    public function testHydrateScopedReferences()
+    {
+        $v = 'hello';
+        $obj = deepclone_hydrate('stdClass', ['stdClass' => ['x' => &$v, 'y' => &$v]]);
+
+        $v = 'world';
+        $this->assertSame('world', $obj->x);
+        $this->assertSame('world', $obj->y);
+    }
+
+    public function testHydrateClassNotFound()
+    {
+        $this->expectException(\DeepClone\ClassNotFoundException::class);
+        $this->expectExceptionMessage('NoSuchClass99');
+        deepclone_hydrate('NoSuchClass99');
+    }
+
+    public function testHydrateAbstractClass()
+    {
+        $this->expectException(\DeepClone\NotInstantiableException::class);
+        $this->expectExceptionMessage('SplHeap');
+        deepclone_hydrate('SplHeap');
+    }
+
+    public function testHydrateInterface()
+    {
+        $this->expectException(\DeepClone\NotInstantiableException::class);
+        $this->expectExceptionMessage('Throwable');
+        deepclone_hydrate('Throwable');
+    }
+
+    public function testHydrateNoArgInstantiate()
+    {
+        $o = deepclone_hydrate('stdClass');
+
+        $this->assertInstanceOf(\stdClass::class, $o);
+    }
+
+    public function testHydrateEnum()
+    {
+        $this->expectException(\DeepClone\NotInstantiableException::class);
+        deepclone_hydrate(HydrateColor::class);
+    }
+
+    public function testHydrateTrait()
+    {
+        $this->expectException(\DeepClone\NotInstantiableException::class);
+        deepclone_hydrate(HydrateTrait::class);
+    }
+
+    public function testHydrateGrandparentPrivate()
+    {
+        $o = deepclone_hydrate(HydrateC::class, [], [
+            "\0".HydrateGP::class."\0secret" => 'gp_val',
+            "\0".HydrateP::class."\0mid" => 42,
+            'pub' => 'hi',
+        ]);
+
+        $this->assertSame('gp_val', $o->getSecret());
+        $this->assertSame(42, $o->getMid());
+        $this->assertSame('hi', $o->pub);
+    }
+
+    public function testHydrateBothParamsOverwrite()
+    {
+        $o = deepclone_hydrate('stdClass', ['stdClass' => ['x' => 'from_scoped']], ['x' => 'from_flat']);
+
+        $this->assertSame('from_flat', $o->x);
+    }
+
+    public function testHydrateIntegerKeyInProperties()
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('string keys');
+        deepclone_hydrate('stdClass', [], [0 => 'val']);
+    }
+
+    public function testHydrateNonArrayInScopedProperties()
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('array values');
+        deepclone_hydrate('stdClass', ['stdClass' => 'not-array']);
+    }
+
+    public function testHydrateReflectorSubclass()
+    {
+        $this->expectException(\DeepClone\NotInstantiableException::class);
+        deepclone_hydrate('ReflectionClass');
+    }
+
+    public function testHydrateClosure()
+    {
+        $this->expectException(\DeepClone\NotInstantiableException::class);
+        deepclone_hydrate('Closure');
+    }
+
+    public function testHydrateSplFileInfo()
+    {
+        $this->expectException(\DeepClone\NotInstantiableException::class);
+        deepclone_hydrate('SplFileInfo');
+    }
+
+    public function testHydrateNulInScopedPropertyName()
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('invalid property name');
+        deepclone_hydrate('stdClass', ['stdClass' => ["foo\0bar" => 'val']]);
+    }
+
+    public function testHydrateNulInMangledKeyProperty()
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('invalid mangled key');
+        deepclone_hydrate('stdClass', [], ["\0*\0foo\0bar" => 'val']);
+    }
+
+    public function testHydrateIntegerKeyInsideScope()
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('string keys');
+        deepclone_hydrate('stdClass', ['stdClass' => [0 => 'val']]);
+    }
+
+    public function testHydrateMangledKeyInsideScope()
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('mangled key');
+        deepclone_hydrate('stdClass', ['stdClass' => ["\0stdClass\0x" => 'val']]);
+    }
+
+    public function testHydrateInterfaceAsScope()
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('not a parent');
+        deepclone_hydrate(\ArrayObject::class, ['IteratorAggregate' => ['x' => 1]]);
+    }
+
+    public function testHydrateUnrelatedScope()
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('not a parent');
+        deepclone_hydrate('stdClass', ['SplHeap' => ['x' => 1]]);
+    }
+
+    public function testHydrateNonExistingScope()
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('not a parent');
+        deepclone_hydrate('stdClass', ['NonExistent' => ['x' => 1]]);
     }
 }

--- a/tests/DeepClone/fixtures.php
+++ b/tests/DeepClone/fixtures.php
@@ -185,3 +185,63 @@ class DeepCloneReadonlyFixture
     ) {
     }
 }
+
+class HydrateFoo
+{
+    protected $prot;
+    private $priv;
+    public readonly int $ro;
+}
+
+#[\AllowDynamicProperties]
+class HydrateBar extends HydrateFoo
+{
+    private $priv;
+}
+
+class HydrateBase
+{
+    private string $secret = '';
+    public function getSecret(): string { return $this->secret; }
+}
+
+class HydrateChild extends HydrateBase
+{
+    protected int $num = 0;
+    public string $pub = '';
+    public function getNum(): int { return $this->num; }
+}
+
+class HydrateReadonly
+{
+    public string $status = 'new';
+    private readonly int $value;
+    public function __construct(int $value) { $this->value = $value; }
+    public function getValue(): int { return $this->value; }
+}
+
+class HydrateGP
+{
+    private string $secret = '';
+    public function getSecret(): string { return $this->secret; }
+}
+
+class HydrateP extends HydrateGP
+{
+    private int $mid = 0;
+    public function getMid(): int { return $this->mid; }
+}
+
+class HydrateC extends HydrateP
+{
+    public string $pub = '';
+}
+
+enum HydrateColor
+{
+    case Red;
+}
+
+trait HydrateTrait
+{
+}


### PR DESCRIPTION
Pure-PHP implementation of `deepclone_hydrate(object|string $object_or_class, array $scoped_vars = [], array $mangled_vars = []): object`, matching the C extension (symfony/php-ext-deepclone#6).

- `$scoped_vars` writes directly with `Closure::bind` for scope access
- `$mangled_vars` resolves mangled keys (`"\0Class\0prop"`, `"\0*\0prop"`) to the correct scope
- SPL special `"\0"` key: ArrayObject/ArrayIterator constructor, SplObjectStorage attach
- PHP `&` reference preservation via `$object->$name = $value; $object->$name = &$value;`
- Instantiability validation reuses `getClassReflector()` (same rules as `deepclone_from_array`)
- `ValueError` on integer keys in `$mangled_vars` or non-array values in `$scoped_vars`
- Fix: `getClassReflector()` now rejects enums
- All parameters renamed to snake_case (`$allowed_classes`, `$object_or_class`, etc.)