### PR TITLE
[Mbstring] Fix mb_strlen() for invalid UTF-8 input

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -519,7 +519,15 @@ final class Mbstring
             return \strlen($s);
         }
 
-        return @iconv_strlen($s, $encoding);
+        if (false !== $len = @iconv_strlen($s, $encoding)) {
+            return $len;
+        }
+
+        if ('UTF-8' !== $encoding) {
+            return $len;
+        }
+
+        return preg_match_all('/[\x00-\x7F]|[\xC0-\xDF][\x80-\xBF]?|[\xE0-\xEF][\x80-\xBF]{0,2}|[\xF0-\xF7][\x80-\xBF]{0,3}|[\xF8-\xFB][\x80-\xBF]{0,4}|[\xFC-\xFD][\x80-\xBF]{0,5}|[\x80-\xBF\xFE\xFF]/s', $s);
     }
 
     public static function mb_strpos($haystack, $needle, $offset = 0, $encoding = null)

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -327,6 +327,15 @@ class MbstringTest extends TestCase
         $this->assertSame(2, mb_strlen("\x00\xFF", 'CP850'));
         $this->assertSame(3, mb_strlen('한국어'));
         $this->assertSame(8, mb_strlen(\Normalizer::normalize('한국어', \Normalizer::NFD)));
+
+        $this->assertSame(1, p::mb_strlen("\xFE"));
+        $this->assertSame(2, p::mb_strlen("\xFE\xFF"));
+        $this->assertSame(4, p::mb_strlen("abc\xFE"));
+        $this->assertSame(1, p::mb_strlen("\xC2"));
+        $this->assertSame(2, p::mb_strlen("\xC2\xC2"));
+        $this->assertSame(1, p::mb_strlen("\x80"));
+        $this->assertSame(3, p::mb_strlen("a\x80b"));
+        $this->assertSame(1, p::mb_strlen("\xE2\x82"));
     }
 
     /**


### PR DESCRIPTION
`mb_strlen()` was returning false on invalid UTF-8; match native behavior.