### PR TITLE
[DeepClone] Fix cache poisoning causing spurious NotInstantiableException

### DIFF
--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -1221,12 +1221,7 @@ final class DeepClone
                 };
         }
 
-        if (!$classReflector = self::$reflectors[$class] ?? null) {
-            if (!class_exists($class) && !interface_exists($class, false) && !trait_exists($class, false)) {
-                throw new \DeepClone\ClassNotFoundException('Class "'.$class.'" not found.');
-            }
-            $classReflector = self::$reflectors[$class] = new \ReflectionClass($class);
-        }
+        $classReflector = self::$reflectors[$class] ??= self::getClassReflector($class);
 
         switch ($class) {
             case 'ArrayIterator':

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -1349,6 +1349,20 @@ class DeepCloneTest extends TestCase
         deepclone_hydrate('SplFileInfo');
     }
 
+    public function testCacheIsolationBetweenScopeHydratorAndClassReflector()
+    {
+        $child = new CacheIsolationChild();
+        $child->pub = 'hi';
+        $child->setPriv('override');
+        deepclone_from_array(deepclone_to_array($child));
+
+        $p = new CacheIsolationParent();
+        $p->setPriv('direct');
+        $clone = deepclone_from_array(deepclone_to_array($p));
+
+        $this->assertSame('direct', $clone->getPriv());
+    }
+
     public function testHydrateNulInScopedPropertyName()
     {
         $this->expectException(\ValueError::class);

--- a/tests/DeepClone/fixtures.php
+++ b/tests/DeepClone/fixtures.php
@@ -199,6 +199,18 @@ class HydrateBar extends HydrateFoo
     private $priv;
 }
 
+class CacheIsolationParent
+{
+    private string $priv = 'def';
+    public function getPriv(): string { return $this->priv; }
+    public function setPriv(string $v): void { $this->priv = $v; }
+}
+
+class CacheIsolationChild extends CacheIsolationParent
+{
+    public string $pub = '';
+}
+
 class HydrateBase
 {
     private string $secret = '';


### PR DESCRIPTION
Reported by @derrabus 

`getHydrator()` wrote to `self::$reflectors[$class]` directly without going through `getClassReflector()`, leaving the companion caches uninitialized.