### PR TITLE
[IoPoll] Polyfill the Io\Poll API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ composer.lock
 phpunit.xml
 .phpunit
 vendor/
+/tests/Io/Poll/phpt/*.php
 /tests/unicode

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Polyfills are provided for:
 - the `ARRAY_FILTER_USE_VALUE` constant introduced in PHP 8.6;
 - the `SortDirection` enum introduced in PHP 8.6;
 - the `grapheme_strrev` function introduced in PHP 8.6;
+- the `Io\Poll` API and `StreamPollHandle` introduced in PHP 8.6 (requires PHP >= 8.1; only the `Poll` backend is available);
 
 It is strongly recommended to upgrade your PHP version and/or install the missing
 extensions whenever possible. This polyfill should be used only when there is no
@@ -133,6 +134,7 @@ should **not** `require` the `symfony/polyfill` package, but the standalone ones
 - `symfony/polyfill-intl-icu` for using the intl functions and classes,
 - `symfony/polyfill-intl-messageformatter` for using the intl messageformatter,
 - `symfony/polyfill-intl-normalizer` for using the intl normalizer,
+- `symfony/polyfill-io-poll` for using the `Io\Poll` API and `StreamPollHandle`,
 - `symfony/polyfill-mbstring` for using the mbstring functions,
 - `symfony/polyfill-util` for using the polyfill utility helpers.
 - `symfony/polyfill-uuid` for using the `uuid_*` functions,

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "symfony/polyfill-intl-messageformatter": "self.version",
         "symfony/polyfill-intl-idn": "self.version",
         "symfony/polyfill-intl-normalizer": "self.version",
+        "symfony/polyfill-io-poll": "self.version",
         "symfony/polyfill-mbstring": "self.version",
         "symfony/polyfill-util": "self.version",
         "symfony/polyfill-uuid": "self.version"
@@ -67,6 +68,7 @@
             "src/Intl/Icu/Resources/stubs",
             "src/Intl/MessageFormatter/Resources/stubs",
             "src/Intl/Normalizer/Resources/stubs",
+            "src/Io/Poll/Resources/stubs",
             "src/Php86/Resources/stubs",
             "src/Php85/Resources/stubs",
             "src/Php84/Resources/stubs",

--- a/src/Io/Poll/LICENSE
+++ b/src/Io/Poll/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Io/Poll/README.md
+++ b/src/Io/Poll/README.md
@@ -1,0 +1,25 @@
+Symfony Polyfill / Io / Poll
+============================
+
+This component provides the [`Io\Poll` API](https://wiki.php.net/rfc/poll_api)
+added to PHP 8.6 core, for PHP >= 8.1:
+
+- `Io\Poll\Context`, `Io\Poll\Watcher` and `StreamPollHandle`
+- `Io\Poll\Backend` and `Io\Poll\Event` enums
+- `Io\IoException` and the `Io\Poll\*Exception` hierarchy
+
+The polyfill is backed by `stream_select()`, so only the `Poll` backend is
+available and edge-triggering is not supported. Event detection follows the
+semantics of the native `poll` backend as closely as `select()` allows:
+`Event::Error` is only reported for connection resets, `Event::ReadHangUp` is
+never reported, and a TCP half-close reports `Read|HangUp` where native
+reports plain `Read`. The phpt tests of the native implementation, borrowed
+from php-src, run against the polyfill as part of the test suite.
+
+More information can be found in the
+[main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).
+
+License
+=======
+
+This library is released under the [MIT license](LICENSE).

--- a/src/Io/Poll/Resources/stubs/Io/IoException.php
+++ b/src/Io/Poll/Resources/stubs/Io/IoException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io;
+
+if (\PHP_VERSION_ID < 80600) {
+    class IoException extends \Exception
+    {
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/Backend.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/Backend.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    enum Backend
+    {
+        case Auto;
+        case Poll;
+        case Epoll;
+        case Kqueue;
+        case EventPorts;
+        case WSAPoll;
+
+        public function isAvailable(): bool
+        {
+            return match ($this) {
+                self::Auto, self::Poll => true,
+                default => false,
+            };
+        }
+
+        public function supportsEdgeTriggering(): bool
+        {
+            return false;
+        }
+
+        public static function getAvailableBackends(): array
+        {
+            return [self::Poll];
+        }
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/BackendUnavailableException.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/BackendUnavailableException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    class BackendUnavailableException extends PollException
+    {
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/Context.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/Context.php
@@ -1,0 +1,286 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    final class Context
+    {
+        private Backend $backend;
+
+        /**
+         * The fd table of the emulated poll backend, keyed by stream resource id.
+         *
+         * @var array<int, Watcher>
+         */
+        private array $watchers = [];
+
+        public function __construct(Backend $backend = Backend::Auto)
+        {
+            if (isset($this->backend)) {
+                throw new \Error('Io\Poll\Context object is already constructed');
+            }
+
+            if (!$backend->isAvailable()) {
+                throw new BackendUnavailableException(\sprintf('Backend %s not available', $backend->name));
+            }
+
+            $this->backend = Backend::Auto === $backend ? Backend::Poll : $backend;
+        }
+
+        public function __destruct()
+        {
+            static $deactivate;
+            $deactivate ??= \Closure::bind(
+                static function (Watcher $w): void {
+                    $w->active = false;
+                    $w->context = null;
+                },
+                null,
+                Watcher::class,
+            );
+
+            foreach ($this->watchers as $watcher) {
+                $deactivate($watcher);
+            }
+        }
+
+        public function getBackend(): Backend
+        {
+            return $this->backend;
+        }
+
+        public function add(Handle $handle, array $events, mixed $data = null): Watcher
+        {
+            if (!$handle instanceof \StreamPollHandle) {
+                throw new InvalidHandleException(\sprintf('Handle of type "%s" is not supported by the polyfill; only %s is.', \get_class($handle), \StreamPollHandle::class));
+            }
+
+            $stream = $handle->getStream();
+            if (!\is_resource($stream) || 'MEMORY' === stream_get_meta_data($stream)['stream_type']) {
+                throw new InvalidHandleException('Invalid handle for polling');
+            }
+
+            static $normalize, $create;
+            $normalize ??= \Closure::bind(
+                static fn (array $events, string $method, int $argument): array => Watcher::normalizeEvents($events, $method, $argument),
+                null,
+                Watcher::class,
+            );
+            $create ??= \Closure::bind(
+                static fn (\WeakReference $ctx, Handle $h, array $e, mixed $d): Watcher => new Watcher($ctx, $h, $e, $d),
+                null,
+                Watcher::class,
+            );
+
+            $events = $normalize($events, __METHOD__, 2);
+
+            if (\in_array(Event::EdgeTriggered, $events, true)) {
+                throw new FailedHandleAddException('Failed to add handle', FailedPollOperationException::ERROR_NOSUPPORT);
+            }
+
+            $id = get_resource_id($stream);
+            if (null !== $existing = $this->watchers[$id] ?? null) {
+                if (\is_resource($existing->getHandle()->getStream())) {
+                    throw new HandleAlreadyWatchedException('Handle already added');
+                }
+                unset($this->watchers[$id]); // the resource id was recycled from a closed stream
+            }
+
+            return $this->watchers[$id] = $create(\WeakReference::create($this), $handle, $events, $data);
+        }
+
+        public function wait(?int $timeoutSeconds = null, int $timeoutMicroseconds = 0, ?int $maxEvents = null): array
+        {
+            if (null !== $timeoutSeconds) {
+                if ($timeoutSeconds < 0) {
+                    throw new \ValueError(\sprintf('%s(): Argument #1 ($timeoutSeconds) must be greater than or equal to 0', __METHOD__));
+                }
+                if ($timeoutMicroseconds < 0) {
+                    throw new \ValueError(\sprintf('%s(): Argument #2 ($timeoutMicroseconds) must be greater than or equal to 0', __METHOD__));
+                }
+            }
+
+            if (null !== $maxEvents && $maxEvents <= 0) {
+                throw new \ValueError(\sprintf('%s(): Argument #3 ($maxEvents) must be greater than 0', __METHOD__));
+            }
+
+            // Like poll() reporting POLLNVAL, drop watchers whose stream has been
+            // closed; poll() returns immediately in that case, without sleeping
+            $evicted = false;
+            foreach ($this->watchers as $id => $watcher) {
+                if (!\is_resource($watcher->getHandle()->getStream())) {
+                    unset($this->watchers[$id]);
+                    $evicted = true;
+                }
+            }
+
+            if (!$this->watchers) {
+                if (!$evicted && null !== $timeoutSeconds && 0 < $micros = $timeoutSeconds * 1_000_000 + $timeoutMicroseconds) {
+                    usleep($micros);
+                }
+
+                return [];
+            }
+
+            $read = $write = [];
+            foreach ($this->watchers as $id => $watcher) {
+                $stream = $watcher->getHandle()->getStream();
+
+                // poll() reports hang-ups and errors even when not requested;
+                // detecting them requires select() readability for every stream,
+                // at the cost of spurious wake-ups that the retry loop below absorbs
+                $read[$id] = $stream;
+
+                if (\in_array(Event::Write, $watcher->getWatchedEvents(), true)) {
+                    $write[$id] = $stream;
+                }
+            }
+
+            if ($evicted) {
+                $deadline = 0;
+            } elseif (null !== $timeoutSeconds) {
+                $deadline = hrtime(true) + ($timeoutSeconds * 1_000_000 + $timeoutMicroseconds) * 1000;
+            } else {
+                $deadline = null;
+            }
+
+            $triggered = [];
+            while (true) {
+                $r = $read;
+                $w = $write;
+                $e = null;
+
+                if (null === $deadline) {
+                    $result = @stream_select($r, $w, $e, null);
+                } else {
+                    $remaining = max(0, $deadline - hrtime(true));
+                    $result = @stream_select($r, $w, $e, \intdiv($remaining, 1_000_000_000), \intdiv($remaining % 1_000_000_000, 1000));
+                }
+
+                if (false === $result) {
+                    throw new FailedPollWaitException('Poll wait failed');
+                }
+
+                if (0 === $result) {
+                    return [];
+                }
+
+                foreach ($this->watchers as $id => $watcher) {
+                    $isReadable = isset($r[$id]);
+                    $isWritable = isset($w[$id]);
+
+                    if (!$isReadable && !$isWritable) {
+                        continue;
+                    }
+
+                    $stream = $watcher->getHandle()->getStream();
+                    $watched = $watcher->getWatchedEvents();
+                    $hangUp = $error = false;
+                    $readable = $isReadable;
+
+                    if ($isReadable) {
+                        $peek = @stream_socket_recvfrom($stream, 1, \STREAM_PEEK);
+                        $meta = stream_get_meta_data($stream);
+                        if (false === $peek) {
+                            if (str_contains($meta['stream_type'], 'socket')) {
+                                // peeking a readable socket only fails when the connection
+                                // was reset (peer closed with unread data): POLLERR|POLLHUP
+                                $error = $hangUp = true;
+                            } elseif (!$meta['seekable'] && feof($stream)) {
+                                // a pipe at EOF raises POLLHUP without POLLIN,
+                                // while a regular file always raises plain POLLIN
+                                $hangUp = true;
+                                $readable = false;
+                            }
+                        } elseif ('' === $peek && !\in_array($meta['stream_type'], ['udp_socket', 'udg_socket'], true)) {
+                            // a stream socket at EOF raises POLLIN|POLLHUP,
+                            // while an empty datagram is plain POLLIN
+                            $hangUp = true;
+                        }
+                    }
+
+                    $events = [];
+                    if ($readable && \in_array(Event::Read, $watched, true)) {
+                        $events[] = Event::Read;
+                    }
+                    if ($isWritable && \in_array(Event::Write, $watched, true)) {
+                        $events[] = Event::Write;
+                    }
+                    if ($error) {
+                        $events[] = Event::Error; // reported even when not watched, like POLLERR
+                    }
+                    if ($hangUp) {
+                        $events[] = Event::HangUp; // reported even when not watched, like POLLHUP
+                    }
+
+                    if ($events) {
+                        $triggered[] = [$watcher, $events];
+                        if (null !== $maxEvents && \count($triggered) === $maxEvents) {
+                            break;
+                        }
+                    }
+                }
+
+                if ($triggered) {
+                    break;
+                }
+
+                // Readiness that maps to no watched event; poll() would not have
+                // woken up, so keep waiting for the remaining timeout
+                if (null !== $deadline && hrtime(true) >= $deadline) {
+                    return [];
+                }
+                usleep(1000);
+            }
+
+            static $setTriggered;
+            $setTriggered ??= \Closure::bind(
+                static fn (Watcher $w, array $events) => $w->triggeredEvents = $events,
+                null,
+                Watcher::class,
+            );
+
+            $result = [];
+            foreach ($triggered as [$watcher, $events]) {
+                $setTriggered($watcher, $events);
+                $result[] = $watcher;
+
+                if (\in_array(Event::OneShot, $watcher->getWatchedEvents(), true)) {
+                    // like the native backend, only the fd entry is dropped; the watcher stays active
+                    unset($this->watchers[get_resource_id($watcher->getHandle()->getStream())]);
+                }
+            }
+
+            return $result;
+        }
+
+        public function __clone()
+        {
+            throw new \Error(\sprintf('Trying to clone an uncloneable object of class %s', self::class));
+        }
+
+        public function __debugInfo(): array
+        {
+            return [];
+        }
+
+        public function __serialize(): array
+        {
+            throw new \Exception(\sprintf("Serialization of '%s' is not allowed", self::class));
+        }
+
+        public function __unserialize(array $data): void
+        {
+            throw new \Exception(\sprintf("Unserialization of '%s' is not allowed", self::class));
+        }
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/Event.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/Event.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    enum Event
+    {
+        case Read;
+        case Write;
+        case Error;
+        case HangUp;
+        case ReadHangUp;
+        case OneShot;
+        case EdgeTriggered;
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/FailedContextInitializationException.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/FailedContextInitializationException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    class FailedContextInitializationException extends FailedPollOperationException
+    {
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/FailedHandleAddException.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/FailedHandleAddException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    class FailedHandleAddException extends FailedPollOperationException
+    {
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/FailedPollOperationException.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/FailedPollOperationException.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    abstract class FailedPollOperationException extends PollException
+    {
+        public const ERROR_NONE = 0;
+        public const ERROR_SYSTEM = 1;
+        public const ERROR_NOMEM = 2;
+        public const ERROR_INVALID = 3;
+        public const ERROR_EXISTS = 4;
+        public const ERROR_NOTFOUND = 5;
+        public const ERROR_TIMEOUT = 6;
+        public const ERROR_INTERRUPTED = 7;
+        public const ERROR_PERMISSION = 8;
+        public const ERROR_TOOBIG = 9;
+        public const ERROR_AGAIN = 10;
+        public const ERROR_NOSUPPORT = 11;
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/FailedPollWaitException.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/FailedPollWaitException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    class FailedPollWaitException extends FailedPollOperationException
+    {
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/FailedWatcherModificationException.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/FailedWatcherModificationException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    class FailedWatcherModificationException extends FailedPollOperationException
+    {
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/Handle.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/Handle.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    /**
+     * @internal only classes provided by PHP core or extensions may implement this interface
+     */
+    interface Handle
+    {
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/HandleAlreadyWatchedException.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/HandleAlreadyWatchedException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    class HandleAlreadyWatchedException extends PollException
+    {
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/InactiveWatcherException.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/InactiveWatcherException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    class InactiveWatcherException extends PollException
+    {
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/InvalidHandleException.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/InvalidHandleException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    class InvalidHandleException extends PollException
+    {
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/PollException.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/PollException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    class PollException extends \Io\IoException
+    {
+    }
+}

--- a/src/Io/Poll/Resources/stubs/Io/Poll/Watcher.php
+++ b/src/Io/Poll/Resources/stubs/Io/Poll/Watcher.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Io\Poll;
+
+if (\PHP_VERSION_ID < 80600) {
+    final class Watcher
+    {
+        private bool $active = true;
+        private array $triggeredEvents = [];
+
+        /**
+         * @param \WeakReference<Context>|null $context Weak so that dropping the last userland
+         *                                              reference to the context destroys it and
+         *                                              deactivates its watchers, like native
+         */
+        private function __construct(
+            private ?\WeakReference $context,
+            private readonly Handle $handle,
+            private array $events,
+            private mixed $data,
+        ) {
+        }
+
+        public function getHandle(): Handle
+        {
+            return $this->handle;
+        }
+
+        public function getWatchedEvents(): array
+        {
+            return $this->events;
+        }
+
+        public function getTriggeredEvents(): array
+        {
+            return $this->triggeredEvents;
+        }
+
+        public function getData(): mixed
+        {
+            return $this->data;
+        }
+
+        public function hasTriggered(Event $event): bool
+        {
+            return \in_array($event, $this->triggeredEvents, true);
+        }
+
+        public function isActive(): bool
+        {
+            return $this->active;
+        }
+
+        public function modify(array $events, mixed $data = null): void
+        {
+            $this->applyEvents(self::normalizeEvents($events, __METHOD__, 1));
+
+            if (1 < \func_num_args()) {
+                $this->data = $data;
+            }
+        }
+
+        public function modifyEvents(array $events): void
+        {
+            $this->applyEvents(self::normalizeEvents($events, __METHOD__, 1));
+        }
+
+        public function modifyData(mixed $data): void
+        {
+            if (!$this->active) {
+                throw new InactiveWatcherException('Cannot modify inactive watcher');
+            }
+
+            $this->data = $data;
+        }
+
+        public function remove(): void
+        {
+            $context = $this->active ? $this->context?->get() : null;
+            if (null === $context) {
+                throw new InactiveWatcherException('Cannot remove inactive watcher');
+            }
+
+            static $detach;
+            $detach ??= \Closure::bind(
+                static function (Context $ctx, Watcher $w): void {
+                    if (false !== $id = \array_search($w, $ctx->watchers, true)) {
+                        unset($ctx->watchers[$id]);
+                    }
+                },
+                null,
+                Context::class,
+            );
+            $detach($context, $this);
+            $this->active = false;
+            $this->context = null;
+        }
+
+        public function __clone()
+        {
+            throw new \Error(\sprintf('Trying to clone an uncloneable object of class %s', self::class));
+        }
+
+        public function __debugInfo(): array
+        {
+            return [];
+        }
+
+        public function __serialize(): array
+        {
+            throw new \Exception(\sprintf("Serialization of '%s' is not allowed", self::class));
+        }
+
+        public function __unserialize(array $data): void
+        {
+            throw new \Exception(\sprintf("Unserialization of '%s' is not allowed", self::class));
+        }
+
+        private function applyEvents(array $events): void
+        {
+            $context = $this->active ? $this->context?->get() : null;
+            if (null === $context) {
+                throw new InactiveWatcherException('Cannot modify inactive watcher');
+            }
+
+            if (!$this->handle instanceof \StreamPollHandle || !\is_resource($this->handle->getStream())) {
+                throw new InvalidHandleException('Invalid handle for polling');
+            }
+
+            if (\in_array(Event::EdgeTriggered, $events, true)) {
+                throw new FailedWatcherModificationException('Failed to modify watcher in polling system', FailedPollOperationException::ERROR_NOSUPPORT);
+            }
+
+            static $contains;
+            $contains ??= \Closure::bind(
+                static fn (Context $ctx, Watcher $w): bool => \in_array($w, $ctx->watchers, true),
+                null,
+                Context::class,
+            );
+            if (!$contains($context, $this)) {
+                throw new FailedWatcherModificationException('Failed to modify watcher in polling system', FailedPollOperationException::ERROR_NOTFOUND);
+            }
+
+            $this->events = $events;
+        }
+
+        /**
+         * Native stores events as a bitmask: duplicates collapse and getWatchedEvents()
+         * returns the cases in declaration order.
+         */
+        private static function normalizeEvents(array $events, string $method, int $argument): array
+        {
+            foreach ($events as $event) {
+                if (!$event instanceof Event) {
+                    throw new \TypeError(\sprintf('%s(): Argument #%d ($events) must be array of Event enums', $method, $argument));
+                }
+            }
+
+            if (!$events) {
+                throw new \TypeError(\sprintf('%s(): Argument #%d ($events) must be array of Event enums', $method, $argument));
+            }
+
+            $normalized = [];
+            foreach (Event::cases() as $case) {
+                if (\in_array($case, $events, true)) {
+                    $normalized[] = $case;
+                }
+            }
+
+            return $normalized;
+        }
+    }
+}

--- a/src/Io/Poll/Resources/stubs/StreamPollHandle.php
+++ b/src/Io/Poll/Resources/stubs/StreamPollHandle.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (\PHP_VERSION_ID < 80600) {
+    final class StreamPollHandle implements Io\Poll\Handle
+    {
+        private $stream;
+
+        public function __construct($stream)
+        {
+            if (!is_resource($stream) || ('stream' !== $type = get_resource_type($stream)) && 'persistent stream' !== $type) {
+                throw new TypeError(sprintf('%s(): Argument #1 ($stream) must be an open stream resource', __METHOD__));
+            }
+
+            if (null !== $this->stream) {
+                throw new Error('StreamPollHandle object is already constructed');
+            }
+
+            $this->stream = $stream;
+        }
+
+        public function getStream()
+        {
+            return $this->stream;
+        }
+
+        public function isValid(): bool
+        {
+            return is_resource($this->stream) && !feof($this->stream);
+        }
+
+        public function __clone()
+        {
+            throw new Error(sprintf('Trying to clone an uncloneable object of class %s', self::class));
+        }
+
+        public function __debugInfo(): array
+        {
+            return [];
+        }
+
+        public function __serialize(): array
+        {
+            throw new Exception(sprintf("Serialization of '%s' is not allowed", self::class));
+        }
+
+        public function __unserialize(array $data): void
+        {
+            throw new Exception(sprintf("Unserialization of '%s' is not allowed", self::class));
+        }
+    }
+}

--- a/src/Io/Poll/composer.json
+++ b/src/Io/Poll/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "symfony/polyfill-io-poll",
+    "type": "library",
+    "description": "Symfony polyfill for the Io\\Poll API",
+    "keywords": ["polyfill", "shim", "compatibility", "portable", "io", "poll"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Nicolas Grekas",
+            "email": "p@tchwork.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.1"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Polyfill\\Io\\Poll\\": "" },
+        "classmap": [ "Resources/stubs" ]
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "thanks": {
+            "name": "symfony/polyfill",
+            "url": "https://github.com/symfony/polyfill"
+        }
+    }
+}

--- a/src/Php86/README.md
+++ b/src/Php86/README.md
@@ -6,6 +6,11 @@ This component provides features added to PHP 8.6 core:
 - [`clamp`](https://wiki.php.net/rfc/clamp_v2)
 - `ARRAY_FILTER_USE_VALUE` constant
 - [`SortDirection`](https://wiki.php.net/rfc/sort_direction_enum)
+- `grapheme_strrev`
+
+The [`Io\Poll` API](https://wiki.php.net/rfc/poll_api) is provided by the
+dedicated [symfony/polyfill-io-poll](https://github.com/symfony/polyfill-io-poll)
+component, which requires PHP >= 8.1.
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/main/README.md).

--- a/tests/Io/Poll/PhptTest.php
+++ b/tests/Io/Poll/PhptTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Io\Poll;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Runs the phpt tests of the native implementation, borrowed verbatim from
+ * php-src (ext/standard/tests/poll), against the polyfill.
+ *
+ * @requires PHP >= 8.1
+ */
+class PhptTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (\PHP_VERSION_ID >= 80600) {
+            $this->markTestSkipped('The Io\Poll polyfill is only used on PHP < 8.6.');
+        }
+    }
+
+    /**
+     * @dataProvider providePhptFiles
+     */
+    public function testPhpt(string $file)
+    {
+        $sections = self::parse($file);
+
+        if (isset($sections['SKIPIF'])) {
+            $output = ltrim($this->execute($file, $sections['SKIPIF']));
+            if (0 === strpos($output, 'skip')) {
+                $this->markTestSkipped(trim(substr($output, 4)));
+            }
+        }
+
+        $output = rtrim(str_replace("\r\n", "\n", $this->execute($file, $sections['FILE'])));
+
+        if (isset($sections['EXPECTF'])) {
+            $expected = rtrim(str_replace("\r\n", "\n", $sections['EXPECTF']));
+            if (!preg_match(self::expectfToRegex($expected), $output)) {
+                $this->assertSame($expected, $output);
+            }
+            $this->addToAssertionCount(1);
+        } else {
+            $expected = rtrim(str_replace("\r\n", "\n", $sections['EXPECT']));
+            // object handles differ between native and polyfill runs
+            $normalize = static function (string $s) {
+                return preg_replace('/(object\([^)]++\))#\d+/', '$1', $s);
+            };
+            $this->assertSame($normalize($expected), $normalize($output));
+        }
+    }
+
+    public static function providePhptFiles(): array
+    {
+        $files = [];
+        foreach (glob(__DIR__.'/phpt/*.phpt') as $file) {
+            $files[basename($file, '.phpt')] = [$file];
+        }
+
+        return $files;
+    }
+
+    private static function parse(string $file): array
+    {
+        $sections = [];
+        $current = null;
+        foreach (file($file) as $line) {
+            if (preg_match('/^--([A-Z_]+)--\s*$/', $line, $m)) {
+                $current = $m[1];
+                $sections[$current] = '';
+            } elseif (null !== $current) {
+                $sections[$current] .= $line;
+            }
+        }
+
+        return $sections;
+    }
+
+    /**
+     * The code runs from a temporary file next to the phpt so that __DIR__
+     * resolves poll.inc; the autoloader is injected via auto_prepend_file
+     * since the phpt files are unmodified copies.
+     */
+    private function execute(string $phptFile, string $code): string
+    {
+        $phpFile = substr($phptFile, 0, -1);
+        file_put_contents($phpFile, $code);
+
+        $proc = proc_open([
+            \PHP_BINARY,
+            '-n',
+            '-d', 'error_reporting=-1',
+            '-d', 'display_errors=1',
+            '-d', 'auto_prepend_file='.\dirname(__DIR__, 3).'/vendor/autoload.php',
+            $phpFile,
+        ], [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+
+        try {
+            $stdout = stream_get_contents($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            proc_close($proc);
+        } finally {
+            unlink($phpFile);
+        }
+
+        return '' !== $stdout ? $stdout : $stderr;
+    }
+
+    private static function expectfToRegex(string $expected): string
+    {
+        return '~^'.strtr(preg_quote($expected, '~'), [
+            '%%' => '%',
+            '%e' => preg_quote(\DIRECTORY_SEPARATOR, '~'),
+            '%s' => '[^\r\n]+',
+            '%S' => '[^\r\n]*',
+            '%a' => '.+',
+            '%A' => '.*',
+            '%w' => '\s*',
+            '%i' => '[+-]?\d+',
+            '%d' => '\d+',
+            '%x' => '[0-9a-fA-F]+',
+            '%f' => '[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][+-]?\d+)?',
+            '%c' => '.',
+        ]).'$~s';
+    }
+}

--- a/tests/Io/Poll/PollTest.php
+++ b/tests/Io/Poll/PollTest.php
@@ -1,0 +1,947 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\Io\Poll;
+
+use Io\IoException;
+use Io\Poll\Backend;
+use Io\Poll\BackendUnavailableException;
+use Io\Poll\Context;
+use Io\Poll\Event;
+use Io\Poll\FailedHandleAddException;
+use Io\Poll\FailedPollOperationException;
+use Io\Poll\FailedPollWaitException;
+use Io\Poll\FailedWatcherModificationException;
+use Io\Poll\Handle;
+use Io\Poll\HandleAlreadyWatchedException;
+use Io\Poll\InactiveWatcherException;
+use Io\Poll\InvalidHandleException;
+use Io\Poll\PollException;
+use Io\Poll\Watcher;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @requires PHP >= 8.1
+ */
+class PollTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (\PHP_VERSION_ID >= 80600) {
+            $this->markTestSkipped('The Io\Poll polyfill is only used on PHP < 8.6; the native implementation has backend-specific behavior that cannot be reproduced.');
+        }
+    }
+
+    public function testBackendEnumCases()
+    {
+        $this->assertTrue(enum_exists(Backend::class));
+
+        $names = array_column(Backend::cases(), 'name');
+        $this->assertContains('Auto', $names);
+        $this->assertContains('Poll', $names);
+        $this->assertContains('Epoll', $names);
+        $this->assertContains('Kqueue', $names);
+        $this->assertContains('EventPorts', $names);
+        $this->assertContains('WSAPoll', $names);
+    }
+
+    public function testBackendAutoAndPollAreAvailable()
+    {
+        $this->assertTrue((Backend::Auto)->isAvailable());
+        $this->assertTrue((Backend::Poll)->isAvailable());
+    }
+
+    public function testBackendUnavailableInPolyfill()
+    {
+        $this->assertFalse((Backend::Epoll)->isAvailable());
+        $this->assertFalse((Backend::Kqueue)->isAvailable());
+        $this->assertFalse((Backend::EventPorts)->isAvailable());
+        $this->assertFalse((Backend::WSAPoll)->isAvailable());
+    }
+
+    public function testBackendGetAvailableBackends()
+    {
+        $available = Backend::getAvailableBackends();
+        $this->assertContains((Backend::Poll), $available);
+        $this->assertNotContains((Backend::Auto), $available);
+        $this->assertNotContains((Backend::Epoll), $available);
+    }
+
+    public function testBackendSupportsEdgeTriggering()
+    {
+        $this->assertFalse((Backend::Auto)->supportsEdgeTriggering());
+        $this->assertFalse((Backend::Poll)->supportsEdgeTriggering());
+    }
+
+    public function testEventEnumCases()
+    {
+        $this->assertTrue(enum_exists(Event::class));
+
+        $names = array_column(Event::cases(), 'name');
+        $this->assertContains('Read', $names);
+        $this->assertContains('Write', $names);
+        $this->assertContains('Error', $names);
+        $this->assertContains('HangUp', $names);
+        $this->assertContains('ReadHangUp', $names);
+        $this->assertContains('OneShot', $names);
+        $this->assertContains('EdgeTriggered', $names);
+    }
+
+    public function testHandleIsInterface()
+    {
+        $this->assertTrue(interface_exists(Handle::class));
+    }
+
+    public function testStreamPollHandleImplementsHandle()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $this->assertInstanceOf(Handle::class, $handle);
+        $this->assertSame($stream, $handle->getStream());
+        $this->assertTrue($handle->isValid());
+        fclose($stream);
+        $this->assertFalse($handle->isValid());
+    }
+
+    public function testStreamPollHandleRejectsNonStream()
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('StreamPollHandle::__construct(): Argument #1 ($stream) must be an open stream resource');
+        new \StreamPollHandle('not a stream');
+    }
+
+    public function testStreamPollHandleRejectsClosedResource()
+    {
+        $stream = fopen('php://temp', 'r+');
+        fclose($stream);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('StreamPollHandle::__construct(): Argument #1 ($stream) must be an open stream resource');
+        new \StreamPollHandle($stream);
+    }
+
+    public function testStreamPollHandleIsValidFalseAtEof()
+    {
+        $stream = tmpfile();
+        fwrite($stream, 'x');
+        rewind($stream);
+        $handle = new \StreamPollHandle($stream);
+        $this->assertTrue($handle->isValid());
+
+        fread($stream, 8192);
+        $this->assertTrue(feof($stream));
+        $this->assertFalse($handle->isValid());
+
+        fclose($stream);
+    }
+
+    public function testExceptionHierarchy()
+    {
+        $this->assertTrue(class_exists(IoException::class));
+        $this->assertTrue(class_exists(PollException::class));
+        $this->assertTrue(class_exists(FailedPollOperationException::class));
+        $this->assertTrue(class_exists(BackendUnavailableException::class));
+        $this->assertTrue(class_exists(InactiveWatcherException::class));
+        $this->assertTrue(class_exists(HandleAlreadyWatchedException::class));
+        $this->assertTrue(class_exists(InvalidHandleException::class));
+
+        $this->assertTrue(is_subclass_of(PollException::class, IoException::class));
+        $this->assertTrue(is_subclass_of(FailedPollOperationException::class, PollException::class));
+        $this->assertTrue(is_subclass_of(BackendUnavailableException::class, PollException::class));
+        $this->assertTrue(is_subclass_of(InactiveWatcherException::class, PollException::class));
+        $this->assertTrue(is_subclass_of(HandleAlreadyWatchedException::class, PollException::class));
+        $this->assertTrue(is_subclass_of(InvalidHandleException::class, PollException::class));
+
+        $this->assertTrue(is_subclass_of(IoException::class, \Exception::class));
+    }
+
+    public function testErrorConstantsOnFailedPollOperationException()
+    {
+        $constants = [
+            'ERROR_NONE', 'ERROR_SYSTEM', 'ERROR_NOMEM', 'ERROR_INVALID',
+            'ERROR_EXISTS', 'ERROR_NOTFOUND', 'ERROR_TIMEOUT', 'ERROR_INTERRUPTED',
+            'ERROR_PERMISSION', 'ERROR_TOOBIG', 'ERROR_AGAIN', 'ERROR_NOSUPPORT',
+        ];
+
+        foreach ($constants as $const) {
+            $this->assertTrue(
+                \defined(FailedPollOperationException::class.'::'.$const),
+                "FailedPollOperationException::$const is defined"
+            );
+        }
+    }
+
+    public function testContextDefaultBackendIsPoll()
+    {
+        $context = new Context();
+        $this->assertSame(Backend::Poll, $context->getBackend());
+    }
+
+    public function testContextExplicitPollBackend()
+    {
+        $context = new Context(Backend::Poll);
+        $this->assertSame(Backend::Poll, $context->getBackend());
+    }
+
+    public function testContextUnavailableBackendThrows()
+    {
+        $this->expectException(BackendUnavailableException::class);
+        $this->expectExceptionMessage('Backend Epoll not available');
+        new Context(Backend::Epoll);
+    }
+
+    public function testContextAddReturnsWatcher()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+
+        $watcher = $context->add($handle, [Event::Read], 'user data');
+
+        $this->assertInstanceOf(Watcher::class, $watcher);
+        $this->assertSame($handle, $watcher->getHandle());
+        $this->assertSame([Event::Read], $watcher->getWatchedEvents());
+        $this->assertSame('user data', $watcher->getData());
+        $this->assertTrue($watcher->isActive());
+        $this->assertSame([], $watcher->getTriggeredEvents());
+
+        fclose($stream);
+    }
+
+    public function testContextAddNormalizesWatchedEvents()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+
+        $watcher = $context->add($handle, [Event::OneShot, Event::Read, Event::Read]);
+
+        $this->assertSame([Event::Read, Event::OneShot], $watcher->getWatchedEvents());
+
+        fclose($stream);
+    }
+
+    public function testContextAddDuplicateHandleThrows()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+        $context->add($handle, [Event::Read]);
+
+        $this->expectException(HandleAlreadyWatchedException::class);
+        $this->expectExceptionMessage('Handle already added');
+        try {
+            $context->add($handle, [Event::Write]);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testContextAddClosedStreamThrows()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        fclose($stream);
+        $context = new Context();
+
+        $this->expectException(InvalidHandleException::class);
+        $this->expectExceptionMessage('Invalid handle for polling');
+        $context->add($handle, [Event::Read]);
+    }
+
+    public function testContextAddMemoryStreamThrows()
+    {
+        $stream = fopen('php://memory', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+
+        $this->expectException(InvalidHandleException::class);
+        $this->expectExceptionMessage('Invalid handle for polling');
+        try {
+            $context->add($handle, [Event::Read]);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testContextAddEdgeTriggeredThrows()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+
+        try {
+            $context->add($handle, [Event::Read, Event::EdgeTriggered]);
+            $this->fail('FailedHandleAddException was not thrown');
+        } catch (FailedHandleAddException $e) {
+            $this->assertSame('Failed to add handle', $e->getMessage());
+            $this->assertSame(FailedPollOperationException::ERROR_NOSUPPORT, $e->getCode());
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testContextAddEmptyEventsThrows()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Io\\Poll\\Context::add(): Argument #2 ($events) must be array of Event enums');
+        try {
+            $context->add($handle, []);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testContextAddInvalidEventsThrows()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Io\\Poll\\Context::add(): Argument #2 ($events) must be array of Event enums');
+        try {
+            $context->add($handle, ['nope']);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testWaitNegativeTimeoutSecondsThrows()
+    {
+        $context = new Context();
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('Io\\Poll\\Context::wait(): Argument #1 ($timeoutSeconds) must be greater than or equal to 0');
+        $context->wait(-1);
+    }
+
+    public function testWaitNegativeTimeoutMicrosecondsThrows()
+    {
+        $context = new Context();
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('Io\\Poll\\Context::wait(): Argument #2 ($timeoutMicroseconds) must be greater than or equal to 0');
+        $context->wait(0, -1);
+    }
+
+    public function testWaitNonPositiveMaxEventsThrows()
+    {
+        $context = new Context();
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('Io\\Poll\\Context::wait(): Argument #3 ($maxEvents) must be greater than 0');
+        $context->wait(0, 0, 0);
+    }
+
+    public function testWaitThrowsWhenInterruptedBySignal()
+    {
+        if (!\function_exists('pcntl_alarm') || !\function_exists('pcntl_signal')) {
+            $this->markTestSkipped('The pcntl extension is required.');
+        }
+
+        pcntl_signal(\SIGALRM, static function () {}, false);
+
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        $context = new Context();
+        $context->add(new \StreamPollHandle($r), [Event::Read]);
+
+        pcntl_alarm(1);
+
+        $this->expectException(FailedPollWaitException::class);
+        $this->expectExceptionMessage('Poll wait failed');
+        try {
+            $context->wait(10);
+        } finally {
+            pcntl_alarm(0);
+            pcntl_signal_dispatch();
+            pcntl_signal(\SIGALRM, \SIG_DFL);
+            fclose($r);
+            fclose($w);
+        }
+    }
+
+    public function testWaitNullTimeoutIgnoresNegativeMicroseconds()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        fwrite($w, 'hello');
+        $context = new Context();
+        $watcher = $context->add(new \StreamPollHandle($r), [Event::Read]);
+
+        $result = $context->wait(null, -1);
+
+        $this->assertSame([$watcher], $result);
+
+        fclose($r);
+        fclose($w);
+    }
+
+    public function testWaitImmediateTimeoutReturnsEmpty()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        $handle = new \StreamPollHandle($r);
+        $context = new Context();
+        $context->add($handle, [Event::Read]);
+
+        $result = $context->wait(0, 0);
+
+        $this->assertSame([], $result);
+        fclose($r);
+        fclose($w);
+    }
+
+    public function testWaitDetectsReadable()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        fwrite($w, 'hello');
+
+        $context = new Context();
+        $handle = new \StreamPollHandle($r);
+        $watcher = $context->add($handle, [Event::Read]);
+
+        $result = $context->wait(0, 0);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($watcher, $result[0]);
+        $this->assertTrue($watcher->hasTriggered(Event::Read));
+        $this->assertSame([Event::Read], $watcher->getTriggeredEvents());
+
+        fclose($r);
+        fclose($w);
+    }
+
+    public function testWaitDetectsWritable()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+
+        $context = new Context();
+        $handle = new \StreamPollHandle($w);
+        $watcher = $context->add($handle, [Event::Write]);
+
+        $result = $context->wait(0, 0);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($watcher, $result[0]);
+        $this->assertTrue($watcher->hasTriggered(Event::Write));
+
+        fclose($r);
+        fclose($w);
+    }
+
+    public function testWaitBlocksUntilTimeoutWithNoEvents()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        $handle = new \StreamPollHandle($r);
+        $context = new Context();
+        $context->add($handle, [Event::Read]);
+
+        $start = hrtime(true);
+        $result = $context->wait(0, 50000);
+        $elapsed = (hrtime(true) - $start) / 1000000;
+
+        $this->assertSame([], $result);
+        $this->assertGreaterThanOrEqual(40, $elapsed);
+
+        fclose($r);
+        fclose($w);
+    }
+
+    public function testWaitDoesNotReturnEarlyOnUnwatchedReadiness()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        fwrite($w, 'pending data');
+
+        $context = new Context();
+        $context->add(new \StreamPollHandle($r), [Event::HangUp]);
+
+        $start = hrtime(true);
+        $result = $context->wait(0, 60000);
+        $elapsed = (hrtime(true) - $start) / 1000000;
+
+        $this->assertSame([], $result);
+        $this->assertGreaterThanOrEqual(50, $elapsed);
+
+        fclose($r);
+        fclose($w);
+    }
+
+    public function testWaitReportsReadAndHangUpOnClosedSocketPeer()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+
+        $context = new Context();
+        $handle = new \StreamPollHandle($r);
+        $watcher = $context->add($handle, [Event::Read]);
+
+        fclose($w);
+
+        $result = $context->wait(0, 0);
+
+        $this->assertSame([$watcher], $result);
+        $this->assertSame([Event::Read, Event::HangUp], $watcher->getTriggeredEvents());
+
+        fclose($r);
+    }
+
+    public function testWaitReportsHangUpEvenWhenNotWatched()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+
+        $context = new Context();
+        $watcher = $context->add(new \StreamPollHandle($r), [Event::ReadHangUp]);
+
+        fclose($w);
+
+        $result = $context->wait(0, 0);
+
+        $this->assertSame([$watcher], $result);
+        $this->assertSame([Event::HangUp], $watcher->getTriggeredEvents());
+
+        fclose($r);
+    }
+
+    public function testWaitReportsReadOnRegularFileAtEof()
+    {
+        $stream = tmpfile();
+        fwrite($stream, 'x');
+        rewind($stream);
+        fread($stream, 8192);
+        $this->assertTrue(feof($stream));
+
+        $context = new Context();
+        $watcher = $context->add(new \StreamPollHandle($stream), [Event::Read]);
+
+        $result = $context->wait(0, 0);
+
+        $this->assertSame([$watcher], $result);
+        $this->assertTrue($watcher->hasTriggered(Event::Read));
+        $this->assertFalse($watcher->hasTriggered(Event::HangUp));
+
+        fclose($stream);
+    }
+
+    public function testWaitReportsHangUpOnPipeAtEof()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Pipes are not selectable on Windows.');
+        }
+
+        $pipe = popen('echo x', 'r');
+        while (!feof($pipe)) {
+            fread($pipe, 8192);
+        }
+
+        $context = new Context();
+        $watcher = $context->add(new \StreamPollHandle($pipe), [Event::Read]);
+
+        $result = $context->wait(0, 0);
+
+        $this->assertSame([$watcher], $result);
+        $this->assertTrue($watcher->hasTriggered(Event::HangUp));
+        $this->assertFalse($watcher->hasTriggered(Event::Read));
+
+        pclose($pipe);
+    }
+
+    public function testWaitReportsReadForEmptyUdpDatagram()
+    {
+        $server = stream_socket_server('udp://127.0.0.1:0', $errno, $errstr, \STREAM_SERVER_BIND);
+        $client = stream_socket_client('udp://'.stream_socket_get_name($server, false));
+        stream_socket_sendto($client, '');
+
+        $context = new Context();
+        $watcher = $context->add(new \StreamPollHandle($server), [Event::Read]);
+
+        $result = $context->wait(1, 0);
+
+        $this->assertSame([$watcher], $result);
+        $this->assertTrue($watcher->hasTriggered(Event::Read));
+        $this->assertFalse($watcher->hasTriggered(Event::HangUp));
+
+        fclose($client);
+        fclose($server);
+    }
+
+    public function testWaitReportsReadOnReadableNonSocketStream()
+    {
+        $stream = tmpfile();
+        fwrite($stream, 'data');
+        rewind($stream);
+        $this->assertFalse(feof($stream));
+
+        $context = new Context();
+        $watcher = $context->add(new \StreamPollHandle($stream), [Event::Read]);
+
+        $result = $context->wait(0, 0);
+
+        $this->assertSame([$watcher], $result);
+        $this->assertTrue($watcher->hasTriggered(Event::Read));
+        $this->assertFalse($watcher->hasTriggered(Event::HangUp));
+
+        fclose($stream);
+    }
+
+    public function testWaitRetainsTriggeredEventsWhenNotRetriggered()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        fwrite($w, 'hello');
+
+        $context = new Context();
+        $watcher = $context->add(new \StreamPollHandle($r), [Event::Read]);
+
+        $context->wait(0, 0);
+        $this->assertSame([Event::Read], $watcher->getTriggeredEvents());
+
+        fread($r, 5);
+
+        $result = $context->wait(0, 0);
+        $this->assertSame([], $result);
+        $this->assertSame([Event::Read], $watcher->getTriggeredEvents());
+
+        fclose($r);
+        fclose($w);
+    }
+
+    public function testWaitMaxEventsLimitsReturn()
+    {
+        [$r1, $w1] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        [$r2, $w2] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        fwrite($w1, 'a');
+        fwrite($w2, 'b');
+
+        $context = new Context();
+        $context->add(new \StreamPollHandle($r1), [Event::Read]);
+        $context->add(new \StreamPollHandle($r2), [Event::Read]);
+
+        $result = $context->wait(0, 0, 1);
+        $this->assertCount(1, $result);
+
+        fclose($r1);
+        fclose($w1);
+        fclose($r2);
+        fclose($w2);
+    }
+
+    public function testWaitReturnsImmediatelyWhenAllHandlesClosed()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        $context = new Context();
+        $watcher = $context->add(new \StreamPollHandle($r), [Event::Read]);
+
+        fclose($r);
+        fclose($w);
+
+        $start = hrtime(true);
+        $result = $context->wait(5, 0);
+        $elapsed = (hrtime(true) - $start) / 1000000;
+
+        $this->assertSame([], $result);
+        $this->assertLessThan(1000, $elapsed);
+        $this->assertTrue($watcher->isActive());
+
+        $start = hrtime(true);
+        $result = $context->wait(0, 50000);
+        $elapsed = (hrtime(true) - $start) / 1000000;
+
+        $this->assertSame([], $result);
+        $this->assertGreaterThanOrEqual(40, $elapsed);
+    }
+
+    public function testWaitOneShotKeepsWatcherActive()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        fwrite($w, 'x');
+
+        $context = new Context();
+        $handle = new \StreamPollHandle($r);
+        $watcher = $context->add($handle, [Event::Read, Event::OneShot]);
+
+        $result = $context->wait(0, 0);
+        $this->assertCount(1, $result);
+        $this->assertTrue($watcher->isActive());
+
+        $result = $context->wait(0, 0);
+        $this->assertSame([], $result);
+
+        try {
+            $watcher->modifyEvents([Event::Read]);
+            $this->fail('FailedWatcherModificationException was not thrown');
+        } catch (FailedWatcherModificationException $e) {
+            $this->assertSame('Failed to modify watcher in polling system', $e->getMessage());
+            $this->assertSame(FailedPollOperationException::ERROR_NOTFOUND, $e->getCode());
+        }
+
+        $watcher->remove();
+        $this->assertFalse($watcher->isActive());
+
+        $watcher2 = $context->add($handle, [Event::Read]);
+        $this->assertTrue($watcher2->isActive());
+
+        fclose($r);
+        fclose($w);
+    }
+
+    public function testWatcherRemove()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+        $watcher = $context->add($handle, [Event::Read]);
+
+        $this->assertTrue($watcher->isActive());
+        $watcher->remove();
+        $this->assertFalse($watcher->isActive());
+
+        $watcher2 = $context->add($handle, [Event::Read]);
+        $this->assertTrue($watcher2->isActive());
+
+        fclose($stream);
+    }
+
+    public function testWatcherRemoveSucceedsOnClosedStream()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        $context = new Context();
+        $watcher = $context->add(new \StreamPollHandle($r), [Event::Read]);
+
+        fclose($r);
+        fclose($w);
+
+        $watcher->remove();
+        $this->assertFalse($watcher->isActive());
+    }
+
+    public function testWatcherRemoveTwiceThrows()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+        $watcher = $context->add($handle, [Event::Read]);
+        $watcher->remove();
+
+        $this->expectException(InactiveWatcherException::class);
+        $this->expectExceptionMessage('Cannot remove inactive watcher');
+        try {
+            $watcher->remove();
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testWatcherModifyEvents()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+        $watcher = $context->add($handle, [Event::Read]);
+
+        $watcher->modifyEvents([Event::Write]);
+        $this->assertSame([Event::Write], $watcher->getWatchedEvents());
+
+        fclose($stream);
+    }
+
+    public function testWatcherModifyEventsRejectsEdgeTriggered()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+        $watcher = $context->add($handle, [Event::Read]);
+
+        try {
+            $watcher->modifyEvents([Event::Read, Event::EdgeTriggered]);
+            $this->fail('FailedWatcherModificationException was not thrown');
+        } catch (FailedWatcherModificationException $e) {
+            $this->assertSame('Failed to modify watcher in polling system', $e->getMessage());
+            $this->assertSame(FailedPollOperationException::ERROR_NOSUPPORT, $e->getCode());
+        } finally {
+            fclose($stream);
+        }
+
+        $this->assertSame([Event::Read], $watcher->getWatchedEvents());
+    }
+
+    public function testWatcherModifyEventsOnClosedStreamThrows()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+        $watcher = $context->add($handle, [Event::Read]);
+
+        fclose($stream);
+
+        $this->expectException(InvalidHandleException::class);
+        $this->expectExceptionMessage('Invalid handle for polling');
+        $watcher->modifyEvents([Event::Write]);
+    }
+
+    public function testWatcherModifyData()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+        $watcher = $context->add($handle, [Event::Read], 'old');
+
+        $watcher->modifyData('new');
+        $this->assertSame('new', $watcher->getData());
+        $this->assertSame([Event::Read], $watcher->getWatchedEvents());
+
+        fclose($stream);
+    }
+
+    public function testWatcherModifyBoth()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+        $watcher = $context->add($handle, [Event::Read], 'old');
+
+        $watcher->modify([Event::Write], 'new');
+        $this->assertSame([Event::Write], $watcher->getWatchedEvents());
+        $this->assertSame('new', $watcher->getData());
+
+        fclose($stream);
+    }
+
+    public function testWatcherModifyPreservesDataWhenOmitted()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+        $watcher = $context->add($handle, [Event::Read], 'payload');
+
+        $watcher->modify([Event::Write]);
+        $this->assertSame('payload', $watcher->getData());
+
+        $watcher->modify([Event::Read], null);
+        $this->assertNull($watcher->getData());
+
+        fclose($stream);
+    }
+
+    public function testWatcherModifyAfterRemoveThrows()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+        $watcher = $context->add($handle, [Event::Read]);
+        $watcher->remove();
+
+        $this->expectException(InactiveWatcherException::class);
+        $this->expectExceptionMessage('Cannot modify inactive watcher');
+        try {
+            $watcher->modifyEvents([Event::Write]);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testWatcherInactiveAfterContextDestroyed()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+        $watcher = $context->add($handle, [Event::Read]);
+
+        $this->assertTrue($watcher->isActive());
+        unset($context);
+        $this->assertFalse($watcher->isActive());
+
+        $this->expectException(InactiveWatcherException::class);
+        $this->expectExceptionMessage('Cannot remove inactive watcher');
+        try {
+            $watcher->remove();
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    /**
+     * @dataProvider provideInvalidModifyEvents
+     */
+    public function testWatcherModifyRejectsInvalidEvents(string $method, array $events)
+    {
+        $stream = fopen('php://temp', 'r+');
+        $handle = new \StreamPollHandle($stream);
+        $context = new Context();
+        $watcher = $context->add($handle, [Event::Read]);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage(\sprintf('Io\\Poll\\Watcher::%s(): Argument #1 ($events) must be array of Event enums', $method));
+        try {
+            $watcher->$method($events);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public static function provideInvalidModifyEvents(): array
+    {
+        return [
+            'modify empty' => ['modify', []],
+            'modify invalid' => ['modify', ['nope']],
+            'modifyEvents empty' => ['modifyEvents', []],
+            'modifyEvents invalid' => ['modifyEvents', ['nope']],
+        ];
+    }
+
+    public function testWatcherConstructorIsPrivate()
+    {
+        $ref = new \ReflectionMethod(Watcher::class, '__construct');
+        $this->assertTrue($ref->isPrivate());
+    }
+
+    /**
+     * @dataProvider provideNotSerializable
+     */
+    public function testNotSerializable(string $class, \Closure $factory)
+    {
+        $instance = $factory();
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Serialization of '$class' is not allowed");
+        serialize($instance);
+    }
+
+    public static function provideNotSerializable(): array
+    {
+        return [
+            'Context' => ['Io\\Poll\\Context', static function () {
+                return new Context();
+            }],
+            'StreamPollHandle' => ['StreamPollHandle', static function () {
+                return new \StreamPollHandle(fopen('php://temp', 'r+'));
+            }],
+            'Watcher' => ['Io\\Poll\\Watcher', static function () {
+                $ctx = new Context();
+
+                return $ctx->add(new \StreamPollHandle(fopen('php://temp', 'r+')), [Event::Read]);
+            }],
+        ];
+    }
+
+    public function testTimeoutMicroOverflowIntoSeconds()
+    {
+        [$r, $w] = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        $handle = new \StreamPollHandle($r);
+        $context = new Context();
+        $context->add($handle, [Event::Read]);
+
+        $start = hrtime(true);
+        $context->wait(0, 1100000);
+        $elapsed = (hrtime(true) - $start) / 1000000;
+
+        $this->assertGreaterThanOrEqual(1000, $elapsed);
+
+        fclose($r);
+        fclose($w);
+    }
+}

--- a/tests/Io/Poll/phpt/poll.inc
+++ b/tests/Io/Poll/phpt/poll.inc
@@ -1,0 +1,321 @@
+<?php
+// stream Poll Testing helper
+
+function pt_new_stream_poll(): Io\Poll\Context {
+    $backend = getenv('POLL_TEST_BACKEND');
+    if ($backend === false) {
+        return new Io\Poll\Context(Io\Poll\Backend::Auto);
+    }
+
+    // Map string to enum case using match
+    $backend_enum = match(strtolower($backend)) {
+        'auto' => Io\Poll\Backend::Auto,
+        'poll' => Io\Poll\Backend::Poll,
+        'epoll' => Io\Poll\Backend::Epoll,
+        'kqueue' => Io\Poll\Backend::Kqueue,
+        'eventports' => Io\Poll\Backend::EventPorts,
+        'wsapoll' => Io\Poll\Backend::WSAPoll,
+        default => throw new ValueError("Unknown backend: $backend"),
+    };
+
+    return new Io\Poll\Context($backend_enum);
+}
+
+function pt_stream_poll_add($poll_ctx, $stream, $events, $data = null): Io\Poll\Watcher {
+    return $poll_ctx->add(new StreamPollHandle($stream), $events, $data);
+}
+
+function pt_skip_for_backend($backend, $msg): void {
+    $backends_to_skip = is_array($backend) ? $backend : array($backend);
+    $current_backend = pt_new_stream_poll()->getBackend();
+    if (in_array($current_backend->name, $backends_to_skip)) {
+        die("skip backend {$current_backend->name} $msg\n");
+    }
+}
+
+function pt_new_socket_pair(): array {
+    $domain = (strtoupper(substr(PHP_OS, 0, 3) == 'WIN') ? STREAM_PF_INET : STREAM_PF_UNIX);
+    $sockets = stream_socket_pair($domain, STREAM_SOCK_STREAM, 0);
+    if ($sockets === false) {
+        die("Cannot create socket pair\n");
+    }
+    return $sockets;
+}
+
+function pt_new_tcp_socket_pair(): array {
+    $server = stream_socket_server("tcp://127.0.0.1:0", $errno, $errstr);
+    if (!$server) {
+        die("Cannot create TCP server: $errstr\n");
+    }
+    $address = stream_socket_get_name($server, false);
+
+    $client = stream_socket_client("tcp://$address", $errno, $errstr);
+    if (!$client) {
+        fclose($server);
+        die("Cannot connect to TCP server: $errstr\n");
+    }
+
+    $server_conn = stream_socket_accept($server);
+    if (!$server_conn) {
+        fclose($server);
+        fclose($client);
+        die("Cannot accept connection\n");
+    }
+
+    // Close the listening socket (no longer needed)
+    fclose($server);
+
+    return [$client, $server_conn];
+}
+
+function pt_new_tcp_socket_connections(int $num_conns): array {
+    $server = stream_socket_server("tcp://127.0.0.1:0", $errno, $errstr);
+    if (!$server) {
+        die("Cannot create TCP server: $errstr\n");
+    }
+    $address = stream_socket_get_name($server, false);
+
+    $clients = [];
+    $server_conns = [];
+    for ($i = 0; $i < $num_conns; ++$i) {
+        $clients[$i] = stream_socket_client("tcp://$address", $errno, $errstr);
+        if (!$clients[$i]) {
+            fclose($server);
+            die("Cannot connect to TCP server: $errstr\n");
+        }
+
+        $server_conns[$i] = stream_socket_accept($server);
+        if (!$server_conns[$i]) {
+            fclose($server);
+            die("Cannot accept connection\n");
+        }
+    }
+
+    // Close the listening socket (no longer needed)
+    fclose($server);
+
+    return [$clients, $server_conns];
+}
+
+function pt_write_sleep($stream, $data, $delay = 10000): int|false {
+    $result = fwrite($stream, $data);
+    usleep($delay);
+    return $result;
+}
+
+function pt_event_array_to_string(array $events): string {
+    $names = [];
+    foreach ($events as $event) {
+        $names[] = $event->name;
+    }
+    return empty($names) ? 'NONE' : implode('|', $names);
+}
+
+function pt_print_events($watchers, $read_data = false): void {
+    if (!is_array($watchers)) {
+        die("Events must be an array\n");
+    }
+    echo "Events count: " . count($watchers) . "\n";
+    foreach ($watchers as $i => $watcher) {
+        if (!$watcher instanceof Io\Poll\Watcher) {
+            die('Invalid event type');
+        }
+        echo "Event[$i]: " . pt_event_array_to_string($watcher->getTriggeredEvents()) . ", user data: " . $watcher->getData();
+        if ($read_data && $watcher->hasTriggered(Io\Poll\Event::Read)) {
+            $data = fread($watcher->getHandle()->getStream(), 1024);
+            echo ", read data: '$data'";
+        }
+        echo "\n";
+    }
+}
+
+function pt_expect_events($watchers, $expected, ?Io\Poll\Context $poll_ctx = null): void {
+    if (!is_array($watchers)) {
+        die("Events must be an array\n");
+    }
+
+    if (!is_array($expected)) {
+        die("Expected events must be an array\n");
+    }
+
+    $event_count = count($watchers);
+    $expected_count = count($expected);
+
+    // Get the current backend for backend-specific expectations
+    $backend = $poll_ctx ? $poll_ctx->getBackend()->name : 'unknown';
+
+    if ($event_count !== $expected_count) {
+        echo "Event count mismatch: got $event_count, expected $expected_count\n";
+        pt_print_mismatched_events($watchers, $expected, [], $backend);
+        return;
+    }
+
+    // Convert events to comparable format for matching
+    $actual_events = [];
+    foreach ($watchers as $watcher) {
+        if (!$watcher instanceof Io\Poll\Watcher) {
+            die('Invalid event type');
+        }
+
+        $event_data = [
+            'events' => $watcher->getTriggeredEvents(),
+            'data' => $watcher->getData(),
+        ];
+
+        $actual_events[] = $event_data;
+    }
+
+    // Resolve backend-specific expectations
+    $resolved_expected = [];
+    foreach ($expected as $exp_event) {
+        $resolved_event = $exp_event;
+
+        // Check if events field is a backend-specific map (associative array with string keys)
+        if (isset($exp_event['events']) && is_array($exp_event['events'])) {
+            // Check if it's a backend map (has string keys like 'default', 'Kqueue', etc.)
+            $keys = array_keys($exp_event['events']);
+            $is_backend_map = false;
+            foreach ($keys as $key) {
+                if (is_string($key)) {
+                    $is_backend_map = true;
+                    break;
+                }
+            }
+
+            if ($is_backend_map) {
+                // It's a backend-specific map, resolve it
+                $resolved_event['events'] = pt_resolve_backend_specific_value($exp_event['events'], $backend);
+            }
+            // Otherwise it's already an array of Event enums, leave it as-is
+        }
+
+        $resolved_expected[] = $resolved_event;
+    }
+
+    // Try to match each expected event with an actual event
+    $matched = [];
+    $unmatched_expected = [];
+
+    foreach ($resolved_expected as $exp_idx => $exp_event) {
+        $found_match = false;
+
+        foreach ($actual_events as $act_idx => $act_event) {
+            if (isset($matched[$act_idx])) {
+                continue; // Already matched
+            }
+
+            // Check if events and data match
+            if (pt_events_equal($act_event['events'], $exp_event['events']) &&
+                $act_event['data'] === $exp_event['data']) {
+
+                // If read data is expected, check it
+                if (isset($exp_event['read'])) {
+                    $read_data = fread($watchers[$act_idx]->getHandle()->getStream(), 1024);
+                    if ($read_data !== $exp_event['read']) {
+                        continue; // Read data doesn't match
+                    }
+                }
+
+                $matched[$act_idx] = $exp_idx;
+                $found_match = true;
+                break;
+            }
+        }
+
+        if (!$found_match) {
+            $unmatched_expected[] = $exp_event;
+        }
+    }
+
+    // Check if all events matched
+    if (count($matched) === $event_count && empty($unmatched_expected)) {
+        echo "Events matched - count: $event_count\n";
+    } else {
+        echo "Events did not match:\n";
+        pt_print_mismatched_events($watchers, $expected, $matched, $backend);
+    }
+}
+
+function pt_events_equal($actual, $expected): bool {
+    // Both should be arrays of Event enums
+    if (!is_array($actual) || !is_array($expected)) {
+        return false;
+    }
+
+    if (count($actual) !== count($expected)) {
+        return false;
+    }
+
+    // Sort both arrays by event name for comparison
+    $actual_names = array_map(fn($e) => $e->name, $actual);
+    $expected_names = array_map(fn($e) => $e->name, $expected);
+    sort($actual_names);
+    sort($expected_names);
+
+    return $actual_names === $expected_names;
+}
+
+function pt_resolve_backend_specific_value($backend_map, $current_backend) {
+    // Direct backend match
+    if (isset($backend_map[$current_backend])) {
+        return $backend_map[$current_backend];
+    }
+
+    // Check for multi-backend keys (e.g., "Kqueue|EventPorts")
+    foreach ($backend_map as $key => $value) {
+        if (strpos($key, '|') !== false) {
+            $backends = array_map('trim', explode('|', $key));
+            if (in_array($current_backend, $backends)) {
+                return $value;
+            }
+        }
+    }
+
+    // Fall back to default
+    if (isset($backend_map['default'])) {
+        return $backend_map['default'];
+    }
+
+    // If no match found, this is an error
+    die("No backend-specific value found for '$current_backend' and no default specified\n");
+}
+
+function pt_print_mismatched_events($actual_watchers, $expected_watchers, $matched = [], $backend_name = null): void {
+    echo "Actual events:\n";
+    foreach ($actual_watchers as $i => $watcher) {
+        $match_status = isset($matched[$i]) ? " [MATCHED]" : " [UNMATCHED]";
+        $watcher_names = pt_event_array_to_string($watcher->getTriggeredEvents());
+        echo "  Event[$i]: $watcher_names, user data: " . $watcher->getData() . $match_status . "\n";
+    }
+
+    echo "Expected events:\n";
+    foreach ($expected_watchers as $i => $exp_event) {
+        $was_matched = in_array($i, $matched);
+        $match_status = $was_matched ? " [MATCHED]" : " [UNMATCHED]";
+
+        $events_value = $exp_event['events'];
+        
+        // Check if it's a backend-specific map
+        if (is_array($events_value) && $backend_name !== null) {
+            $keys = array_keys($events_value);
+            $is_backend_map = false;
+            foreach ($keys as $key) {
+                if (is_string($key)) {
+                    $is_backend_map = true;
+                    break;
+                }
+            }
+            
+            if ($is_backend_map) {
+                $events_value = pt_resolve_backend_specific_value($events_value, $backend_name);
+            }
+        }
+
+        $watcher_names = is_array($events_value) ? pt_event_array_to_string($events_value) : 'INVALID';
+        echo "  Event[$i]: $watcher_names, user data: " . $exp_event['data'];
+        if (isset($exp_event['read'])) {
+            echo ", read data: '" . $exp_event['read'] . "'";
+        }
+        echo $match_status . "\n";
+    }
+}

--- a/tests/Io/Poll/phpt/poll_backend_getAvailableBackends.phpt
+++ b/tests/Io/Poll/phpt/poll_backend_getAvailableBackends.phpt
@@ -1,0 +1,12 @@
+--TEST--
+\Io\Poll\Backend::getAvailableBackends() - loop
+--FILE--
+<?php
+$objs = [];
+foreach (($expr1 = \Io\Poll\Backend::getAvailableBackends()) as $expr2) {
+    $objs[] = $expr2;
+}
+echo "Okay\n";
+?>
+--EXPECT--
+Okay

--- a/tests/Io/Poll/phpt/poll_clone_not_allowed.phpt
+++ b/tests/Io/Poll/phpt/poll_clone_not_allowed.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Io\Poll: Context, Watcher and StreamPollHandle are not cloneable
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($r, $w) = pt_new_socket_pair();
+$ctx = pt_new_stream_poll();
+$handle = new StreamPollHandle($r);
+$watcher = $ctx->add($handle, [Io\Poll\Event::Read]);
+
+foreach ([$ctx, $handle, $watcher] as $obj) {
+    try {
+        clone $obj;
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+echo "done\n";
+?>
+--EXPECT--
+Trying to clone an uncloneable object of class Io\Poll\Context
+Trying to clone an uncloneable object of class StreamPollHandle
+Trying to clone an uncloneable object of class Io\Poll\Watcher
+done

--- a/tests/Io/Poll/phpt/poll_ctx_backend_unix.phpt
+++ b/tests/Io/Poll/phpt/poll_ctx_backend_unix.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Poll context - backend on Unix
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+    die ("skip not for Windows");
+}
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+// this just prints default poll ctx
+$poll_ctx = new Io\Poll\Context();
+var_dump($poll_ctx->getBackend());
+// test with poll that is always available on Unix systems
+$poll_ctx = new Io\Poll\Context(Io\Poll\Backend::Poll);
+$backend = $poll_ctx->getBackend();
+var_dump($backend->name);
+try {
+    new Io\Poll\Context(Io\Poll\Backend::WSAPoll);
+} catch (\Io\Poll\BackendUnavailableException $e) {
+    var_dump($e->getMessage());
+}
+?>
+--EXPECTF--
+enum(Io\Poll\Backend::%s)
+string(4) "Poll"
+string(29) "Backend WSAPoll not available"

--- a/tests/Io/Poll/phpt/poll_ctx_backend_windows.phpt
+++ b/tests/Io/Poll/phpt/poll_ctx_backend_windows.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Poll context - backend on Windows
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) != 'WIN') {
+    die ("skip only for Windows");
+}
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+// this just prints default poll ctx
+$poll_ctx = new Io\Poll\Context();
+var_dump($poll_ctx->getBackend());
+// test with WSAPoll
+$poll_ctx = new Io\Poll\Context(Io\Poll\Backend::WSAPoll);
+$backend = $poll_ctx->getBackend();
+var_dump($backend->name);
+try {
+    new Io\Poll\Context(Io\Poll\Backend::Epoll);
+} catch (\Io\Poll\BackendUnavailableException $e) {
+    var_dump($e->getMessage());
+}
+?>
+--EXPECTF--
+enum(Io\Poll\Backend::%s)
+string(7) "WSAPoll"
+string(27) "Backend Epoll not available"

--- a/tests/Io/Poll/phpt/poll_double_construct.phpt
+++ b/tests/Io/Poll/phpt/poll_double_construct.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Io\Poll: calling __construct() twice throws instead of leaking
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($r, $w) = pt_new_socket_pair();
+
+$handle = new StreamPollHandle($r);
+try {
+    $handle->__construct($r);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+$ctx = pt_new_stream_poll();
+try {
+    $ctx->__construct();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "done\n";
+?>
+--EXPECT--
+StreamPollHandle object is already constructed
+Io\Poll\Context object is already constructed
+done

--- a/tests/Io/Poll/phpt/poll_stream_add_error_duplicate.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_add_error_duplicate.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Poll stream - add duplicite error
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1r, $socket1w) = pt_new_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $socket1w, [Io\Poll\Event::Write], "socket2_data");
+
+try {
+    pt_stream_poll_add($poll_ctx, $socket1w, [Io\Poll\Event::Write], "socket2_data");
+} catch (Io\Poll\HandleAlreadyWatchedException $e) {
+    echo "ERROR: " . $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+ERROR: Handle already added

--- a/tests/Io/Poll/phpt/poll_stream_handle_close_then_free.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_handle_close_then_free.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Io\Poll: StreamPollHandle cleanup is safe when the stream is closed first
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($r, $w) = pt_new_socket_pair();
+$ctx = pt_new_stream_poll();
+$watcher = $ctx->add(new StreamPollHandle($r), [Io\Poll\Event::Read]);
+
+// Close the underlying streams before the watcher and handle are freed.
+fclose($r);
+fclose($w);
+
+unset($watcher, $ctx);
+gc_collect_cycles();
+echo "ok\n";
+?>
+--EXPECT--
+ok

--- a/tests/Io/Poll/phpt/poll_stream_handle_fd_release.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_handle_fd_release.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Io\Poll: StreamPollHandle releases its stream resource (no fd leak)
+--SKIPIF--
+<?php
+if (!is_dir('/proc/self/fd')) {
+    die("skip requires /proc/self/fd (Linux)\n");
+}
+?>
+--FILE--
+<?php
+function open_fds(): int {
+    return count(scandir('/proc/self/fd'));
+}
+
+$before = open_fds();
+for ($i = 0; $i < 100; $i++) {
+    list($r, $w) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+    $h = new StreamPollHandle($r);
+    unset($h, $r, $w);
+}
+gc_collect_cycles();
+$delta = open_fds() - $before;
+
+// Without the fix each handle pins its stream, leaking ~100 fds.
+var_dump($delta < 10);
+?>
+--EXPECT--
+bool(true)

--- a/tests/Io/Poll/phpt/poll_stream_sock_add_only.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_sock_add_only.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Poll stream - only add
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1, $socket2) = pt_new_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $socket2, [Io\Poll\Event::Write], "socket2_data");
+
+var_dump($poll_ctx);
+
+?>
+--EXPECT--
+object(Io\Poll\Context)#1 (0) {
+}

--- a/tests/Io/Poll/phpt/poll_stream_sock_modify_write.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_sock_modify_write.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Poll stream - socket modify write
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1, $socket2) = pt_new_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+$watcher = pt_stream_poll_add($poll_ctx, $socket2, [Io\Poll\Event::Write], "socket_data");
+$watcher->modify([Io\Poll\Event::Write], "modified_data");
+
+pt_expect_events($poll_ctx->wait(0), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'modified_data']
+]);
+?>
+--EXPECT--
+Events matched - count: 1

--- a/tests/Io/Poll/phpt/poll_stream_sock_read.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_sock_read.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Poll stream - socket read
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1r, $socket1w) = pt_new_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $socket1r, [Io\Poll\Event::Read], "socket_data");
+
+fwrite($socket1w, "test data");
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Read], 'data' => 'socket_data', 'read' => 'test data']
+]);
+
+?>
+--EXPECT--
+Events matched - count: 1

--- a/tests/Io/Poll/phpt/poll_stream_sock_remove_write.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_sock_remove_write.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Poll stream - socket remove write
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1r, $socket1w) = pt_new_socket_pair();
+list($socket2r, $socket2w) = pt_new_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+$watcher1w = pt_stream_poll_add($poll_ctx, $socket1w, [Io\Poll\Event::Write], "socket_data_1");
+pt_stream_poll_add($poll_ctx, $socket2w, [Io\Poll\Event::Write], "socket_data_2");
+
+pt_expect_events($poll_ctx->wait(0), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket_data_1'],
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket_data_2']
+]);
+
+$watcher1w->remove();
+
+pt_expect_events($poll_ctx->wait(0), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket_data_2']
+]);
+
+// check that both streams are still usable
+var_dump(fwrite($socket1w, "test 1"));
+var_dump(fwrite($socket2w, "test 2"));
+var_dump(fread($socket1r, 100));
+var_dump(fread($socket2r, 100));
+
+?>
+--EXPECT--
+Events matched - count: 2
+Events matched - count: 1
+int(6)
+int(6)
+string(6) "test 1"
+string(6) "test 2"

--- a/tests/Io/Poll/phpt/poll_stream_sock_rw_close.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_sock_rw_close.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Poll stream - socket write / read close
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1r, $socket1w) = pt_new_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $socket1r, [Io\Poll\Event::Read], "socket1_data");
+pt_stream_poll_add($poll_ctx, $socket1w, [Io\Poll\Event::Write], "socket2_data");
+
+fwrite($socket1w, "test data");
+
+fclose($socket1r);
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    [
+        'events' => [
+            'default' => [Io\Poll\Event::Write, Io\Poll\Event::Error, Io\Poll\Event::HangUp],
+            'Kqueue|EventPorts' => [Io\Poll\Event::Write, Io\Poll\Event::HangUp],
+        ],
+        'data' => 'socket2_data'
+    ]
+], $poll_ctx);
+
+fclose($socket1w);
+pt_expect_events($poll_ctx->wait(0, 100000), []);
+
+?>
+--EXPECT--
+Events matched - count: 1
+Events matched - count: 0

--- a/tests/Io/Poll/phpt/poll_stream_sock_rw_multi_edge.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_sock_rw_multi_edge.phpt
@@ -1,0 +1,62 @@
+--TEST--
+Poll stream - socket write / read multiple times with edge triggering
+--SKIPIF--
+<?php
+require_once __DIR__ . '/poll.inc';
+pt_skip_for_backend(['Poll', 'WSAPoll', 'EventPorts'], 'does not support edge triggering')
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1r, $socket1w) = pt_new_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $socket1r, [Io\Poll\Event::Read, Io\Poll\Event::EdgeTriggered], "socket1_data");
+pt_stream_poll_add($poll_ctx, $socket1w, [Io\Poll\Event::Write, Io\Poll\Event::EdgeTriggered], "socket2_data");
+
+pt_expect_events($poll_ctx->wait(0), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket2_data']
+]);
+
+pt_expect_events($poll_ctx->wait(0), []);
+
+fwrite($socket1w, "test data");
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Read], 'data' => 'socket1_data', 'read' => 'test data']
+]);
+
+fwrite($socket1w, "more data");
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket2_data'],
+    ['events' => [Io\Poll\Event::Read], 'data' => 'socket1_data']
+]);
+
+pt_expect_events($poll_ctx->wait(0, 100000), []);
+
+fwrite($socket1w, " and even more data");
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Read], 'data' => 'socket1_data', 'read' => 'more data and even more data']
+]);
+
+fclose($socket1r);
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    [
+        'events' => ['default' => [Io\Poll\Event::Write, Io\Poll\Event::HangUp]],
+        'data' => 'socket2_data'
+    ]
+], $poll_ctx);
+
+fclose($socket1w);
+pt_expect_events($poll_ctx->wait(0, 100000), []);
+
+?>
+--EXPECT--
+Events matched - count: 1
+Events matched - count: 0
+Events matched - count: 1
+Events matched - count: 2
+Events matched - count: 0
+Events matched - count: 1
+Events matched - count: 1
+Events matched - count: 0

--- a/tests/Io/Poll/phpt/poll_stream_sock_rw_multi_level.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_sock_rw_multi_level.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Poll stream - socket write / read multiple times with level triggering
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1r, $socket1w) = pt_new_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $socket1r, [Io\Poll\Event::Read], "socket1_data");
+pt_stream_poll_add($poll_ctx, $socket1w, [Io\Poll\Event::Write], "socket2_data");
+
+pt_expect_events($poll_ctx->wait(0), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket2_data']
+]);
+
+pt_expect_events($poll_ctx->wait(0), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket2_data']
+]);
+
+fwrite($socket1w, "test data");
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket2_data'],
+    ['events' => [Io\Poll\Event::Read], 'data' => 'socket1_data', 'read' => 'test data']
+]);
+
+fwrite($socket1w, "more data");
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket2_data'],
+    ['events' => [Io\Poll\Event::Read], 'data' => 'socket1_data']
+]);
+
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket2_data'],
+    ['events' => [Io\Poll\Event::Read], 'data' => 'socket1_data']
+]);
+
+fwrite($socket1w, " and even more data");
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket2_data'],
+    ['events' => [Io\Poll\Event::Read], 'data' => 'socket1_data', 'read' => 'more data and even more data']
+]);
+
+fclose($socket1r);
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Write, Io\Poll\Event::HangUp], 'data' => 'socket2_data']
+], $poll_ctx);
+
+fclose($socket1w);
+pt_expect_events($poll_ctx->wait(0, 100000), []);
+
+?>
+--EXPECT--
+Events matched - count: 1
+Events matched - count: 1
+Events matched - count: 2
+Events matched - count: 2
+Events matched - count: 2
+Events matched - count: 2
+Events matched - count: 1
+Events matched - count: 0

--- a/tests/Io/Poll/phpt/poll_stream_sock_rw_single_edge.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_sock_rw_single_edge.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Poll stream - socket write / read few time only
+--SKIPIF--
+<?php
+require_once __DIR__ . '/poll.inc';
+pt_skip_for_backend(['Poll', 'WSAPoll', 'EventPorts'], 'does not support edge triggering')
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1r, $socket1w) = pt_new_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $socket1r, [Io\Poll\Event::Read, Io\Poll\Event::EdgeTriggered], "socket1_data");
+pt_stream_poll_add($poll_ctx, $socket1w, [Io\Poll\Event::Write, Io\Poll\Event::EdgeTriggered], "socket2_data");
+
+pt_expect_events($poll_ctx->wait(0), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket2_data']
+]);
+fwrite($socket1w, "test data");
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Read], 'data' => 'socket1_data', 'read' => 'test data']
+]);
+
+?>
+--EXPECT--
+Events matched - count: 1
+Events matched - count: 1

--- a/tests/Io/Poll/phpt/poll_stream_sock_rw_single_level.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_sock_rw_single_level.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Poll stream - socket write / read few time only
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1r, $socket1w) = pt_new_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $socket1r, [Io\Poll\Event::Read], "socket1_data");
+pt_stream_poll_add($poll_ctx, $socket1w, [Io\Poll\Event::Write], "socket2_data");
+
+pt_expect_events($poll_ctx->wait(0), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket2_data']
+]);
+fwrite($socket1w, "test data");
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket2_data'],
+    ['events' => [Io\Poll\Event::Read], 'data' => 'socket1_data', 'read' => 'test data']
+]);
+
+?>
+--EXPECT--
+Events matched - count: 1
+Events matched - count: 2

--- a/tests/Io/Poll/phpt/poll_stream_sock_write.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_sock_write.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Poll stream - socket write
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1r, $socket1w) = pt_new_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $socket1w, [Io\Poll\Event::Write], "socket_data");
+
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'socket_data']
+]);
+
+?>
+--EXPECT--
+Events matched - count: 1

--- a/tests/Io/Poll/phpt/poll_stream_sock_write_close.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_sock_write_close.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Poll stream - socket write close
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1r, $socket1w) = pt_new_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+list($socket2r, $socket2w) = pt_new_socket_pair();
+
+pt_stream_poll_add($poll_ctx, $socket1w, [Io\Poll\Event::Write], "socket1w_data");
+pt_stream_poll_add($poll_ctx, $socket2w, [Io\Poll\Event::Write], "socket2w_data");
+
+fclose($socket1w);
+fclose($socket2w);
+pt_expect_events($poll_ctx->wait(0, 100000), []);
+
+?>
+--EXPECT--
+Events matched - count: 0

--- a/tests/Io/Poll/phpt/poll_stream_tcp_read.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_tcp_read.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Poll stream - socket read
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($socket1r, $socket1w) = pt_new_tcp_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $socket1r, [Io\Poll\Event::Read], "socket_data");
+
+pt_write_sleep($socket1w, "test data");
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Read], 'data' => 'socket_data', 'read' => 'test data']
+]);
+
+?>
+--EXPECT--
+Events matched - count: 1

--- a/tests/Io/Poll/phpt/poll_stream_tcp_read_multiple_level.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_tcp_read_multiple_level.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Poll stream - TCP read write level
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($clients, $servers) = pt_new_tcp_socket_connections(20);
+$poll_ctx = pt_new_stream_poll();
+
+for ($i = 0; $i < count($servers); $i++) {
+    pt_stream_poll_add($poll_ctx, $servers[$i], [Io\Poll\Event::Read], "server{$i}_data");
+}
+
+pt_expect_events($poll_ctx->wait(0), []);
+
+for ($i = 0; $i < count($clients); $i++) {
+    pt_write_sleep($clients[$i], "test $i data");
+}
+
+// Build expected events for all 20 connections
+$expected_events = [];
+for ($i = 0; $i < 20; $i++) {
+    $expected_events[] = ['events' => [Io\Poll\Event::Read], 'data' => "server{$i}_data", 'read' => "test $i data"];
+}
+pt_expect_events($poll_ctx->wait(0, 100000), $expected_events);
+
+pt_write_sleep($clients[1], "more data");
+pt_write_sleep($clients[2], "more data");
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Read], 'data' => 'server1_data', 'read' => 'more data'],
+    ['events' => [Io\Poll\Event::Read], 'data' => 'server2_data', 'read' => 'more data']
+]);
+
+pt_expect_events($poll_ctx->wait(0, 100000), []);
+
+?>
+--EXPECT--
+Events matched - count: 0
+Events matched - count: 20
+Events matched - count: 2
+Events matched - count: 0

--- a/tests/Io/Poll/phpt/poll_stream_tcp_read_one_shot.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_tcp_read_one_shot.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Poll stream - TCP read write oneshot
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($client1, $server1) = pt_new_tcp_socket_pair();
+list($client2, $server2) = pt_new_tcp_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $client1, [Io\Poll\Event::Read, Io\Poll\Event::OneShot], "client1_data");
+pt_stream_poll_add($poll_ctx, $server1, [Io\Poll\Event::Read, Io\Poll\Event::OneShot], "server1_data");
+pt_stream_poll_add($poll_ctx, $client2, [Io\Poll\Event::Read, Io\Poll\Event::OneShot], "client2_data");
+pt_stream_poll_add($poll_ctx, $server2, [Io\Poll\Event::Read, Io\Poll\Event::OneShot], "server2_data");
+
+pt_expect_events($poll_ctx->wait(0), []);
+
+pt_write_sleep($client1, "test data");
+pt_write_sleep($client2, "test data");
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Read], 'data' => 'server1_data', 'read' => 'test data'],
+    ['events' => [Io\Poll\Event::Read], 'data' => 'server2_data', 'read' => 'test data']
+]);
+
+pt_write_sleep($client1, "more data");
+pt_write_sleep($client2, "more data");
+pt_expect_events($poll_ctx->wait(0, 100000), []);
+
+?>
+--EXPECT--
+Events matched - count: 0
+Events matched - count: 2
+Events matched - count: 0

--- a/tests/Io/Poll/phpt/poll_stream_tcp_rw_one_shot.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_tcp_rw_one_shot.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Poll stream - TCP read write oneshot combined
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($client, $server) = pt_new_tcp_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $client, [Io\Poll\Event::Read, Io\Poll\Event::Write, Io\Poll\Event::OneShot], "client_data");
+pt_stream_poll_add($poll_ctx, $server, [Io\Poll\Event::Read, Io\Poll\Event::Write, Io\Poll\Event::OneShot], "server_data");
+
+pt_expect_events($poll_ctx->wait(0), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'client_data'],
+    ['events' => [Io\Poll\Event::Write], 'data' => 'server_data']
+]);
+
+pt_write_sleep($client, "test data");
+pt_expect_events($poll_ctx->wait(0, 100000), []);
+
+pt_write_sleep($client, "test data");
+pt_expect_events($poll_ctx->wait(0, 100000), []);
+
+?>
+--EXPECT--
+Events matched - count: 2
+Events matched - count: 0
+Events matched - count: 0

--- a/tests/Io/Poll/phpt/poll_stream_tcp_rw_one_shot_mixed.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_tcp_rw_one_shot_mixed.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Poll stream - TCP read write oneshot combined and mixed
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($client, $server) = pt_new_tcp_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $client, [Io\Poll\Event::Read, Io\Poll\Event::Write, Io\Poll\Event::OneShot], "client_data");
+pt_stream_poll_add($poll_ctx, $server, [Io\Poll\Event::Read, Io\Poll\Event::Write, Io\Poll\Event::OneShot], "server_data");
+
+pt_write_sleep($client, "test data");
+pt_expect_events($poll_ctx->wait(0), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'client_data'],
+    ['events' => [Io\Poll\Event::Read, Io\Poll\Event::Write], 'data' => 'server_data']
+]);
+
+pt_write_sleep($client, "test data");
+pt_expect_events($poll_ctx->wait(0, 100000), []);
+
+?>
+--EXPECT--
+Events matched - count: 2
+Events matched - count: 0

--- a/tests/Io/Poll/phpt/poll_stream_tcp_rw_single_level.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_tcp_rw_single_level.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Poll stream - TCP read write level combined
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($client, $server) = pt_new_tcp_socket_pair();
+$poll_ctx = pt_new_stream_poll();
+
+pt_stream_poll_add($poll_ctx, $client, [Io\Poll\Event::Read, Io\Poll\Event::Write], "client_data");
+pt_stream_poll_add($poll_ctx, $server, [Io\Poll\Event::Read, Io\Poll\Event::Write], "server_data");
+
+pt_expect_events($poll_ctx->wait(0), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'client_data'],
+    ['events' => [Io\Poll\Event::Write], 'data' => 'server_data']
+]);
+
+fwrite($client, "test data");
+usleep(10000);
+pt_expect_events($poll_ctx->wait(0, 100000), [
+    ['events' => [Io\Poll\Event::Write], 'data' => 'client_data'],
+    ['events' => [Io\Poll\Event::Read, Io\Poll\Event::Write], 'data' => 'server_data', 'read' => 'test data']
+]);
+
+?>
+--EXPECT--
+Events matched - count: 2
+Events matched - count: 2

--- a/tests/Io/Poll/phpt/poll_stream_wait_no_add.phpt
+++ b/tests/Io/Poll/phpt/poll_stream_wait_no_add.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Poll stream - only wait
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+$poll_ctx = pt_new_stream_poll();
+$events = $poll_ctx->wait(0, 100000);
+pt_print_events($events);
+
+?>
+--EXPECT--
+Events count: 0

--- a/tests/Io/Poll/phpt/poll_watcher_gc_cycle.phpt
+++ b/tests/Io/Poll/phpt/poll_watcher_gc_cycle.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Io\Poll: cycle collector reclaims a Watcher referenced through its own data
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+class Canary {
+    public $ref;
+    public function __destruct() {
+        echo "Canary freed\n";
+    }
+}
+
+list($r, $w) = pt_new_socket_pair();
+$ctx = pt_new_stream_poll();
+$watcher = $ctx->add(new StreamPollHandle($r), [Io\Poll\Event::Read]);
+
+$c = new Canary();
+$c->ref = $watcher;         // Canary -> Watcher
+$watcher->modifyData($c);   // Watcher->data -> Canary (cycle)
+
+unset($ctx, $watcher, $c, $r, $w);
+
+echo "before gc\n";
+gc_collect_cycles();
+echo "after gc\n";
+?>
+--EXPECT--
+before gc
+Canary freed
+after gc

--- a/tests/Io/Poll/phpt/poll_watcher_outlives_context.phpt
+++ b/tests/Io/Poll/phpt/poll_watcher_outlives_context.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Io\Poll: Watcher operations are safe after its Context is destroyed
+--FILE--
+<?php
+require_once __DIR__ . '/poll.inc';
+
+list($r, $w) = pt_new_socket_pair();
+$ctx = pt_new_stream_poll();
+$watcher = $ctx->add(new StreamPollHandle($r), [Io\Poll\Event::Read], "data");
+
+// Drop the Context while still holding the Watcher it returned.
+unset($ctx);
+gc_collect_cycles();
+
+var_dump($watcher->isActive());
+
+try {
+    $watcher->remove();
+} catch (Io\Poll\InactiveWatcherException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $watcher->modifyEvents([Io\Poll\Event::Write]);
+} catch (Io\Poll\InactiveWatcherException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "done\n";
+?>
+--EXPECT--
+bool(false)
+Cannot remove inactive watcher
+Cannot modify inactive watcher
+done

--- a/tests/Php86/Php86Test.php
+++ b/tests/Php86/Php86Test.php
@@ -18,7 +18,7 @@ class Php86Test extends TestCase
     /**
      * @dataProvider provideValidClampInput
      */
-    public function testClampSuccess(array $arguments, $result): void
+    public function testClampSuccess(array $arguments, $result)
     {
         [$value, $min, $max] = $arguments;
 
@@ -33,7 +33,7 @@ class Php86Test extends TestCase
         $this->assertSame($result, $actual);
     }
 
-    public function testClampNanReturn(): void
+    public function testClampNanReturn()
     {
         $this->assertNan(clamp(\NAN, 4, 6));
     }
@@ -139,7 +139,7 @@ class Php86Test extends TestCase
     /**
      * @dataProvider provideInvalidClampInput
      */
-    public function testClampFailure(array $arguments, string $error): void
+    public function testClampFailure(array $arguments, string $error)
     {
         $this->expectException(\ValueError::class);
         $this->expectExceptionMessage($error);


### PR DESCRIPTION
Tracks the [Polling API RFC](https://wiki.php.net/rfc/poll_api) targeted at PHP 8.6.

Shipped as a dedicated `symfony/polyfill-io-poll` package (`src/Io/Poll/`), requiring PHP >= 8.1 (enums); the split repository and Packagist entry will need to be created before the next release. Surface:

- `Io\IoException`, `Io\Poll\PollException`, abstract `FailedPollOperationException` (with `ERROR_*` constants), and the seven specialized exceptions (`Failed{ContextInitialization,HandleAdd,WatcherModification,PollWait}Exception`, `BackendUnavailableException`, `InactiveWatcherException`, `HandleAlreadyWatchedException`, `InvalidHandleException`).
- `Io\Poll\Backend` enum with `Auto`, `Poll`, `Epoll`, `Kqueue`, `EventPorts`, `WSAPoll` cases and `isAvailable()` / `supportsEdgeTriggering()` / `getAvailableBackends()`.
- `Io\Poll\Event` enum with `Read`, `Write`, `Error`, `HangUp`, `ReadHangUp`, `OneShot`, `EdgeTriggered`.
- `Io\Poll\Handle` marker interface (annotated `@internal` to discourage userland implementations).
- Final `Io\Poll\Context`, `Io\Poll\Watcher`, and global `StreamPollHandle`, with private constructors, clone/double-construct/serialization guards throwing the native errors, and empty `__debugInfo()` like native; the watcher references its context through a `WeakReference` so that destroying the context deactivates its watchers like native refcounting does.

Backed by `stream_select()`, so only the `Poll` backend is available; `Auto` resolves to it and the other backends throw `BackendUnavailableException`. Behavior mirrors the native `poll` backend of `io_poll.c` / `poll_backend_poll.c`: exception messages and codes match, `Event::EdgeTriggered` is rejected with `ERROR_NOSUPPORT`, closed streams are dropped like `POLLNVAL`, a fired `OneShot` watcher stays active with `modify*()` throwing `ERROR_NOTFOUND`, `HangUp` (detected with `stream_socket_recvfrom(..., STREAM_PEEK)` and `feof()`) is reported alongside `Read` like `POLLIN|POLLHUP`, even when not watched, and never for regular files or datagram sockets, and a connection reset (peer closed with unread data, detected when peeking a readable socket fails) reports `Error|HangUp` like `POLLERR|POLLHUP`. `Event::ReadHangUp` is never emitted, matching the native `poll` backend. Known divergences are documented in the component README: TCP half-close reports `Read|HangUp` where native reports plain `Read`.

The test suite combines 64 unit tests with the 28 phpt tests of the native implementation, borrowed verbatim from php-src (`ext/standard/tests/poll`) and executed against the polyfill through a small PHPUnit runner; the phpt suite resolves its backend-specific expectations against the `Poll` backend, which is exactly what the polyfill emulates.
