### PR TITLE
[Intl/MessageFormatter] Add missing parseMessage() method

### DIFF
--- a/src/Intl/MessageFormatter/MessageFormatter.php
+++ b/src/Intl/MessageFormatter/MessageFormatter.php
@@ -150,6 +150,11 @@ class MessageFormatter
         return false;
     }
 
+    public static function parseMessage(string $locale, string $pattern, string $message)
+    {
+        return false;
+    }
+
     private static function parseTokens(array $tokens, array $values, $locale)
     {
         foreach ($tokens as $i => $token) {

--- a/tests/Intl/MessageFormatter/MessageFormatterTest.php
+++ b/tests/Intl/MessageFormatter/MessageFormatterTest.php
@@ -295,4 +295,9 @@ _MSG_
             'nested select without other' => ['{n, plural, other {{x, select, brown {a}}}}'],
         ];
     }
+
+    public function testParseMessageWithInvalidPattern()
+    {
+        $this->assertFalse(MessageFormatter::parseMessage('en_US', '{invalid', 'message'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Add the static `MessageFormatter::parseMessage()` method to mirror the native intl API. The polyfill does not implement parsing, so the method returns `false`, matching the instance `parse()`.