### PR TITLE
[Grapheme] Return false from grapheme_strrev() on invalid UTF-8

### DIFF
--- a/src/Intl/Grapheme/Grapheme.php
+++ b/src/Intl/Grapheme/Grapheme.php
@@ -329,6 +329,10 @@ final class Grapheme
 
     public static function grapheme_strrev(string $string)
     {
+        if (!preg_match('//u', $string)) {
+            return false;
+        }
+
         $units = grapheme_str_split($string);
 
         if (false === $units) {

--- a/src/Php86/Php86.php
+++ b/src/Php86/Php86.php
@@ -65,6 +65,10 @@ final class Php86
 
     public static function grapheme_strrev(string $string)
     {
+        if (!preg_match('//u', $string)) {
+            return false;
+        }
+
         if (false === $units = grapheme_str_split($string)) {
             return false;
         }

--- a/tests/Intl/Grapheme/GraphemeTest.php
+++ b/tests/Intl/Grapheme/GraphemeTest.php
@@ -325,6 +325,8 @@ class GraphemeTest extends TestCase
 
     /**
      * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_strrev
+     *
+     * @requires PHP < 8.6
      */
     public function testGraphemeStrrevInvalidUtf8()
     {

--- a/tests/Php86/Php86Test.php
+++ b/tests/Php86/Php86Test.php
@@ -208,6 +208,9 @@ class Php86Test extends TestCase
         ];
     }
 
+    /**
+     * @requires PHP < 8.6
+     */
     public function testGraphemeStrrevInvalidUtf8()
     {
         $this->assertFalse(grapheme_strrev("\xFF"));


### PR DESCRIPTION
Native `grapheme_str_split()` doesn't signal invalid UTF-8 (it returns the replacement character), so the polyfills now validate the input and return `false` for inconsistent encodings. PHP 8.6 native `grapheme_strrev()` returns the replacement character instead, so the test is skipped on that version.