### PR TITLE
Match polyfill signatures to native PHP 8.x to silence TestListener warnings

### DIFF
--- a/src/Apcu/bootstrap80.php
+++ b/src/Apcu/bootstrap80.php
@@ -22,7 +22,7 @@ if (extension_loaded('Zend Data Cache')) {
         function apcu_exists($key): array|bool { return p\Apcu::apcu_exists($key); }
     }
     if (!function_exists('apcu_fetch')) {
-        function apcu_fetch($key, &$success = null) { return p\Apcu::apcu_fetch($key, $success); }
+        function apcu_fetch($key, &$success = null): mixed { return p\Apcu::apcu_fetch($key, $success); }
     }
     if (!function_exists('apcu_store')) {
         function apcu_store($key, mixed $value, ?int $ttl = 0): array|bool { return p\Apcu::apcu_store($key, $value, (int) $ttl); }

--- a/src/Intl/Grapheme/bootstrap80.php
+++ b/src/Intl/Grapheme/bootstrap80.php
@@ -38,6 +38,10 @@ if (!defined('GRAPHEME_EXTR_MAXCHARS')) {
 if (!function_exists('grapheme_extract')) {
     function grapheme_extract(?string $haystack, ?int $size, ?int $type = GRAPHEME_EXTR_COUNT, ?int $offset = 0, &$next = null): string|false { return p\Grapheme::grapheme_extract((string) $haystack, (int) $size, (int) $type, (int) $offset, $next); }
 }
+if (\PHP_VERSION_ID >= 80500) {
+    return require __DIR__.'/bootstrap85.php';
+}
+
 if (!function_exists('grapheme_stripos')) {
     function grapheme_stripos(?string $haystack, ?string $needle, ?int $offset = 0): int|false { return p\Grapheme::grapheme_stripos((string) $haystack, (string) $needle, (int) $offset); }
 }

--- a/src/Intl/Grapheme/bootstrap85.php
+++ b/src/Intl/Grapheme/bootstrap85.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// The $locale argument added to grapheme_*() in PHP 8.5 / ICU 74 is accepted
+// for native-signature compatibility but ignored by the polyfill, which only
+// performs UTF-8 case folding.
+
+use Symfony\Polyfill\Intl\Grapheme as p;
+
+if (!function_exists('grapheme_stripos')) {
+    function grapheme_stripos(?string $haystack, ?string $needle, ?int $offset = 0, ?string $locale = ''): int|false { return p\Grapheme::grapheme_stripos((string) $haystack, (string) $needle, (int) $offset); }
+}
+if (!function_exists('grapheme_stristr')) {
+    function grapheme_stristr(?string $haystack, ?string $needle, ?bool $beforeNeedle = false, ?string $locale = ''): string|false { return p\Grapheme::grapheme_stristr((string) $haystack, (string) $needle, (bool) $beforeNeedle); }
+}
+if (!function_exists('grapheme_strlen')) {
+    function grapheme_strlen(?string $string): int|false|null { return p\Grapheme::grapheme_strlen((string) $string); }
+}
+if (!function_exists('grapheme_strpos')) {
+    function grapheme_strpos(?string $haystack, ?string $needle, ?int $offset = 0, ?string $locale = ''): int|false { return p\Grapheme::grapheme_strpos((string) $haystack, (string) $needle, (int) $offset); }
+}
+if (!function_exists('grapheme_strripos')) {
+    function grapheme_strripos(?string $haystack, ?string $needle, ?int $offset = 0, ?string $locale = ''): int|false { return p\Grapheme::grapheme_strripos((string) $haystack, (string) $needle, (int) $offset); }
+}
+if (!function_exists('grapheme_strrpos')) {
+    function grapheme_strrpos(?string $haystack, ?string $needle, ?int $offset = 0, ?string $locale = ''): int|false { return p\Grapheme::grapheme_strrpos((string) $haystack, (string) $needle, (int) $offset); }
+}
+if (!function_exists('grapheme_strstr')) {
+    function grapheme_strstr(?string $haystack, ?string $needle, ?bool $beforeNeedle = false, ?string $locale = ''): string|false { return p\Grapheme::grapheme_strstr((string) $haystack, (string) $needle, (bool) $beforeNeedle); }
+}
+if (!function_exists('grapheme_substr')) {
+    function grapheme_substr(?string $string, ?int $offset, ?int $length = null, ?string $locale = ''): string|false { return p\Grapheme::grapheme_substr((string) $string, (int) $offset, $length); }
+}

--- a/src/Php83/bootstrap81.php
+++ b/src/Php83/bootstrap81.php
@@ -9,8 +9,26 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\Polyfill\Php83 as p;
+
 if (\PHP_VERSION_ID >= 80300) {
     return;
+}
+
+if (!function_exists('json_validate')) {
+    function json_validate(string $json, int $depth = 512, int $flags = 0): bool { return p\Php83::json_validate($json, $depth, $flags); }
+}
+
+if (!function_exists('str_increment')) {
+    function str_increment(string $string): string { return p\Php83::str_increment($string); }
+}
+
+if (!function_exists('str_decrement')) {
+    function str_decrement(string $string): string { return p\Php83::str_decrement($string); }
+}
+
+if (extension_loaded('mbstring') && !function_exists('mb_str_pad')) {
+    function mb_str_pad(?string $string, ?int $length, ?string $pad_string = ' ', ?int $pad_type = STR_PAD_RIGHT, ?string $encoding = null): string { return p\Php83::mb_str_pad((string) $string, (int) $length, (string) $pad_string, (int) $pad_type, $encoding); }
 }
 
 if (!function_exists('ldap_exop_sync') && function_exists('ldap_exop')) {


### PR DESCRIPTION
- `apcu_fetch`: add `mixed` return type matching native PHP 8.0+.
- Grapheme functions: route PHP 8.5+ through a new `bootstrap85.php` exposing the `$locale` parameter added in newer ICU.
- Php83 `bootstrap81.php`: re-declare `json_validate`, `str_increment`, `str_decrement` and `mb_str_pad` so the TestListener can find polyfills to verify on PHP 8.1+.