### PR TITLE
[Php83] Fix mb_str_pad invalid encoding error reporting

### DIFF
--- a/src/Php83/Php83.php
+++ b/src/Php83/Php83.php
@@ -60,7 +60,7 @@ final class Php83
             $errorToTrigger = \sprintf('mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "%s" given', $encoding);
         }
 
-        if (mb_strlen($pad_string, $encoding) <= 0) {
+        if (null === $errorToTrigger && mb_strlen($pad_string, $encoding) <= 0) {
             $errorToTrigger = 'mb_str_pad(): Argument #3 ($pad_string) must be a non-empty string';
         }
 


### PR DESCRIPTION
When an invalid encoding is given, the `mb_strlen()` call on the pad string would throw an `mb_strlen`-prefixed error before the encoding check could trigger the expected `mb_str_pad`-prefixed error.