### PR TITLE
[Tests] Adapt Intl tests to newer PHP/ICU behavior

### DIFF
--- a/tests/Intl/Icu/AbstractIntlDateFormatterTest.php
+++ b/tests/Intl/Icu/AbstractIntlDateFormatterTest.php
@@ -997,10 +997,15 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
 
     protected function assertIsIntlFailure($formatter, $errorMessage, $errorCode)
     {
-        $this->assertSame($errorMessage, $this->getIntlErrorMessage());
+        $stripPrefix = static function (string $message): string {
+            return preg_replace('/^(?:IntlDateFormatter::(?:format|parse)|datefmt_format)(?:\(\))?: /', '', $message);
+        };
+        $errorMessage = $stripPrefix($errorMessage);
+
+        $this->assertSame($errorMessage, $stripPrefix($this->getIntlErrorMessage()));
         $this->assertSame($errorCode, $this->getIntlErrorCode());
         $this->assertTrue($this->isIntlFailure($this->getIntlErrorCode()));
-        $this->assertSame($errorMessage, $formatter->getErrorMessage());
+        $this->assertSame($errorMessage, $stripPrefix($formatter->getErrorMessage()));
         $this->assertSame($errorCode, $formatter->getErrorCode());
         $this->assertTrue($this->isIntlFailure($formatter->getErrorCode()));
     }

--- a/tests/Intl/Icu/IntlListFormatterTest.php
+++ b/tests/Intl/Icu/IntlListFormatterTest.php
@@ -31,6 +31,10 @@ class IntlListFormatterTest extends TestCase
 
     public function testUnsupportedLocales()
     {
+        if (\PHP_VERSION_ID >= 80500) {
+            $this->markTestSkipped('Native IntlListFormatter accepts the "ja" locale on PHP 8.5+.');
+        }
+
         if (80000 <= \PHP_VERSION_ID) {
             $this->expectException(\ValueError::class);
         } else {

--- a/tests/Intl/Icu/Verification/IntlDateFormatterTest.php
+++ b/tests/Intl/Icu/Verification/IntlDateFormatterTest.php
@@ -97,6 +97,18 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
         parent::testFormatIgnoresPatternForRelativeDateType();
     }
 
+    /**
+     * @dataProvider setTimeZoneProvider
+     */
+    public function testSetTimeZone($timeZoneId, $expectedTimeZoneId)
+    {
+        if (\PHP_VERSION_ID >= 80500 && 'UTC' === $expectedTimeZoneId && \in_array($timeZoneId, ['Foo/Bar', 'GMT+00:AA', 'GMT+00AA'], true)) {
+            $this->expectException(\IntlException::class);
+        }
+
+        parent::testSetTimeZone($timeZoneId, $expectedTimeZoneId);
+    }
+
     protected function getDateFormatter($locale, $datetype, $timetype, $timezone = null, $calendar = IntlDateFormatter::GREGORIAN, $pattern = null)
     {
         if (version_compare(\INTL_ICU_VERSION, '55.1', '<')) {

--- a/tests/Intl/Idn/IdnTest.php
+++ b/tests/Intl/Idn/IdnTest.php
@@ -122,6 +122,10 @@ class IdnTest extends TestCase
      */
     public function testToUnicode($source, $toUnicode, $toUnicodeStatus, $toAsciiN, $toAsciiNStatus, $toAsciiT, $toAsciiTStatus)
     {
+        if (\defined('INTL_ICU_VERSION') && version_compare(\INTL_ICU_VERSION, '74', '>=')) {
+            $this->markTestSkipped('IdnaTestV2.txt is based on Unicode 13.0.0; ICU 74+ uses newer Unicode data.');
+        }
+
         if (\PHP_VERSION_ID >= 80400 && '' === $source) {
             $this->expectException(\ValueError::class);
         }
@@ -154,6 +158,10 @@ class IdnTest extends TestCase
      */
     public function testToAsciiNonTransitional($source, $toUnicode, $toUnicodeStatus, $toAsciiN, $toAsciiNStatus, $toAsciiT, $toAsciiTStatus)
     {
+        if (\defined('INTL_ICU_VERSION') && version_compare(\INTL_ICU_VERSION, '74', '>=')) {
+            $this->markTestSkipped('IdnaTestV2.txt is based on Unicode 13.0.0; ICU 74+ uses newer Unicode data.');
+        }
+
         if (\PHP_VERSION_ID >= 80400 && '' === $source) {
             $this->expectException(\ValueError::class);
         }
@@ -186,6 +194,10 @@ class IdnTest extends TestCase
      */
     public function testToAsciiTransitional($source, $toUnicode, $toUnicodeStatus, $toAsciiN, $toAsciiNStatus, $toAsciiT, $toAsciiTStatus)
     {
+        if (\defined('INTL_ICU_VERSION') && version_compare(\INTL_ICU_VERSION, '74', '>=')) {
+            $this->markTestSkipped('IdnaTestV2.txt is based on Unicode 13.0.0; ICU 74+ uses newer Unicode data.');
+        }
+
         if (\PHP_VERSION_ID >= 80400 && '' === $source) {
             $this->expectException(\ValueError::class);
         }

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -23,7 +23,8 @@ class Php83Test extends TestCase
     public function testJsonValidate(bool $valid, string $json, string $errorMessage = 'No error', int $depth = 512, int $options = 0)
     {
         $this->assertSame($valid, json_validate($json, $depth, $options));
-        $this->assertSame($errorMessage, json_last_error_msg());
+        $actualErrorMessage = preg_replace('/ near location \d+:\d+/', '', json_last_error_msg());
+        $this->assertSame($errorMessage, $actualErrorMessage);
     }
 
     /**


### PR DESCRIPTION
- Strip the new `NumberFormatter::parse() / IntlDateFormatter::*` prefix on Intl error messages introduced in PHP 8.5+.
- Expect `IntlException` on invalid time zones in the Verification subclass on PHP 8.5+.
- Skip `IntlListFormatter::testUnsupportedLocales` on PHP 8.5+ where the native class accepts the `ja` locale.
- Skip the Idn UTS46 tests on ICU 74+ since `IdnaTestV2.txt` is based on Unicode 13.
- Strip the new ` near location X:Y` suffix from `json_last_error_msg()` on PHP 8.6+.