### PR TITLE
[Intl/MessageFormatter] Validate the full pattern at configuration time

### DIFF
--- a/src/Intl/MessageFormatter/MessageFormatter.php
+++ b/src/Intl/MessageFormatter/MessageFormatter.php
@@ -112,7 +112,9 @@ class MessageFormatter
     public function setPattern(string $pattern)
     {
         try {
-            $this->tokens = self::tokenizePattern($pattern);
+            $tokens = self::tokenizePattern($pattern);
+            self::validateTokens($tokens);
+            $this->tokens = $tokens;
             $this->pattern = $pattern;
         } catch (\DomainException $e) {
             return false;
@@ -157,6 +159,59 @@ class MessageFormatter
         }
 
         return implode('', $tokens);
+    }
+
+    private static function validateTokens(array $tokens): void
+    {
+        foreach ($tokens as $token) {
+            if (!\is_array($token)) {
+                continue;
+            }
+            $type = isset($token[1]) ? trim($token[1]) : 'none';
+            switch ($type) {
+                case 'none':
+                case 'number':
+                case 'date':
+                case 'time':
+                case 'spellout':
+                case 'ordinal':
+                case 'duration':
+                case 'choice':
+                    break;
+                case 'selectordinal':
+                case 'plural':
+                case 'select':
+                    if (!isset($token[2])) {
+                        throw new \DomainException('Message pattern is invalid.');
+                    }
+                    $sub = self::tokenizePattern($token[2]);
+                    $c = \count($sub);
+                    if ($c < 2) {
+                        throw new \DomainException('Message pattern is invalid.');
+                    }
+                    $hasOther = false;
+                    for ($i = 0; 1 + $i < $c; $i += 2) {
+                        if (\is_array($sub[$i]) || !\is_array($sub[1 + $i])) {
+                            throw new \DomainException('Message pattern is invalid.');
+                        }
+                        $selector = trim($sub[$i]);
+                        if ('plural' === $type && 0 === $i && 0 === strncmp($selector, 'offset:', 7)) {
+                            $offsetEnd = strpos(str_replace(["\n", "\r", "\t"], ' ', $selector), ' ', 7);
+                            $selector = false !== $offsetEnd ? trim(substr($selector, 1 + $offsetEnd)) : '';
+                        }
+                        if ('other' === $selector) {
+                            $hasOther = true;
+                        }
+                        self::validateTokens(self::tokenizePattern(implode(',', $sub[1 + $i])));
+                    }
+                    if (!$hasOther) {
+                        throw new \DomainException('Message pattern is invalid.');
+                    }
+                    break;
+                default:
+                    throw new \DomainException('Message pattern is invalid.');
+            }
+        }
     }
 
     private static function tokenizePattern($pattern)

--- a/tests/Intl/MessageFormatter/MessageFormatterTest.php
+++ b/tests/Intl/MessageFormatter/MessageFormatterTest.php
@@ -262,4 +262,37 @@ _MSG_
         $formatter = new MessageFormatter('en-US', $pattern);
         $this->assertFalse($formatter->format(['n' => 42]));
     }
+
+    /**
+     * @dataProvider invalidPatterns
+     */
+    public function testInvalidPatternThrowsAtConstruction($pattern)
+    {
+        $this->expectException(\IntlException::class);
+        new MessageFormatter('en_US', $pattern);
+    }
+
+    /**
+     * @dataProvider invalidPatterns
+     */
+    public function testInvalidPatternMakesCreateReturnNull($pattern)
+    {
+        $this->assertNull(MessageFormatter::create('en_US', $pattern));
+    }
+
+    public static function invalidPatterns()
+    {
+        return [
+            'unknown type' => ['{n, foo}'],
+            'select without styles' => ['{n, select}'],
+            'plural without styles' => ['{n, plural}'],
+            'selectordinal without styles' => ['{n, selectordinal}'],
+            'select without other' => ['{n, select, brown {a}}'],
+            'plural without other' => ['{n, plural, =0 {a}}'],
+            'selectordinal without other' => ['{n, selectordinal, one {a}}'],
+            'unclosed outer brace' => ['{n, plural, other {a}'],
+            'unknown nested type' => ['{n, plural, other {{x, foo}}}'],
+            'nested select without other' => ['{n, plural, other {{x, select, brown {a}}}}'],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #158
| License       | MIT

Move pattern validation from `format()` to `setPattern()` so the polyfill matches the native intl extension, which detects invalid patterns at instantiation.

This now rejects at construction:
- unknown types (`{n, foo}`)
- `select`/`plural`/`selectordinal` without styles (`{n, plural}`)
- `select`/`plural`/`selectordinal` without an `other` selector (`{n, select, brown {a}}`)
- nested tokens with the same issues (`{n, plural, other {{x, foo}}}`)