### PR TITLE
Update `IntlDateFormatter::__construct()` parameters

### DIFF
--- a/src/Intl/Icu/IntlDateFormatter.php
+++ b/src/Intl/Icu/IntlDateFormatter.php
@@ -142,7 +142,7 @@ abstract class IntlDateFormatter
      * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed
      */
-    public function __construct(?string $locale, ?int $dateType, ?int $timeType, $timezone = null, $calendar = null, ?string $pattern = '')
+    public function __construct(?string $locale, ?int $dateType = IntlDateFormatter::FULL, ?int $timeType = IntlDateFormatter::FULL, $timezone = null, $calendar = null, ?string $pattern = '')
     {
         if ('en' !== $locale && null !== $locale) {
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'locale', $locale, 'Only the locale "en" is supported');
@@ -193,7 +193,7 @@ abstract class IntlDateFormatter
      * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed
      */
-    public static function create(?string $locale, ?int $dateType, ?int $timeType, $timezone = null, ?int $calendar = null, ?string $pattern = '')
+    public static function create(?string $locale, ?int $dateType = IntlDateFormatter::FULL, ?int $timeType = IntlDateFormatter::FULL, $timezone = null, ?int $calendar = null, ?string $pattern = '')
     {
         return new static($locale, $dateType, $timeType, $timezone, $calendar, $pattern);
     }


### PR DESCRIPTION
Since PHP 8.1, parameters `dateType` and `timeType` are optional.

See: https://www.php.net/manual/en/intldateformatter.create.php#refsect1-intldateformatter.create-changelog

Same as https://github.com/symfony/polyfill-intl-icu/pull/2