### PR TITLE
[RFC] Add grapheme_strrev function php 8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Polyfills are provided for:
 - the `clamp` function introduced in PHP 8.6;
 - the `ARRAY_FILTER_USE_VALUE` constant introduced in PHP 8.6;
 - the `SortDirection` enum introduced in PHP 8.6;
+- the `grapheme_strrev` function introduced in PHP 8.6;
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no

--- a/src/Intl/Grapheme/Grapheme.php
+++ b/src/Intl/Grapheme/Grapheme.php
@@ -28,6 +28,7 @@ namespace Symfony\Polyfill\Intl\Grapheme;
  * - grapheme_substr   - Return part of a string
  * - grapheme_str_split - Splits a string into an array of individual or chunks of graphemes
  * - grapheme_levenshtein - Calculate the grapheme-unit Levenshtein distance between two strings
+ * - grapheme_strrev - Reverse a string by grapheme clusters
  *
  * @author Nicolas Grekas <p@tchwork.com>
  *
@@ -324,5 +325,16 @@ final class Grapheme
         }
 
         return false !== $needlePos ? self::grapheme_strlen(substr($s, 0, $needlePos)) + $offset : false;
+    }
+
+    public static function grapheme_strrev(string $string)
+    {
+        $units = grapheme_str_split($string);
+
+        if (false === $units) {
+            return false;
+        }
+
+        return implode('', array_reverse($units));
     }
 }

--- a/src/Intl/Grapheme/bootstrap.php
+++ b/src/Intl/Grapheme/bootstrap.php
@@ -58,3 +58,6 @@ if (!function_exists('grapheme_str_split')) {
 if (!function_exists('grapheme_levenshtein')) {
     function grapheme_levenshtein(string $string1, string $string2, int $insertion_cost = 1, int $replacement_cost = 1, int $deletion_cost = 1, string $locale = '') { return p\Php85::grapheme_levenshtein($string1, $string2, $insertion_cost, $replacement_cost, $deletion_cost); }
 }
+if (!function_exists('grapheme_strrev')) {
+    function grapheme_strrev(string $string) { return p\Grapheme::grapheme_strrev($string); }
+}

--- a/src/Intl/Grapheme/bootstrap80.php
+++ b/src/Intl/Grapheme/bootstrap80.php
@@ -17,6 +17,9 @@ if (!function_exists('grapheme_str_split')) {
 if (!function_exists('grapheme_levenshtein')) {
     function grapheme_levenshtein(string $string1, string $string2, int $insertion_cost = 1, int $replacement_cost = 1, int $deletion_cost = 1, string $locale = ''): int|false { return p\Grapheme::grapheme_levenshtein($string1, $string2, $insertion_cost, $replacement_cost, $deletion_cost); }
 }
+if (!function_exists('grapheme_strrev')) {
+    function grapheme_strrev(string $string): string|false { return p\Grapheme::grapheme_strrev($string); }
+}
 
 if (extension_loaded('intl')) {
     return;

--- a/src/Php86/Php86.php
+++ b/src/Php86/Php86.php
@@ -62,4 +62,13 @@ final class Php86
 
         throw new \ValueError($message);
     }
+
+    public static function grapheme_strrev(string $string)
+    {
+        if (false === $units = grapheme_str_split($string)) {
+            return false;
+        }
+
+        return implode('', array_reverse($units));
+    }
 }

--- a/src/Php86/bootstrap.php
+++ b/src/Php86/bootstrap.php
@@ -37,3 +37,7 @@ if (!function_exists('clamp')) {
      */
     function clamp($value, $min, $max) { return p\Php86::clamp($value, $min, $max); }
 }
+
+if (extension_loaded('intl') && !function_exists('grapheme_strrev')) {
+    function grapheme_strrev(string $string) { return p\Php86::grapheme_strrev($string); }
+}

--- a/tests/Intl/Grapheme/GraphemeTest.php
+++ b/tests/Intl/Grapheme/GraphemeTest.php
@@ -296,4 +296,38 @@ class GraphemeTest extends TestCase
         $this->expectException(\ValueError::class);
         grapheme_levenshtein('a', 'b', -1);
     }
+
+    /**
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_strrev
+     *
+     * @dataProvider provideGraphemeStrrev
+     */
+    public function testGraphemeStrrev(string $expected, string $string)
+    {
+        $this->assertSame($expected, grapheme_strrev($string));
+    }
+
+    public static function provideGraphemeStrrev(): array
+    {
+        return [
+            ['', ''],
+            ['A', 'A'],
+            ['EDCBA', 'ABCDE'],
+            ['elppA eplpA', 'Aplpe Apple'],
+            ['🍏elppA', 'Apple🍏'],
+            ['🇳🇨 - 🇨🇳', '🇨🇳 - 🇳🇨'],
+            ['日本語', '語本日'],
+            ['🎉👍🏽🎊', '🎊👍🏽🎉'],
+            ['C👍🏽A', 'A👍🏽C'],
+            ["B\0A", "A\0B"],
+        ];
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_strrev
+     */
+    public function testGraphemeStrrevInvalidUtf8()
+    {
+        $this->assertFalse(grapheme_strrev("\xFF"));
+    }
 }

--- a/tests/Php86/Php86Test.php
+++ b/tests/Php86/Php86Test.php
@@ -183,4 +183,33 @@ class Php86Test extends TestCase
         $this->assertInstanceOf(\UnitEnum::class, \SortDirection::Ascending);
         $this->assertInstanceOf(\UnitEnum::class, \SortDirection::Descending);
     }
+
+    /**
+     * @dataProvider provideGraphemeStrrev
+     */
+    public function testGraphemeStrrev(string $expected, string $string)
+    {
+        $this->assertSame($expected, grapheme_strrev($string));
+    }
+
+    public static function provideGraphemeStrrev(): array
+    {
+        return [
+            ['', ''],
+            ['A', 'A'],
+            ['EDCBA', 'ABCDE'],
+            ['elppA eplpA', 'Aplpe Apple'],
+            ['🍏elppA', 'Apple🍏'],
+            ['🇳🇨 - 🇨🇳', '🇨🇳 - 🇳🇨'],
+            ['日本語', '語本日'],
+            ['🎉👍🏽🎊', '🎊👍🏽🎉'],
+            ['C👍🏽A', 'A👍🏽C'],
+            ["B\0A", "A\0B"],
+        ];
+    }
+
+    public function testGraphemeStrrevInvalidUtf8()
+    {
+        $this->assertFalse(grapheme_strrev("\xFF"));
+    }
 }


### PR DESCRIPTION
Adds the new grapheme_strrev function added to PHP 8.6. This function is part of the Intl extension's Grapheme functions and reverses a string by grapheme clusters, correctly handling multi-byte and multi code-point characters (such as Emoji sequences).

 - [RFC](https://php.watch/rfcs/grapheme_strrev)
 - [Commit](https://github.com/php/php-src/commit/7a1c2612c01d9bd4d0c2d128fb5b2bf8f0a2e671)
 - [PHP 8.6: New grapheme_strrev function](https://php.watch/versions/8.6/grapheme_strrev)
 - [Codex](https://php.watch/codex/grapheme_strrev)