### PR TITLE
[DeepClone] Shave per-prop overhead with a lean hydrator variant

### DIFF
--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -1455,9 +1455,25 @@ final class DeepClone
 
             $scope = $class;
 
-            // Three variants × ref-preserving vs ref-less, so the common (no-refs) hot path skips
-            // the by-ref double-write and the per-iteration checks that can't trip.
+            // Four variants. When the class has no hooked/readonly/unsetOnNull/backedEnum
+            // props, the hottest path skips the $notByRef table lookup entirely. Each
+            // hasRefs branch is hoisted out of the loop so it's branch-predicted once.
             if (!$unsetOnNull && !$backedEnum) {
+                if (!$notByRef) {
+                    return \Closure::bind(static function ($properties, $object, $hasRefs): void {
+                        if ($hasRefs) {
+                            foreach ($properties as $name => &$value) {
+                                $object->$name = $value;
+                                $object->$name = &$value;
+                            }
+                        } else {
+                            foreach ($properties as $name => $value) {
+                                $object->$name = $value;
+                            }
+                        }
+                    }, null, $class);
+                }
+
                 return \Closure::bind(static function ($properties, $object, $hasRefs) use ($notByRef, $scope): void {
                     if ($hasRefs) {
                         foreach ($properties as $name => &$value) {


### PR DESCRIPTION
Follow-up to #574 — a single targeted optimization on `deepclone_hydrate()`'s hot path, closing the gap to raw `ReflectionProperty::setValue` for flat-class hydration.

## Lean hydrator variant for classes with no special props

Previously, every hydrator closure branched through a `$notByRef[$name] ?? false` lookup on each property — needed only for hooked / readonly / non-nullable-typed / backed-enum props. For plain DTO-like classes where `$notByRef` ends up empty, the lookup was pure overhead: ~15 ns per property on every call.

`getSimpleHydrator()` now emits a slimmer closure for that case, skipping the table lookup and the 3-way `elseif` chain. The write loop is just:

```php
foreach ($properties as $name => $value) {
    $object->$name = $value;
}
```

…reclaiming ~210 ns on a 14-prop class, which is what kept the polyfill at parity-or-slower vs raw Reflection despite its cheaper inner write.

## Results

PHP 8.4 + opcache, 14-field DTO, 100-entity batch:

| class shape                    | before | after |  vs Reflection |
|--------------------------------|-------:|------:|---------------:|
| plain class (no special props) |  1,460 | 1,330 | 0.94× (**wins**) |
| User with 1 readonly prop      |  1,460 | 1,450 | 1.03× (par)    |
| 3-level inheritance            |  1,345 | 1,345 | 1.68× (lags)   |

## Known residuals (for later PRs)

- **Multi-scope hierarchies** still pay the outer `foreach ($scoped_vars as ...)` × per-scope closure dispatch. Flattening into a single per-class hydrator that knows about inherited scopes would help but requires bigger restructuring.
- **Classes with one readonly prop** fall through to the branchy path because the readonly handler sits in `$notByRef`. Moving readonly into a separate per-call `isInitialized()` check (and doing direct writes on fresh instances) could recover the lean-path win for them too.

## Test plan

- [x] 370/370 DeepClone tests green locally
- [ ] CI green (DeepClone-specific — existing `Intl\Icu` / `Intl\Idn` failures on 1.x are pre-existing, unrelated)