### PR TITLE
[DeepClone] Fix PHP warning for `__sleep()`-listed uninitialized declared properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.35.1
+
+  * Fix PHP warning for `__sleep()`-listed uninitialized declared properties
+
 # 1.35.0
 
   * Add polyfill for `deepclone_hydrate()`

--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -665,6 +665,9 @@ final class DeepClone
             }
             if ($sleep) {
                 foreach ($sleep as $n => $v) {
+                    if (\is_string($n) && $reflector->hasProperty($n)) {
+                        continue;
+                    }
                     trigger_error(\sprintf('serialize(): "%s" returned as member variable from __sleep() but does not exist', $n), \E_USER_NOTICE);
                 }
             }
@@ -1221,7 +1224,7 @@ final class DeepClone
                 };
         }
 
-        $classReflector = self::$reflectors[$class] ??= self::getClassReflector($class);
+        $classReflector = self::$reflectors[$class] ?? new \ReflectionClass($class);
 
         switch ($class) {
             case 'ArrayIterator':

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -1349,6 +1349,45 @@ class DeepCloneTest extends TestCase
         deepclone_hydrate('SplFileInfo');
     }
 
+    public function testRoundtripWithAbstractParentScope()
+    {
+        $o = new AbstractScopeChild('entity');
+        $o->setSecret('changed');
+        $clone = deepclone_from_array(deepclone_to_array($o));
+
+        $this->assertSame('entity', $clone->sourceEntity);
+    }
+
+    public function testRoundtripWithPrivatePropertyOnAbstractParent()
+    {
+        $o = new AbstractWithPrivateChild();
+        $o->set('changed');
+        $o->pub = 'hello';
+        $clone = deepclone_from_array(deepclone_to_array($o));
+
+        $this->assertSame('changed', $clone->get());
+        $this->assertSame('hello', $clone->pub);
+    }
+
+    public function testSleepSilentlySkipsUninitializedTypedProperty()
+    {
+        $o = new AbstractScopeChild('entity');
+        $errors = [];
+        set_error_handler(function ($_, $msg) use (&$errors) {
+            $errors[] = $msg;
+
+            return true;
+        });
+
+        try {
+            deepclone_to_array($o);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $errors);
+    }
+
     public function testCacheIsolationBetweenScopeHydratorAndClassReflector()
     {
         $child = new CacheIsolationChild();

--- a/tests/DeepClone/fixtures.php
+++ b/tests/DeepClone/fixtures.php
@@ -211,6 +211,51 @@ class CacheIsolationChild extends CacheIsolationParent
     public string $pub = '';
 }
 
+abstract class AbstractScopeBase
+{
+    public string $sourceEntity;
+    public string $mappedBy;
+    private string $secret = 'def';
+
+    public function __sleep(): array
+    {
+        return ['sourceEntity', 'mappedBy'];
+    }
+
+    public function setSecret(string $v): void
+    {
+        $this->secret = $v;
+    }
+}
+
+class AbstractScopeChild extends AbstractScopeBase
+{
+    public function __construct(string $src)
+    {
+        $this->sourceEntity = $src;
+    }
+}
+
+abstract class AbstractWithPrivate
+{
+    private string $secret = 'default';
+
+    public function set(string $v): void
+    {
+        $this->secret = $v;
+    }
+
+    public function get(): string
+    {
+        return $this->secret;
+    }
+}
+
+class AbstractWithPrivateChild extends AbstractWithPrivate
+{
+    public string $pub = '';
+}
+
 class HydrateBase
 {
     private string $secret = '';


### PR DESCRIPTION
Fixing https://github.com/symfony/symfony/issues/63957 on the polyfill-side.