### PR TITLE
[Mbstring][Php83][Php84] Accept null in mb_* polyfills

### DIFF
--- a/src/Mbstring/bootstrap.php
+++ b/src/Mbstring/bootstrap.php
@@ -134,32 +134,32 @@ if (!function_exists('mb_str_split')) {
 
 if (!function_exists('mb_str_pad')) {
     /** @return string|false */
-    function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = STR_PAD_RIGHT, ?string $encoding = null) { return p\Mbstring::mb_str_pad($string, $length, $pad_string, $pad_type, $encoding); }
+    function mb_str_pad(?string $string, ?int $length, ?string $pad_string = ' ', ?int $pad_type = STR_PAD_RIGHT, ?string $encoding = null) { return p\Mbstring::mb_str_pad((string) $string, (int) $length, (string) $pad_string, (int) $pad_type, $encoding); }
 }
 
 if (!function_exists('mb_ucfirst')) {
     /** @return string|false */
-    function mb_ucfirst(string $string, ?string $encoding = null) { return p\Mbstring::mb_ucfirst($string, $encoding); }
+    function mb_ucfirst(?string $string, ?string $encoding = null) { return p\Mbstring::mb_ucfirst((string) $string, $encoding); }
 }
 
 if (!function_exists('mb_lcfirst')) {
     /** @return string|false */
-    function mb_lcfirst(string $string, ?string $encoding = null) { return p\Mbstring::mb_lcfirst($string, $encoding); }
+    function mb_lcfirst(?string $string, ?string $encoding = null) { return p\Mbstring::mb_lcfirst((string) $string, $encoding); }
 }
 
 if (!function_exists('mb_trim')) {
     /** @return string|false */
-    function mb_trim(string $string, ?string $characters = null, ?string $encoding = null) { return p\Mbstring::mb_trim($string, $characters, $encoding); }
+    function mb_trim(?string $string, ?string $characters = null, ?string $encoding = null) { return p\Mbstring::mb_trim((string) $string, $characters, $encoding); }
 }
 
 if (!function_exists('mb_ltrim')) {
     /** @return string|false */
-    function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null) { return p\Mbstring::mb_ltrim($string, $characters, $encoding); }
+    function mb_ltrim(?string $string, ?string $characters = null, ?string $encoding = null) { return p\Mbstring::mb_ltrim((string) $string, $characters, $encoding); }
 }
 
 if (!function_exists('mb_rtrim')) {
     /** @return string|false */
-    function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null) { return p\Mbstring::mb_rtrim($string, $characters, $encoding); }
+    function mb_rtrim(?string $string, ?string $characters = null, ?string $encoding = null) { return p\Mbstring::mb_rtrim((string) $string, $characters, $encoding); }
 }
 
 if (extension_loaded('mbstring')) {

--- a/src/Mbstring/bootstrap80.php
+++ b/src/Mbstring/bootstrap80.php
@@ -129,27 +129,27 @@ if (!function_exists('mb_str_split')) {
 }
 
 if (!function_exists('mb_str_pad')) {
-    function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = STR_PAD_RIGHT, ?string $encoding = null): string { return p\Mbstring::mb_str_pad($string, $length, $pad_string, $pad_type, $encoding); }
+    function mb_str_pad(?string $string, ?int $length, ?string $pad_string = ' ', ?int $pad_type = STR_PAD_RIGHT, ?string $encoding = null): string { return p\Mbstring::mb_str_pad((string) $string, (int) $length, (string) $pad_string, (int) $pad_type, $encoding); }
 }
 
 if (!function_exists('mb_ucfirst')) {
-    function mb_ucfirst(string $string, ?string $encoding = null): string { return p\Mbstring::mb_ucfirst($string, $encoding); }
+    function mb_ucfirst(?string $string, ?string $encoding = null): string { return p\Mbstring::mb_ucfirst((string) $string, $encoding); }
 }
 
 if (!function_exists('mb_lcfirst')) {
-    function mb_lcfirst(string $string, ?string $encoding = null): string { return p\Mbstring::mb_lcfirst($string, $encoding); }
+    function mb_lcfirst(?string $string, ?string $encoding = null): string { return p\Mbstring::mb_lcfirst((string) $string, $encoding); }
 }
 
 if (!function_exists('mb_trim')) {
-    function mb_trim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Mbstring::mb_trim($string, $characters, $encoding); }
+    function mb_trim(?string $string, ?string $characters = null, ?string $encoding = null): string { return p\Mbstring::mb_trim((string) $string, $characters, $encoding); }
 }
 
 if (!function_exists('mb_ltrim')) {
-    function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Mbstring::mb_ltrim($string, $characters, $encoding); }
+    function mb_ltrim(?string $string, ?string $characters = null, ?string $encoding = null): string { return p\Mbstring::mb_ltrim((string) $string, $characters, $encoding); }
 }
 
 if (!function_exists('mb_rtrim')) {
-    function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Mbstring::mb_rtrim($string, $characters, $encoding); }
+    function mb_rtrim(?string $string, ?string $characters = null, ?string $encoding = null): string { return p\Mbstring::mb_rtrim((string) $string, $characters, $encoding); }
 }
 
 if (extension_loaded('mbstring')) {

--- a/src/Php83/bootstrap.php
+++ b/src/Php83/bootstrap.php
@@ -38,7 +38,7 @@ if (\PHP_VERSION_ID >= 80000) {
 if (extension_loaded('mbstring')) {
     if (!function_exists('mb_str_pad')) {
         /** @return string|false */
-        function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = STR_PAD_RIGHT, ?string $encoding = null) { return p\Php83::mb_str_pad($string, $length, $pad_string, $pad_type, $encoding); }
+        function mb_str_pad(?string $string, ?int $length, ?string $pad_string = ' ', ?int $pad_type = STR_PAD_RIGHT, ?string $encoding = null) { return p\Php83::mb_str_pad((string) $string, (int) $length, (string) $pad_string, (int) $pad_type, $encoding); }
     }
 }
 

--- a/src/Php83/bootstrap80.php
+++ b/src/Php83/bootstrap80.php
@@ -13,7 +13,7 @@ use Symfony\Polyfill\Php83 as p;
 
 if (extension_loaded('mbstring')) {
     if (!function_exists('mb_str_pad')) {
-        function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = STR_PAD_RIGHT, ?string $encoding = null): string { return p\Php83::mb_str_pad($string, $length, $pad_string, $pad_type, $encoding); }
+        function mb_str_pad(?string $string, ?int $length, ?string $pad_string = ' ', ?int $pad_type = STR_PAD_RIGHT, ?string $encoding = null): string { return p\Php83::mb_str_pad((string) $string, (int) $length, (string) $pad_string, (int) $pad_type, $encoding); }
     }
 }
 

--- a/src/Php84/bootstrap.php
+++ b/src/Php84/bootstrap.php
@@ -52,27 +52,27 @@ if (\PHP_VERSION_ID >= 80000) {
 if (extension_loaded('mbstring')) {
     if (!function_exists('mb_ucfirst')) {
         /** @return string|false */
-        function mb_ucfirst(string $string, ?string $encoding = null) { return p\Php84::mb_ucfirst($string, $encoding); }
+        function mb_ucfirst(?string $string, ?string $encoding = null) { return p\Php84::mb_ucfirst((string) $string, $encoding); }
     }
 
     if (!function_exists('mb_lcfirst')) {
         /** @return string|false */
-        function mb_lcfirst(string $string, ?string $encoding = null) { return p\Php84::mb_lcfirst($string, $encoding); }
+        function mb_lcfirst(?string $string, ?string $encoding = null) { return p\Php84::mb_lcfirst((string) $string, $encoding); }
     }
 
     if (!function_exists('mb_trim')) {
         /** @return string|false */
-        function mb_trim(string $string, ?string $characters = null, ?string $encoding = null) { return p\Php84::mb_trim($string, $characters, $encoding); }
+        function mb_trim(?string $string, ?string $characters = null, ?string $encoding = null) { return p\Php84::mb_trim((string) $string, $characters, $encoding); }
     }
 
     if (!function_exists('mb_ltrim')) {
         /** @return string|false */
-        function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null) { return p\Php84::mb_ltrim($string, $characters, $encoding); }
+        function mb_ltrim(?string $string, ?string $characters = null, ?string $encoding = null) { return p\Php84::mb_ltrim((string) $string, $characters, $encoding); }
     }
 
     if (!function_exists('mb_rtrim')) {
         /** @return string|false */
-        function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null) { return p\Php84::mb_rtrim($string, $characters, $encoding); }
+        function mb_rtrim(?string $string, ?string $characters = null, ?string $encoding = null) { return p\Php84::mb_rtrim((string) $string, $characters, $encoding); }
     }
 }
 

--- a/src/Php84/bootstrap80.php
+++ b/src/Php84/bootstrap80.php
@@ -13,23 +13,23 @@ use Symfony\Polyfill\Php84 as p;
 
 if (extension_loaded('mbstring')) {
     if (!function_exists('mb_ucfirst')) {
-        function mb_ucfirst(string $string, ?string $encoding = null): string { return p\Php84::mb_ucfirst($string, $encoding); }
+        function mb_ucfirst(?string $string, ?string $encoding = null): string { return p\Php84::mb_ucfirst((string) $string, $encoding); }
     }
 
     if (!function_exists('mb_lcfirst')) {
-        function mb_lcfirst(string $string, ?string $encoding = null): string { return p\Php84::mb_lcfirst($string, $encoding); }
+        function mb_lcfirst(?string $string, ?string $encoding = null): string { return p\Php84::mb_lcfirst((string) $string, $encoding); }
     }
 
     if (!function_exists('mb_trim')) {
-        function mb_trim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Php84::mb_trim($string, $characters, $encoding); }
+        function mb_trim(?string $string, ?string $characters = null, ?string $encoding = null): string { return p\Php84::mb_trim((string) $string, $characters, $encoding); }
     }
 
     if (!function_exists('mb_ltrim')) {
-        function mb_ltrim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Php84::mb_ltrim($string, $characters, $encoding); }
+        function mb_ltrim(?string $string, ?string $characters = null, ?string $encoding = null): string { return p\Php84::mb_ltrim((string) $string, $characters, $encoding); }
     }
 
     if (!function_exists('mb_rtrim')) {
-        function mb_rtrim(string $string, ?string $characters = null, ?string $encoding = null): string { return p\Php84::mb_rtrim($string, $characters, $encoding); }
+        function mb_rtrim(?string $string, ?string $characters = null, ?string $encoding = null): string { return p\Php84::mb_rtrim((string) $string, $characters, $encoding); }
     }
 }
 

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -962,4 +962,17 @@ class MbstringTest extends TestCase
 
         yield ["foo\n", "foo\n", 'o'];
     }
+
+    /**
+     * @group legacy
+     */
+    public function testNullStringArgument()
+    {
+        $this->assertSame('', @mb_trim(null));
+        $this->assertSame('', @mb_ltrim(null));
+        $this->assertSame('', @mb_rtrim(null));
+        $this->assertSame('', @mb_ucfirst(null));
+        $this->assertSame('', @mb_lcfirst(null));
+        $this->assertSame('     ', @mb_str_pad(null, 5));
+    }
 }

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -148,6 +148,14 @@ class Php83Test extends TestCase
     }
 
     /**
+     * @group legacy
+     */
+    public function testMbStrPadWithNullString()
+    {
+        $this->assertSame('     ', @mb_str_pad(null, 5));
+    }
+
+    /**
      * @return iterable<array{0: bool, 1: string, 2?: string, 3?: int, 4?: int}>
      */
     public static function jsonDataProvider(): iterable

--- a/tests/Php84/Php84Test.php
+++ b/tests/Php84/Php84Test.php
@@ -345,6 +345,18 @@ class Php84Test extends TestCase
     }
 
     /**
+     * @group legacy
+     */
+    public function testNullStringArgument()
+    {
+        $this->assertSame('', @mb_trim(null));
+        $this->assertSame('', @mb_ltrim(null));
+        $this->assertSame('', @mb_rtrim(null));
+        $this->assertSame('', @mb_ucfirst(null));
+        $this->assertSame('', @mb_lcfirst(null));
+    }
+
+    /**
      * @dataProvider fpowProvider
      */
     public function testFpow(float $num, float $exponent, float $expected)


### PR DESCRIPTION
Allows passing `null` to the `mb_*` polyfills consistent with native PHP behavior. The companion tests are tagged `@group legacy` so the deprecations PHP raises stay isolated from the bridge's threshold.

Closes https://github.com/symfony/polyfill/issues/506