### PR TITLE
[PHP 8.6] Add SortDirection enum for PHP 8.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Polyfills are provided for:
 - the `locale_is_right_to_left` function introduced in PHP 8.5;
 - the `clamp` function introduced in PHP 8.6;
 - the `ARRAY_FILTER_USE_VALUE` constant introduced in PHP 8.6;
+- the `SortDirection` enum introduced in PHP 8.6;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
             "src/Intl/Icu/Resources/stubs",
             "src/Intl/MessageFormatter/Resources/stubs",
             "src/Intl/Normalizer/Resources/stubs",
+            "src/Php86/Resources/stubs",
             "src/Php85/Resources/stubs",
             "src/Php84/Resources/stubs",
             "src/Php83/Resources/stubs",

--- a/src/Php86/README.md
+++ b/src/Php86/README.md
@@ -4,7 +4,8 @@ Symfony Polyfill / Php86
 This component provides features added to PHP 8.6 core:
 
 - [`clamp`](https://wiki.php.net/rfc/clamp_v2)
-- [`ARRAY_FILTER_USE_VALUE`] constant
+- `ARRAY_FILTER_USE_VALUE` constant
+- [`SortDirection`](https://wiki.php.net/rfc/sort_direction_enum)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).

--- a/src/Php86/Resources/stubs/SortDirection.php
+++ b/src/Php86/Resources/stubs/SortDirection.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80600 && \PHP_VERSION_ID >= 80100) {
+    enum SortDirection
+    {
+        case Ascending;
+        case Descending;
+    }
+}

--- a/src/Php86/composer.json
+++ b/src/Php86/composer.json
@@ -20,7 +20,8 @@
     },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Php86\\": "" },
-        "files": [ "bootstrap.php" ]
+        "files": [ "bootstrap.php" ],
+        "classmap": [ "Resources/stubs" ]
     },
     "minimum-stability": "dev",
     "extra": {

--- a/tests/Php86/Php86Test.php
+++ b/tests/Php86/Php86Test.php
@@ -35,7 +35,7 @@ class Php86Test extends TestCase
 
     public function testClampNanReturn(): void
     {
-        $this->assertTrue(is_nan(clamp(NAN, 4, 6)));
+        $this->assertNan(clamp(\NAN, 4, 6));
     }
 
     public static function provideValidClampInput(): array
@@ -172,5 +172,15 @@ class Php86Test extends TestCase
                 'clamp(): Argument #2 ($min) must be smaller than or equal to argument #3 ($max)',
             ],
         ];
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testSortDirectionEnum()
+    {
+        $this->assertTrue(enum_exists(\SortDirection::class), 'SortDirection enum exists');
+        $this->assertInstanceOf(\UnitEnum::class, \SortDirection::Ascending);
+        $this->assertInstanceOf(\UnitEnum::class, \SortDirection::Descending);
     }
 }


### PR DESCRIPTION
Adds the new `SortDirection` Enum added to PH 8.6. This Enum is meant to be used in user-land PHP and core PHP alike, and the RFC encourages polyfilling it too.

 - [RFC](https://php.watch/rfcs/sort_direction_enum)
 - [Commit](https://github.com/php/php-src/commit/32c1931f18109655bc074dd5cda3248b838de636)
 - [Discussion](https://externals.io/message/130226)
 - [PHP 8.6: SortDirection](https://php.watch/versions/8.6/SortDirection), [Codex](https://php.watch/codex/SortDirection)