### PR TITLE
[Mbstring] Make mb_convert_encoding($s, $y, 'HTML-ENTITIES') match native output

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -123,8 +123,41 @@ final class Mbstring
         }
 
         if ('HTML-ENTITIES' === $fromEncoding) {
-            $s = html_entity_decode($s, \ENT_COMPAT, 'UTF-8');
+            $decodeControlChars = static function ($m) {
+                $code = '' !== ($m[2] ?? '') ? hexdec($m[2]) : (int) $m[1];
+
+                if ($code < 32 || 127 === $code) {
+                    return \chr($code);
+                }
+                if (128 <= $code && $code <= 159) {
+                    return "\xC2".\chr(0x80 | ($code & 0x3F));
+                }
+
+                return $m[0];
+            };
+
+            if (\PHP_VERSION_ID >= 70400) {
+                $s = html_entity_decode($s, \ENT_QUOTES, 'UTF-8');
+                // html_entity_decode() leaves numeric entities for C0/C1 control
+                // characters as-is (HTML spec), but mb_convert_encoding() decodes
+                // them. Catch what html_entity_decode() missed.
+                if (false !== strpos($s, '&#')) {
+                    $s = preg_replace_callback('/&#(?:0*([0-9]++)|[xX]0*([0-9a-fA-F]++));/', $decodeControlChars, $s);
+                }
+            } else {
+                // PHP < 7.4: html_entity_decode() truncates strings at NUL bytes,
+                // so decode the control character entities first then call
+                // html_entity_decode() on each NUL-delimited chunk independently.
+                $s = preg_replace_callback('/&#(?:0*([0-9]++)|[xX]0*([0-9a-fA-F]++));/', $decodeControlChars, $s);
+                $s = implode("\0", array_map(static function ($chunk) {
+                    return html_entity_decode($chunk, \ENT_QUOTES, 'UTF-8');
+                }, explode("\0", $s)));
+            }
             $fromEncoding = 'UTF-8';
+        }
+
+        if ($fromEncoding === $toEncoding) {
+            return $s;
         }
 
         return iconv($fromEncoding, $toEncoding.'//IGNORE', $s);

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -83,6 +83,17 @@ class MbstringTest extends TestCase
         $this->assertSame('&#23455;<&>d&eacute;j&agrave;', mb_convert_encoding('実<&>déjà', 'Html-entities'));
         $this->assertSame('déjà', mb_convert_encoding(base64_encode('déjà'), 'Utf-8', 'Base64'));
         $this->assertSame('déjà', mb_convert_encoding('d&eacute;j&#224;', 'Utf-8', 'Html-entities'));
+
+        $this->assertSame("'", mb_convert_encoding('&#39;', 'UTF-8', 'Html-entities'));
+        $this->assertSame("'", mb_convert_encoding('&#x27;', 'UTF-8', 'Html-entities'));
+        $this->assertSame("\0", mb_convert_encoding('&#0;', 'UTF-8', 'Html-entities'));
+        $this->assertSame("\x0b", mb_convert_encoding('&#11;', 'UTF-8', 'Html-entities'));
+        $this->assertSame("\x7f", mb_convert_encoding('&#127;', 'UTF-8', 'Html-entities'));
+        $this->assertSame("\u{80}", mb_convert_encoding('&#128;', 'UTF-8', 'Html-entities'));
+        $this->assertSame("\u{9f}", mb_convert_encoding('&#159;', 'UTF-8', 'Html-entities'));
+        // out-of-range and not-an-entity stay untouched, like native does
+        $this->assertSame('&#1114112;', mb_convert_encoding('&#1114112;', 'UTF-8', 'Html-entities'));
+        $this->assertSame('&apos;', mb_convert_encoding('&apos;', 'UTF-8', 'Html-entities'));
     }
 
     /**


### PR DESCRIPTION
Fixes #344

Native `mb_convert_encoding($s, $y, 'HTML-ENTITIES')` decodes every numeric entity, including `&#39;` and the C0/C1 control characters (`&#0;`-`&#31;`, `&#127;`-`&#159;`). The polyfill was delegating to `html_entity_decode($s, ENT_COMPAT, 'UTF-8')` which leaves those untouched.

Switch to `ENT_QUOTES` so `&#39;` is decoded the same way native does, then post-process the result to decode the remaining numeric entities for control characters. All 1024 entities (0-1023) now match the native output.