### PR TITLE
[Php83] Fix ldap_exop_sync polyfill on PHP < 8.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     coverage: "none"
-                    extensions: "apcu, intl-73.2, mbstring, odbc, uuid, mongodb"
+                    extensions: "apcu, intl-73.2, ldap, mbstring, odbc, uuid, mongodb"
                     ini-values: "memory_limit=-1, session.gc_probability=0, apc.enable_cli=1"
                     php-version: "${{ matrix.php }}"
                     tools: "composer:v2"

--- a/src/Php83/bootstrap.php
+++ b/src/Php83/bootstrap.php
@@ -43,7 +43,7 @@ if (extension_loaded('mbstring')) {
 }
 
 if (!function_exists('ldap_exop_sync') && function_exists('ldap_exop')) {
-    function ldap_exop_sync($ldap, string $request_oid, ?string $request_data = null, ?array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $response_oid); }
+    function ldap_exop_sync($ldap, string $request_oid, ?string $request_data = null, ?array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $response_data, $response_oid); }
 }
 
 if (!function_exists('ldap_connect_wallet') && function_exists('ldap_connect')) {

--- a/src/Php83/bootstrap80.php
+++ b/src/Php83/bootstrap80.php
@@ -22,7 +22,7 @@ if (\PHP_VERSION_ID >= 80100) {
 }
 
 if (!function_exists('ldap_exop_sync') && function_exists('ldap_exop')) {
-    function ldap_exop_sync($ldap, string $request_oid, ?string $request_data = null, ?array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $response_oid); }
+    function ldap_exop_sync($ldap, string $request_oid, ?string $request_data = null, ?array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $response_data, $response_oid); }
 }
 
 if (!function_exists('ldap_connect_wallet') && function_exists('ldap_connect')) {

--- a/src/Php83/bootstrap81.php
+++ b/src/Php83/bootstrap81.php
@@ -14,7 +14,7 @@ if (\PHP_VERSION_ID >= 80300) {
 }
 
 if (!function_exists('ldap_exop_sync') && function_exists('ldap_exop')) {
-    function ldap_exop_sync(\LDAP\Connection $ldap, string $request_oid, ?string $request_data = null, ?array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $response_oid); }
+    function ldap_exop_sync(\LDAP\Connection $ldap, string $request_oid, ?string $request_data = null, ?array $controls = null, &$response_data = null, &$response_oid = null): bool { return ldap_exop($ldap, $request_oid, $request_data, $response_data, $response_oid); }
 }
 
 if (!function_exists('ldap_connect_wallet') && function_exists('ldap_connect')) {

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -216,6 +216,36 @@ class Php83Test extends TestCase
         $this->assertSame(['http' => ['method' => 'POST']], stream_context_get_options($context));
     }
 
+    public function testLdapExopSync()
+    {
+        if (\PHP_VERSION_ID >= 80300) {
+            $this->markTestSkipped('PHP >= 8.3 provides ldap_exop_sync() natively.');
+        }
+        if (!extension_loaded('ldap')) {
+            $this->markTestSkipped('The ldap extension is required.');
+        }
+
+        $errors = [];
+        set_error_handler(static function ($errno, $errstr) use (&$errors) {
+            $errors[] = $errstr;
+
+            return true;
+        });
+
+        try {
+            $ldap = ldap_connect('ldap://example.invalid');
+            ldap_exop_sync($ldap, '1.3.6.1.4.1.4203.1.11.1', null, [['oid' => '1.2.3', 'value' => 'x']]);
+        } catch (\Throwable $e) {
+            $errors[] = $e->getMessage();
+        } finally {
+            restore_error_handler();
+        }
+
+        $joined = implode("\n", $errors);
+        $this->assertStringNotContainsString('expects at most', $joined);
+        $this->assertStringNotContainsString('expects exactly', $joined);
+    }
+
     public function testDateTimeExceptionClassesExist()
     {
         $this->assertTrue(class_exists(\DateError::class));


### PR DESCRIPTION
Fixes the `ldap_exop_sync` polyfill registration on PHP < 8.3. CI now exercises it.