### PR TITLE
[Uuid] Mark UUID_TYPE_DCE and UUID_TYPE_NAME as deprecated on PHP 8.5+

### DIFF
--- a/src/Util/TestListenerTrait.php
+++ b/src/Util/TestListenerTrait.php
@@ -49,7 +49,9 @@ class TestListenerTrait
             }
             $testedClass = new \ReflectionClass($m[1].$m[2]);
             $bootstrap = \dirname($testedClass->getFileName()).'/bootstrap';
-            if (\PHP_VERSION_ID >= 80200 && file_exists($bootstrap.'82.php')) {
+            if (\PHP_VERSION_ID >= 80500 && file_exists($bootstrap.'85.php')) {
+                $bootstrap .= '85';
+            } elseif (\PHP_VERSION_ID >= 80200 && file_exists($bootstrap.'82.php')) {
                 $bootstrap .= '82';
             } elseif (\PHP_VERSION_ID >= 80100 && file_exists($bootstrap.'81.php')) {
                 $bootstrap .= '81';

--- a/src/Uuid/bootstrap80.php
+++ b/src/Uuid/bootstrap80.php
@@ -11,6 +11,10 @@
 
 use Symfony\Polyfill\Uuid as p;
 
+if (\PHP_VERSION_ID >= 80500) {
+    require __DIR__.'/bootstrap85.php';
+}
+
 if (!defined('UUID_VARIANT_NCS')) {
     define('UUID_VARIANT_NCS', 0);
 }

--- a/src/Uuid/bootstrap85.php
+++ b/src/Uuid/bootstrap85.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#[Deprecated(message: 'use UUID_TYPE_RANDOM instead')]
+const UUID_TYPE_DCE = 4;
+
+#[Deprecated(message: 'use UUID_TYPE_TIME instead')]
+const UUID_TYPE_NAME = 1;

--- a/tests/Uuid/UuidTest.php
+++ b/tests/Uuid/UuidTest.php
@@ -368,4 +368,42 @@ class UuidTest extends TestCase
 
         $this->assertFalse(@uuid_unparse($uuid));
     }
+
+    public function testDeprecatedTypeDce()
+    {
+        $this->assertSame(4, $this->captureDeprecation(static function() { return \UUID_TYPE_DCE; }, 'UUID_TYPE_DCE'));
+    }
+
+    public function testDeprecatedTypeName()
+    {
+        $this->assertSame(1, $this->captureDeprecation(static function() { return \UUID_TYPE_NAME; }, 'UUID_TYPE_NAME'));
+    }
+
+    private function captureDeprecation(\Closure $access, string $name)
+    {
+        if (\PHP_VERSION_ID < 80500) {
+            $this->markTestSkipped('The Deprecated attribute applies to global constants since PHP 8.5.');
+        }
+        if (extension_loaded('uuid')) {
+            $this->markTestSkipped('ext-uuid is loaded, the polyfill is not in use.');
+        }
+
+        $deprecation = null;
+        set_error_handler(static function ($type, $message) use (&$deprecation) {
+            $deprecation = $message;
+
+            return true;
+        }, \E_USER_DEPRECATED | \E_DEPRECATED);
+
+        try {
+            $value = $access();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNotNull($deprecation, sprintf('Using %s should trigger a deprecation.', $name));
+        $this->assertStringContainsString($name, $deprecation);
+
+        return $value;
+    }
 }


### PR DESCRIPTION
Aligns the polyfill with native PHP 8.5+ where these constants are deprecated.

Closes https://github.com/symfony/polyfill/issues/567