### PR TITLE
PHP can be built without PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT

### DIFF
--- a/src/Php84/Resources/stubs/Pdo/Mysql.php
+++ b/src/Php84/Resources/stubs/Pdo/Mysql.php
@@ -15,7 +15,7 @@ use PDO;
 
 if (\PHP_VERSION_ID < 80400 && \extension_loaded('pdo_mysql')) {
     // Feature detection for non-mysqlnd; see also https://www.php.net/manual/en/class.pdo-mysql.php#pdo-mysql.constants.attr-max-buffer-size
-    if (\defined('PDO::MYSQL_ATTR_MAX_BUFFER_SIZE') && \defined('PDO::MYSQL_ATTR_READ_DEFAULT_FILE') && \defined('PDO::MYSQL_ATTR_READ_DEFAULT_GROUP')) {
+    if (\defined('PDO::MYSQL_ATTR_MAX_BUFFER_SIZE') && \defined('PDO::MYSQL_ATTR_READ_DEFAULT_FILE') && \defined('PDO::MYSQL_ATTR_READ_DEFAULT_GROUP') && \defined('PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT')) {
         class Mysql extends \PDO
         {
             public const ATTR_COMPRESS = \PDO::MYSQL_ATTR_COMPRESS;
@@ -76,7 +76,6 @@ if (\PHP_VERSION_ID < 80400 && \extension_loaded('pdo_mysql')) {
             public const ATTR_SSL_CERT = \PDO::MYSQL_ATTR_SSL_CERT;
             public const ATTR_SSL_CIPHER = \PDO::MYSQL_ATTR_SSL_CIPHER;
             public const ATTR_SSL_KEY = \PDO::MYSQL_ATTR_SSL_KEY;
-            public const ATTR_SSL_VERIFY_SERVER_CERT = \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
             public const ATTR_USE_BUFFERED_QUERY = \PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
 
             public function __construct(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null)

--- a/tests/Php84/PdoTest.php
+++ b/tests/Php84/PdoTest.php
@@ -195,12 +195,12 @@ class PdoTest extends TestCase
         $this->assertSame(\PHP_VERSION_ID < 80500 ? 1011 : 1010, \Pdo\Mysql::ATTR_SSL_CIPHER);
         $this->assertSame(\PHP_VERSION_ID < 80500 ? 1012 : 1011, \Pdo\Mysql::ATTR_SERVER_PUBLIC_KEY);
         $this->assertSame(\PHP_VERSION_ID < 80500 ? 1013 : 1012, \Pdo\Mysql::ATTR_MULTI_STATEMENTS);
-        $this->assertSame(\PHP_VERSION_ID < 80500 ? 1014 : 1013, \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT);
         $this->assertSame(\PHP_VERSION_ID < 80500 ? 1015 : 1014, \Pdo\Mysql::ATTR_LOCAL_INFILE_DIRECTORY);
-        if (\defined('PDO::MYSQL_ATTR_MAX_BUFFER_SIZE') && \defined('PDO::MYSQL_ATTR_READ_DEFAULT_FILE') && \defined('PDO::MYSQL_ATTR_READ_DEFAULT_GROUP')) {
+        if (\defined('PDO::MYSQL_ATTR_MAX_BUFFER_SIZE') && \defined('PDO::MYSQL_ATTR_READ_DEFAULT_FILE') && \defined('PDO::MYSQL_ATTR_READ_DEFAULT_GROUP') && \defined('PDO::ATTR_SSL_VERIFY_SERVER_CERT')) {
             $this->assertSame(1003, \Pdo\Mysql::ATTR_READ_DEFAULT_FILE);
             $this->assertSame(1004, \Pdo\Mysql::ATTR_READ_DEFAULT_GROUP);
             $this->assertSame(1005, \Pdo\Mysql::ATTR_MAX_BUFFER_SIZE);
+            $this->assertSame(\PHP_VERSION_ID < 80500 ? 1014 : 1013, \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT);
         }
     }
 


### PR DESCRIPTION
It's possible to build PHP without `PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT` which results in errors on Drupal when using Drush - 
```
vendor/bin/drush status
Error: Undefined constant PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT in [constant expression]() (line 38 of vendor/symfony/polyfill-php84/Resources/stubs/Pdo/Mysql.php).
```

This occurs on cheap hosting.