### PR TITLE
[Php83] Fix str_increment() for numeric strings beyond PHP_INT_MAX

### DIFF
--- a/src/Php83/Php83.php
+++ b/src/Php83/Php83.php
@@ -103,34 +103,33 @@ final class Php83
             throw new \ValueError('str_increment(): Argument #1 ($string) must be composed only of alphanumeric ASCII characters');
         }
 
-        if (is_numeric($string)) {
-            $offset = stripos($string, 'e');
-            if (false !== $offset) {
-                $char = $string[$offset];
-                ++$char;
-                $string[$offset] = $char;
-                ++$string;
+        for ($i = \strlen($string) - 1; $i >= 0; --$i) {
+            $char = $string[$i];
 
-                switch ($string[$offset]) {
-                    case 'f':
-                        $string[$offset] = 'e';
-                        break;
-                    case 'F':
-                        $string[$offset] = 'E';
-                        break;
-                    case 'g':
-                        $string[$offset] = 'f';
-                        break;
-                    case 'G':
-                        $string[$offset] = 'F';
-                        break;
-                }
-
-                return $string;
+            if ('z' === $char) {
+                $string[$i] = 'a';
+                continue;
             }
+            if ('Z' === $char) {
+                $string[$i] = 'A';
+                continue;
+            }
+            if ('9' === $char) {
+                $string[$i] = '0';
+                continue;
+            }
+
+            $string[$i] = \chr(\ord($char) + 1);
+
+            return $string;
         }
 
-        return ++$string;
+        switch ($string[0]) {
+            case 'a': return 'a'.$string;
+            case 'A': return 'A'.$string;
+        }
+
+        return '1'.$string;
     }
 
     public static function str_decrement(string $string): string

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -266,6 +266,13 @@ class Php83Test extends TestCase
         yield ['e', 'd'];
         yield ['E', 'D'];
         yield ['5', '4'];
+        yield ['10', '9'];
+        yield ['100', '99'];
+        yield ['1000', '999'];
+        yield ['9223372036854775808', '9223372036854775807'];
+        yield ['9223372036854775821', '9223372036854775820'];
+        yield ['10000000000000000000', '9999999999999999999'];
+        yield ['013', '012'];
     }
 
     public static function strDecrementProvider(): iterable


### PR DESCRIPTION
Fixes `str_increment()` for numeric strings whose value exceeds `PHP_INT_MAX`.