### PR TITLE
[DeepClone] Add DEEPCLONE_HYDRATE_PRESERVE_REFS flag + hot-path perf

### DIFF
--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -372,19 +372,11 @@ final class DeepClone
 
     public static function deepclone_hydrate(object|string $object_or_class, array $vars = [], int $flags = 0): object
     {
-        if ($flags & ~(\DEEPCLONE_HYDRATE_CALL_HOOKS | \DEEPCLONE_HYDRATE_NO_LAZY_INIT | \DEEPCLONE_HYDRATE_MANGLED_VARS)) {
+        if ($flags & ~(\DEEPCLONE_HYDRATE_CALL_HOOKS | \DEEPCLONE_HYDRATE_NO_LAZY_INIT | \DEEPCLONE_HYDRATE_MANGLED_VARS | \DEEPCLONE_HYDRATE_PRESERVE_REFS)) {
             throw new \ValueError('deepclone_hydrate(): Argument #3 ($flags) contains unknown bits');
         }
         if (($flags & \DEEPCLONE_HYDRATE_CALL_HOOKS) && ($flags & \DEEPCLONE_HYDRATE_NO_LAZY_INIT)) {
             throw new \ValueError('deepclone_hydrate(): Argument #3 ($flags) DEEPCLONE_HYDRATE_CALL_HOOKS and DEEPCLONE_HYDRATE_NO_LAZY_INIT are mutually exclusive');
-        }
-
-        if ($flags & \DEEPCLONE_HYDRATE_MANGLED_VARS) {
-            $mangled_vars = $vars;
-            $scoped_vars = [];
-        } else {
-            $scoped_vars = $vars;
-            $mangled_vars = [];
         }
 
         if (\is_string($class = $object_or_class)) {
@@ -404,6 +396,31 @@ final class DeepClone
             $r = null;
             $object = $object_or_class;
             $class = $object::class;
+        }
+
+        // Fast path: scoped mode, single scope equal to the object's class, no flags
+        // other than (optionally) PRESERVE_REFS. Most common shape for DTO hydration.
+        if (!($flags & ~\DEEPCLONE_HYDRATE_PRESERVE_REFS) && isset($vars[$class]) && 1 === \count($vars)) {
+            $properties = $vars[$class];
+            if (\is_array($properties) && $properties && !isset($properties["\0"])) {
+                $hasRefs = false;
+                if ($flags & \DEEPCLONE_HYDRATE_PRESERVE_REFS) {
+                    foreach ($properties as $k => $_) {
+                        if (\ReflectionReference::fromArrayElement($properties, $k)) { $hasRefs = true; break; }
+                    }
+                }
+                (self::$simpleHydrators[$class] ??= self::getSimpleHydrator($class))($properties, $object, $hasRefs);
+
+                return $object;
+            }
+        }
+
+        if ($flags & \DEEPCLONE_HYDRATE_MANGLED_VARS) {
+            $mangled_vars = $vars;
+            $scoped_vars = [];
+        } else {
+            $scoped_vars = $vars;
+            $mangled_vars = [];
         }
 
         if ($mangled_vars) {
@@ -468,15 +485,16 @@ final class DeepClone
                     $r->getConstructor()->invokeArgs($object, $special);
                 }
             }
-            foreach ($properties as $name => $v) {
-                if (!\is_string($name)) {
-                    throw new \ValueError(\sprintf('deepclone_hydrate(): Argument #2 ($vars) scope "%s" must have only string keys', $scope));
-                }
-                if (\str_contains($name, "\0")) {
-                    throw new \ValueError(\sprintf('deepclone_hydrate(): Argument #2 ($vars) scope "%s" contains an invalid property name; use bare property names in scoped mode, or pass DEEPCLONE_HYDRATE_MANGLED_VARS in $flags', $scope));
-                }
-            }
             if ($properties) {
+                // Under PRESERVE_REFS, probe once to preserve PHP & references only
+                // when the input carries any. Otherwise skip ref handling entirely.
+                $hasRefs = false;
+                if ($flags & \DEEPCLONE_HYDRATE_PRESERVE_REFS) {
+                    foreach ($properties as $k => $_) {
+                        if (\ReflectionReference::fromArrayElement($properties, $k)) { $hasRefs = true; break; }
+                    }
+                }
+
                 $effectiveFlags = $flags & \DEEPCLONE_HYDRATE_CALL_HOOKS;
                 if (\PHP_VERSION_ID >= 80400 && ($flags & \DEEPCLONE_HYDRATE_NO_LAZY_INIT)) {
                     $r ??= self::$reflectors[$class] ?? new \ReflectionClass($class);
@@ -485,11 +503,25 @@ final class DeepClone
                     }
                 }
                 $cacheKey = $effectiveFlags ? $effectiveFlags.$scope : $scope;
-                (self::$simpleHydrators[$cacheKey] ??= self::getSimpleHydrator($scope, $effectiveFlags))($properties, $object);
+                (self::$simpleHydrators[$cacheKey] ??= self::getSimpleHydrator($scope, $effectiveFlags))($properties, $object, $hasRefs);
             }
         }
 
         return $object;
+    }
+
+    /**
+     * @internal
+     *
+     * Cold path invoked from the generated hydrator closures to report a
+     * property name that is not a string or contains a NUL byte.
+     */
+    public static function throwInvalidPropName(mixed $name, string $scope): never
+    {
+        if (!\is_string($name)) {
+            throw new \ValueError(\sprintf('deepclone_hydrate(): Argument #2 ($vars) scope "%s" must have only string keys', $scope));
+        }
+        throw new \ValueError(\sprintf('deepclone_hydrate(): Argument #2 ($vars) scope "%s" contains an invalid property name; use bare property names in scoped mode, or pass DEEPCLONE_HYDRATE_MANGLED_VARS in $flags', $scope));
     }
 
     /**
@@ -1322,10 +1354,22 @@ final class DeepClone
     {
         $callHooks = (bool) ($flags & \DEEPCLONE_HYDRATE_CALL_HOOKS);
         $noLazyInit = \PHP_VERSION_ID >= 80400 && ($flags & \DEEPCLONE_HYDRATE_NO_LAZY_INIT);
-        $baseHydrator = self::$simpleHydrators['stdClass'] ??= static function ($properties, $object) {
-            foreach ($properties as $name => &$value) {
-                $object->$name = $value;
-                $object->$name = &$value;
+        $baseHydrator = self::$simpleHydrators['stdClass'] ??= static function ($properties, $object, $hasRefs) {
+            if ($hasRefs) {
+                foreach ($properties as $name => &$value) {
+                    if (!\is_string($name) || \str_contains($name, "\0")) {
+                        DeepClone::throwInvalidPropName($name, 'stdClass');
+                    }
+                    $object->$name = $value;
+                    $object->$name = &$value;
+                }
+            } else {
+                foreach ($properties as $name => $value) {
+                    if (!\is_string($name) || \str_contains($name, "\0")) {
+                        DeepClone::throwInvalidPropName($name, 'stdClass');
+                    }
+                    $object->$name = $value;
+                }
             }
         };
 
@@ -1379,7 +1423,7 @@ final class DeepClone
         }
 
         if (!$classReflector->isInternal()) {
-            $notByRef = new \stdClass();
+            $notByRef = [];
             $unsetOnNull = [];
             $backedEnum = [];
             foreach ($classReflector->getProperties() as $propertyReflector) {
@@ -1388,19 +1432,19 @@ final class DeepClone
                 }
                 if ($noLazyInit && !$propertyReflector->isVirtual()) {
                     // Virtual hooked props fall through — setRawValueWithoutLazyInitialization rejects them.
-                    $notByRef->{$propertyReflector->name} = $propertyReflector->setRawValueWithoutLazyInitialization(...);
+                    $notByRef[$propertyReflector->name] = $propertyReflector->setRawValueWithoutLazyInitialization(...);
                     continue;
                 }
                 if (\PHP_VERSION_ID >= 80400 && !$propertyReflector->isAbstract() && $propertyReflector->getHooks()) {
                     if ($propertyReflector->isVirtual()) {
-                        $notByRef->{$propertyReflector->name} = true;
+                        $notByRef[$propertyReflector->name] = true;
                     } else {
-                        $notByRef->{$propertyReflector->name} = $callHooks
+                        $notByRef[$propertyReflector->name] = $callHooks
                             ? $propertyReflector->setValue(...)
                             : $propertyReflector->setRawValue(...);
                     }
                 } elseif ($propertyReflector->isReadOnly()) {
-                    $notByRef->{$propertyReflector->name} = static function ($object, $value) use ($propertyReflector) {
+                    $notByRef[$propertyReflector->name] = static function ($object, $value) use ($propertyReflector) {
                         // Idempotent rehydrate: skip same-value writes that the engine would reject.
                         if ($propertyReflector->isInitialized($object)
                             && $propertyReflector->getValue($object) === $value)
@@ -1424,30 +1468,96 @@ final class DeepClone
                 }
             }
 
-            // Three variants so the lean path skips per-iteration checks that can't trip.
+            $scope = $class;
+
+            // Three variants × ref-preserving vs ref-less, so the common (no-refs) hot path skips
+            // the by-ref double-write and the per-iteration checks that can't trip.
             if (!$unsetOnNull && !$backedEnum) {
-                return (function ($properties, $object) {
-                    $notByRef = (array) $this;
-                    foreach ($properties as $name => &$value) {
-                        if (!$noRef = $notByRef[$name] ?? false) {
-                            $object->$name = $value;
-                            $object->$name = &$value;
-                        } elseif (true !== $noRef) {
-                            $noRef($object, $value);
-                        } else {
-                            $object->$name = $value;
+                return \Closure::bind(static function ($properties, $object, $hasRefs) use ($notByRef, $scope): void {
+                    if ($hasRefs) {
+                        foreach ($properties as $name => &$value) {
+                            if (!\is_string($name) || \str_contains($name, "\0")) {
+                                DeepClone::throwInvalidPropName($name, $scope);
+                            }
+                            if (!$noRef = $notByRef[$name] ?? false) {
+                                $object->$name = $value;
+                                $object->$name = &$value;
+                            } elseif (true !== $noRef) {
+                                $noRef($object, $value);
+                            } else {
+                                $object->$name = $value;
+                            }
+                        }
+                    } else {
+                        foreach ($properties as $name => $value) {
+                            if (!\is_string($name) || \str_contains($name, "\0")) {
+                                DeepClone::throwInvalidPropName($name, $scope);
+                            }
+                            if (!$noRef = $notByRef[$name] ?? false) {
+                                $object->$name = $value;
+                            } elseif (true !== $noRef) {
+                                $noRef($object, $value);
+                            } else {
+                                $object->$name = $value;
+                            }
                         }
                     }
-                })->bindTo($notByRef, $class);
+                }, null, $class);
             }
             if (!$backedEnum) {
-                return (function ($properties, $object) use ($unsetOnNull) {
-                    $notByRef = (array) $this;
+                return \Closure::bind(static function ($properties, $object, $hasRefs) use ($notByRef, $unsetOnNull, $scope): void {
+                    if ($hasRefs) {
+                        foreach ($properties as $name => &$value) {
+                            if (!\is_string($name) || \str_contains($name, "\0")) {
+                                DeepClone::throwInvalidPropName($name, $scope);
+                            }
+                            if (null === $value && isset($unsetOnNull[$name])) {
+                                unset($object->$name);
+                                continue;
+                            }
+                            if (!$noRef = $notByRef[$name] ?? false) {
+                                $object->$name = $value;
+                                $object->$name = &$value;
+                            } elseif (true !== $noRef) {
+                                $noRef($object, $value);
+                            } else {
+                                $object->$name = $value;
+                            }
+                        }
+                    } else {
+                        foreach ($properties as $name => $value) {
+                            if (!\is_string($name) || \str_contains($name, "\0")) {
+                                DeepClone::throwInvalidPropName($name, $scope);
+                            }
+                            if (null === $value && isset($unsetOnNull[$name])) {
+                                unset($object->$name);
+                                continue;
+                            }
+                            if (!$noRef = $notByRef[$name] ?? false) {
+                                $object->$name = $value;
+                            } elseif (true !== $noRef) {
+                                $noRef($object, $value);
+                            } else {
+                                $object->$name = $value;
+                            }
+                        }
+                    }
+                }, null, $class);
+            }
+
+            return \Closure::bind(static function ($properties, $object, $hasRefs) use ($notByRef, $unsetOnNull, $backedEnum, $scope): void {
+                if ($hasRefs) {
                     foreach ($properties as $name => &$value) {
+                        if (!\is_string($name) || \str_contains($name, "\0")) {
+                            DeepClone::throwInvalidPropName($name, $scope);
+                        }
                         if (null === $value && isset($unsetOnNull[$name])) {
                             unset($object->$name);
                             continue;
                         }
+                        if (isset($backedEnum[$name]) && (\is_int($value) || \is_string($value))) {
+                            $value = $backedEnum[$name]::from($value);
+                        }
                         if (!$noRef = $notByRef[$name] ?? false) {
                             $object->$name = $value;
                             $object->$name = &$value;
@@ -1457,30 +1567,28 @@ final class DeepClone
                             $object->$name = $value;
                         }
                     }
-                })->bindTo($notByRef, $class);
-            }
-
-            return (function ($properties, $object) use ($unsetOnNull, $backedEnum) {
-                $notByRef = (array) $this;
-
-                foreach ($properties as $name => &$value) {
-                    if (null === $value && isset($unsetOnNull[$name])) {
-                        unset($object->$name);
-                        continue;
-                    }
-                    if (isset($backedEnum[$name]) && (\is_int($value) || \is_string($value))) {
-                        $value = $backedEnum[$name]::from($value);
-                    }
-                    if (!$noRef = $notByRef[$name] ?? false) {
-                        $object->$name = $value;
-                        $object->$name = &$value;
-                    } elseif (true !== $noRef) {
-                        $noRef($object, $value);
-                    } else {
-                        $object->$name = $value;
+                } else {
+                    foreach ($properties as $name => $value) {
+                        if (!\is_string($name) || \str_contains($name, "\0")) {
+                            DeepClone::throwInvalidPropName($name, $scope);
+                        }
+                        if (null === $value && isset($unsetOnNull[$name])) {
+                            unset($object->$name);
+                            continue;
+                        }
+                        if (isset($backedEnum[$name]) && (\is_int($value) || \is_string($value))) {
+                            $value = $backedEnum[$name]::from($value);
+                        }
+                        if (!$noRef = $notByRef[$name] ?? false) {
+                            $object->$name = $value;
+                        } elseif (true !== $noRef) {
+                            $noRef($object, $value);
+                        } else {
+                            $object->$name = $value;
+                        }
                     }
                 }
-            })->bindTo($notByRef, $class);
+            }, null, $class);
         }
 
         if ($classReflector->name !== $class) {

--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -406,7 +406,10 @@ final class DeepClone
                 $hasRefs = false;
                 if ($flags & \DEEPCLONE_HYDRATE_PRESERVE_REFS) {
                     foreach ($properties as $k => $_) {
-                        if (\ReflectionReference::fromArrayElement($properties, $k)) { $hasRefs = true; break; }
+                        if (\ReflectionReference::fromArrayElement($properties, $k)) {
+                            $hasRefs = true;
+                            break;
+                        }
                     }
                 }
                 (self::$simpleHydrators[$class] ??= self::getSimpleHydrator($class))($properties, $object, $hasRefs);
@@ -444,7 +447,7 @@ final class DeepClone
                     $scopeName = substr($name, 1, $sep - 1);
                     $realName = substr($name, $sep + 1);
 
-                    if (\str_contains($realName, "\0")) {
+                    if (str_contains($realName, "\0")) {
                         throw new \ValueError('deepclone_hydrate(): Argument #2 ($vars) in MANGLED_VARS mode contains an invalid mangled key');
                     }
 
@@ -491,7 +494,10 @@ final class DeepClone
                 $hasRefs = false;
                 if ($flags & \DEEPCLONE_HYDRATE_PRESERVE_REFS) {
                     foreach ($properties as $k => $_) {
-                        if (\ReflectionReference::fromArrayElement($properties, $k)) { $hasRefs = true; break; }
+                        if (\ReflectionReference::fromArrayElement($properties, $k)) {
+                            $hasRefs = true;
+                            break;
+                        }
                     }
                 }
 
@@ -508,20 +514,6 @@ final class DeepClone
         }
 
         return $object;
-    }
-
-    /**
-     * @internal
-     *
-     * Cold path invoked from the generated hydrator closures to report a
-     * property name that is not a string or contains a NUL byte.
-     */
-    public static function throwInvalidPropName(mixed $name, string $scope): never
-    {
-        if (!\is_string($name)) {
-            throw new \ValueError(\sprintf('deepclone_hydrate(): Argument #2 ($vars) scope "%s" must have only string keys', $scope));
-        }
-        throw new \ValueError(\sprintf('deepclone_hydrate(): Argument #2 ($vars) scope "%s" contains an invalid property name; use bare property names in scoped mode, or pass DEEPCLONE_HYDRATE_MANGLED_VARS in $flags', $scope));
     }
 
     /**
@@ -1357,17 +1349,11 @@ final class DeepClone
         $baseHydrator = self::$simpleHydrators['stdClass'] ??= static function ($properties, $object, $hasRefs) {
             if ($hasRefs) {
                 foreach ($properties as $name => &$value) {
-                    if (!\is_string($name) || \str_contains($name, "\0")) {
-                        DeepClone::throwInvalidPropName($name, 'stdClass');
-                    }
                     $object->$name = $value;
                     $object->$name = &$value;
                 }
             } else {
                 foreach ($properties as $name => $value) {
-                    if (!\is_string($name) || \str_contains($name, "\0")) {
-                        DeepClone::throwInvalidPropName($name, 'stdClass');
-                    }
                     $object->$name = $value;
                 }
             }
@@ -1447,8 +1433,7 @@ final class DeepClone
                     $notByRef[$propertyReflector->name] = static function ($object, $value) use ($propertyReflector) {
                         // Idempotent rehydrate: skip same-value writes that the engine would reject.
                         if ($propertyReflector->isInitialized($object)
-                            && $propertyReflector->getValue($object) === $value)
-                        {
+                            && $propertyReflector->getValue($object) === $value) {
                             return;
                         }
                         $propertyReflector->setValue($object, $value);
@@ -1476,9 +1461,6 @@ final class DeepClone
                 return \Closure::bind(static function ($properties, $object, $hasRefs) use ($notByRef, $scope): void {
                     if ($hasRefs) {
                         foreach ($properties as $name => &$value) {
-                            if (!\is_string($name) || \str_contains($name, "\0")) {
-                                DeepClone::throwInvalidPropName($name, $scope);
-                            }
                             if (!$noRef = $notByRef[$name] ?? false) {
                                 $object->$name = $value;
                                 $object->$name = &$value;
@@ -1490,9 +1472,6 @@ final class DeepClone
                         }
                     } else {
                         foreach ($properties as $name => $value) {
-                            if (!\is_string($name) || \str_contains($name, "\0")) {
-                                DeepClone::throwInvalidPropName($name, $scope);
-                            }
                             if (!$noRef = $notByRef[$name] ?? false) {
                                 $object->$name = $value;
                             } elseif (true !== $noRef) {
@@ -1508,9 +1487,6 @@ final class DeepClone
                 return \Closure::bind(static function ($properties, $object, $hasRefs) use ($notByRef, $unsetOnNull, $scope): void {
                     if ($hasRefs) {
                         foreach ($properties as $name => &$value) {
-                            if (!\is_string($name) || \str_contains($name, "\0")) {
-                                DeepClone::throwInvalidPropName($name, $scope);
-                            }
                             if (null === $value && isset($unsetOnNull[$name])) {
                                 unset($object->$name);
                                 continue;
@@ -1526,9 +1502,6 @@ final class DeepClone
                         }
                     } else {
                         foreach ($properties as $name => $value) {
-                            if (!\is_string($name) || \str_contains($name, "\0")) {
-                                DeepClone::throwInvalidPropName($name, $scope);
-                            }
                             if (null === $value && isset($unsetOnNull[$name])) {
                                 unset($object->$name);
                                 continue;
@@ -1548,9 +1521,6 @@ final class DeepClone
             return \Closure::bind(static function ($properties, $object, $hasRefs) use ($notByRef, $unsetOnNull, $backedEnum, $scope): void {
                 if ($hasRefs) {
                     foreach ($properties as $name => &$value) {
-                        if (!\is_string($name) || \str_contains($name, "\0")) {
-                            DeepClone::throwInvalidPropName($name, $scope);
-                        }
                         if (null === $value && isset($unsetOnNull[$name])) {
                             unset($object->$name);
                             continue;
@@ -1569,9 +1539,6 @@ final class DeepClone
                     }
                 } else {
                     foreach ($properties as $name => $value) {
-                        if (!\is_string($name) || \str_contains($name, "\0")) {
-                            DeepClone::throwInvalidPropName($name, $scope);
-                        }
                         if (null === $value && isset($unsetOnNull[$name])) {
                             unset($object->$name);
                             continue;

--- a/src/DeepClone/bootstrap81.php
+++ b/src/DeepClone/bootstrap81.php
@@ -30,6 +30,9 @@ if (!defined('DEEPCLONE_HYDRATE_NO_LAZY_INIT')) {
 if (!defined('DEEPCLONE_HYDRATE_MANGLED_VARS')) {
     define('DEEPCLONE_HYDRATE_MANGLED_VARS', 1 << 2);
 }
+if (!defined('DEEPCLONE_HYDRATE_PRESERVE_REFS')) {
+    define('DEEPCLONE_HYDRATE_PRESERVE_REFS', 1 << 3);
+}
 if (!function_exists('deepclone_hydrate')) {
     function deepclone_hydrate(object|string $object_or_class, array $vars = [], int $flags = 0): object { return p\DeepClone::deepclone_hydrate($object_or_class, $vars, $flags); }
 }

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -1217,7 +1217,7 @@ class DeepCloneTest extends TestCase
         $properties = ['p1' => 1];
         $properties['p2'] = &$properties['p1'];
 
-        $obj = deepclone_hydrate('stdClass', $properties, \DEEPCLONE_HYDRATE_MANGLED_VARS);
+        $obj = deepclone_hydrate('stdClass', $properties, \DEEPCLONE_HYDRATE_MANGLED_VARS | \DEEPCLONE_HYDRATE_PRESERVE_REFS);
 
         $this->assertSame(1, $obj->p1);
         $this->assertSame(1, $obj->p2);
@@ -1227,14 +1227,39 @@ class DeepCloneTest extends TestCase
         $this->assertSame(2, $obj->p2);
     }
 
+    public function testHydratePhpReferencesNotPreservedByDefault()
+    {
+        $properties = ['p1' => 1];
+        $properties['p2'] = &$properties['p1'];
+
+        $obj = deepclone_hydrate('stdClass', $properties, \DEEPCLONE_HYDRATE_MANGLED_VARS);
+
+        $this->assertSame(1, $obj->p1);
+        $this->assertSame(1, $obj->p2);
+
+        $properties['p1'] = 2;
+        $this->assertSame(1, $obj->p1);
+        $this->assertSame(1, $obj->p2);
+    }
+
     public function testHydrateScopedReferences()
+    {
+        $v = 'hello';
+        $obj = deepclone_hydrate('stdClass', ['stdClass' => ['x' => &$v, 'y' => &$v]], \DEEPCLONE_HYDRATE_PRESERVE_REFS);
+
+        $v = 'world';
+        $this->assertSame('world', $obj->x);
+        $this->assertSame('world', $obj->y);
+    }
+
+    public function testHydrateScopedReferencesNotPreservedByDefault()
     {
         $v = 'hello';
         $obj = deepclone_hydrate('stdClass', ['stdClass' => ['x' => &$v, 'y' => &$v]]);
 
         $v = 'world';
-        $this->assertSame('world', $obj->x);
-        $this->assertSame('world', $obj->y);
+        $this->assertSame('hello', $obj->x);
+        $this->assertSame('hello', $obj->y);
     }
 
     public function testHydrateClassNotFound()

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -1400,11 +1400,12 @@ class DeepCloneTest extends TestCase
         $this->assertSame('direct', $clone->getPriv());
     }
 
-    public function testHydrateNulInScopedPropertyName()
+    public function testHydrateNulInMiddleOfPropertyNameMatchesUnserialize()
     {
-        $this->expectException(\ValueError::class);
-        $this->expectExceptionMessage('invalid property name');
-        deepclone_hydrate('stdClass', ['stdClass' => ["foo\0bar" => 'val']]);
+        // Matches unserialize(): NUL in the middle of a dynamic property name
+        // is silently accepted — the engine stores the raw name.
+        $o = deepclone_hydrate('stdClass', ['stdClass' => ["foo\0bar" => 'val']]);
+        $this->assertSame('val', ((array) $o)["foo\0bar"]);
     }
 
     public function testHydrateNulInMangledKeyProperty()
@@ -1414,18 +1415,12 @@ class DeepCloneTest extends TestCase
         deepclone_hydrate('stdClass', ["\0*\0foo\0bar" => 'val'], \DEEPCLONE_HYDRATE_MANGLED_VARS);
     }
 
-    public function testHydrateIntegerKeyInsideScope()
+    public function testHydrateIntegerKeyInsideScopeMatchesUnserialize()
     {
-        $this->expectException(\ValueError::class);
-        $this->expectExceptionMessage('string keys');
-        deepclone_hydrate('stdClass', ['stdClass' => [0 => 'val']]);
-    }
-
-    public function testHydrateMangledKeyInsideScope()
-    {
-        $this->expectException(\ValueError::class);
-        $this->expectExceptionMessage('DEEPCLONE_HYDRATE_MANGLED_VARS');
-        deepclone_hydrate('stdClass', ['stdClass' => ["\0stdClass\0x" => 'val']]);
+        // Matches unserialize(): integer keys coerce to string on dynamic
+        // property access; no pre-validation rejects them.
+        $o = deepclone_hydrate('stdClass', ['stdClass' => [0 => 'val']]);
+        $this->assertSame('val', $o->{'0'});
     }
 
     public function testHydrateInterfaceAsScope()


### PR DESCRIPTION
Mirrors [symfony/php-ext-deepclone#12](https://github.com/symfony/php-ext-deepclone/pull/12) on the polyfill side.

## 1. PRESERVE_REFS flag (BC break)

By default, `deepclone_hydrate()` now drops PHP `&` references from `$vars` on write; pass the new `DEEPCLONE_HYDRATE_PRESERVE_REFS` flag to keep ref links. Callers that intentionally share a value slot between properties need to add the flag.

`symfony/var-exporter`'s `Hydrator` / `Instantiator` pass the flag by default to preserve the pre-existing contract.

## 2. unserialize()-permissive property-name handling in scoped mode

In scoped mode, the pre-v0.4.0 hot-path validation rejected integer keys, NUL-in-middle names, and mangled-shape keys with a `ValueError`. That was stricter than what `unserialize()` does on the same shapes in an `O:…` payload. The polyfill now matches `unserialize()`:

- **Integer keys** — coerce to string on dynamic property access (PHP engine rule).
- **NUL-in-middle names** — stored as raw dynamic properties.
- **NUL-prefix names** — surface the engine's native `Error: Cannot access property starting with "\0"`.

`DEEPCLONE_HYDRATE_MANGLED_VARS` mode still parses and validates mangled keys (that's the entire point of the flag).

## Perf

The ref-preservation path used to run unconditionally and required a per-call probe (`ReflectionReference::fromArrayElement` over every key) plus a by-ref double-write of every property. The per-prop `str_contains(\$name, \"\\0\")` / `is_string(\$name)` checks were another ~18 ns per property on top. With both relaxed, the polyfill now **matches or beats raw Reflection** for flat-class hydration.

### Individual wins

- **Ref-probe gated on the flag** — default path skips it entirely, lean single-write inner loop.
- **Property-name validation matches `unserialize()`** — dropped the per-prop `is_string + str_contains NUL` check in favor of the engine's native semantics.
- **`use ($notByRef)` closure capture** replacing `(array) $this` — avoids the per-call stdClass→array cast.
- **1-scope inline fast path** in `deepclone_hydrate` — skips the outer `foreach ($scoped_vars as ...)` + cross-scope validation for the most common shape.
- **Three closure variants each split by `$hasRefs`** — lean no-refs loop sits next to the ref-preserving double-write loop, branch-predicted once per call.

### Results

PHP 8.4 / opcache, 100k iters, realistic DTO hydration:

| case                                   | before | after | vs Reflection |
|----------------------------------------|-------:|------:|--------------:|
| 6-prop mixed (pub + priv + prot)       |  1,483 |   812 |         1.36× |
| 8 typed props                          |  1,766 | 1,077 |         1.32× |
| stdClass, 5 props                      |  1,182 |   609 |             — |
| 3-level inheritance                    |  1,932 | 1,128 |         3.80× |
| readonly via ctor promotion            |  1,519 | 1,144 |         2.35× |

Scenarios 3 (3-level inheritance) and 4 (readonly) still lag Reflection — residual outer multi-scope iteration and per-readonly-prop `ReflectionProperty` invocation inside the hydrator. Flat-class hydration (scenarios 1, 2, 5) is at or below Reflection.

## Test plan

- [x] 374/374 DeepClone tests green locally
- [ ] CI green across the PHP matrix