### PR TITLE
[Php84] Declare $persistent property in ReflectionConstant stub

### DIFF
--- a/src/Php84/Resources/stubs/ReflectionConstant.php
+++ b/src/Php84/Resources/stubs/ReflectionConstant.php
@@ -22,6 +22,7 @@ if (\PHP_VERSION_ID < 80400) {
 
         private $value;
         private $deprecated;
+        private $persistent;
 
         private static $persistentConstants = [];
 


### PR DESCRIPTION
Avoids the dynamic-property deprecation triggered by the testUnserialization test on PHP 8.2+.