### PR TITLE
[DeepClone] Cap IS_LONG objectMeta count at 1M

### DIFF
--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -330,6 +330,14 @@ final class DeepClone
             if ($meta < 0) {
                 throw new \ValueError('deepclone_from_array(): Argument #1 ($data) "objectMeta" count must be non-negative, '.$meta.' given');
             }
+            // Sanity cap: the IS_LONG form specifies a count without the per-
+            // object payload, so a tiny input can demand huge allocations.
+            // Legitimate use never needs more than ~1M objects in a single
+            // payload — beyond that, use the array form which is naturally
+            // bounded by the hash-table size.
+            if ($meta > 0x100000) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) "objectMeta" count out of range: '.$meta);
+            }
             if ($meta > 0 && $numClasses < 1) {
                 throw new \ValueError('deepclone_from_array(): Argument #1 ($data) "objectMeta" references class index 0 but "classes" is empty');
             }

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -355,6 +355,16 @@ class DeepCloneTest extends TestCase
         deepclone_from_array(['classes' => 'stdClass', 'objectMeta' => -1, 'prepared' => 0]);
     }
 
+    public function testFromArrayRejectsOversizedObjectMetaCount()
+    {
+        // Matches the ext cap (1 << 20). Guards against a DoS where a tiny
+        // payload with a huge IS_LONG objectMeta count triggers a massive
+        // allocation.
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('deepclone_from_array(): Argument #1 ($data) "objectMeta" count out of range: 1048577');
+        deepclone_from_array(['classes' => 'stdClass', 'objectMeta' => 0x100001, 'prepared' => 0]);
+    }
+
     public function testFromArrayRejectsObjectMetaReferencingEmptyClasses()
     {
         $this->expectException(\ValueError::class);


### PR DESCRIPTION
Mirrors the ext fix from [v0.5.1](https://github.com/symfony/php-ext-deepclone/releases/tag/v0.5.1). A tiny payload with a huge integer \`objectMeta\` used to trigger an enormous \`array_fill()\` before any validation — a DoS vector for anyone feeding untrusted payloads through \`deepclone_from_array()\`. Caps the count at \`1 << 20\`, matching the ext.

## Repro

\`\`\`php
deepclone_from_array([
    'classes'    => 'stdClass',
    'objectMeta' => 0x40000000,  // 1G — would try to allocate 1G array slots
    'prepared'   => 0,
]);
\`\`\`

Pre-fix: OOM / 1GB+ allocation. Post-fix: \`ValueError: ... "objectMeta" count out of range: 1073741824\`.

Found by libFuzzer on the ext (C side); auditing the polyfill showed the same unbounded \`array_fill\` pattern.