### PR TITLE
Improve testing environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,17 +15,22 @@ jobs:
 
         strategy:
             matrix:
-                include:
-                    - php: '7.2'
-                    - php: '7.3'
-                    - php: '7.4'
-                    - php: '8.0'
-                    - php: '8.1'
-                    - php: '8.2'
-                    - php: '8.3'
-                    - php: '8.4'
-                    - php: '8.5'
-                    - php: '8.6'
+                php: [
+                    '7.2',
+                    '7.3',
+                    '7.4',
+                    '8.0',
+                    '8.1',
+                    '8.2',
+                    '8.3',
+                    '8.4',
+                    '8.5',
+                    '8.6',
+                ]
+                extensions: [
+                    "none, iconv, json, dom, mbstring, xml, xmlwriter, tokenizer, pdo_sqlite",
+                    "apc, apcu, bcmath, curl, ctype, dom, iconv, intl-73.2, json, ldap, mbstring, mongodb, mysqli, pdo_dblib, pdo_firebird, pdo_mysql, pdo_odbc, pdo_pgsql, pdo_sqlite, odbc, tidy, tokenizer, uuid, xml, xmlwriter",
+                ]
             fail-fast: false
 
         steps:
@@ -36,16 +41,15 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     coverage: "none"
-                    extensions: "apcu, intl-73.2, ldap, mbstring, odbc, uuid, mongodb"
+                    extensions: "${{ matrix.extensions }}"
                     ini-values: "memory_limit=-1, session.gc_probability=0, apc.enable_cli=1"
                     php-version: "${{ matrix.php }}"
-                    tools: "composer:v2"
+                    tools: "composer:v2, pie"
 
             -   name: Install ext-deepclone via PIE
-                if: ${{ matrix.php >= '8.2' }}
+                if: ${{ !startsWith(matrix.extensions, 'none') && matrix.php >= '8.2' }}
                 run: |
-                    curl -sLO https://github.com/php/pie/releases/latest/download/pie.phar
-                    sudo BOX_REQUIREMENT_CHECKER=0 php pie.phar install symfony/deepclone
+                    sudo BOX_REQUIREMENT_CHECKER=0 pie install symfony/deepclone
                     php --ri deepclone || echo "extension=deepclone" | sudo tee "$(php -r 'echo PHP_CONFIG_FILE_SCAN_DIR;')/99-deepclone.ini"
                     php -m | grep -q deepclone && echo "deepclone loaded" || echo "deepclone NOT loaded"
 

--- a/src/Intl/Grapheme/bootstrap.php
+++ b/src/Intl/Grapheme/bootstrap.php
@@ -56,7 +56,7 @@ if (!function_exists('grapheme_str_split')) {
     function grapheme_str_split(string $string, int $length = 1) { return p\Grapheme::grapheme_str_split($string, $length); }
 }
 if (!function_exists('grapheme_levenshtein')) {
-    function grapheme_levenshtein(string $string1, string $string2, int $insertion_cost = 1, int $replacement_cost = 1, int $deletion_cost = 1, string $locale = '') { return p\Php85::grapheme_levenshtein($string1, $string2, $insertion_cost, $replacement_cost, $deletion_cost); }
+    function grapheme_levenshtein(string $string1, string $string2, int $insertion_cost = 1, int $replacement_cost = 1, int $deletion_cost = 1, string $locale = '') { return p\Grapheme::grapheme_levenshtein($string1, $string2, $insertion_cost, $replacement_cost, $deletion_cost); }
 }
 if (!function_exists('grapheme_strrev')) {
     function grapheme_strrev(string $string) { return p\Grapheme::grapheme_strrev($string); }

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -726,7 +726,9 @@ class MbstringTest extends TestCase
         $this->expectExceptionMessage($expectedError);
 
         set_error_handler(static function ($errno, $errstr, $errfile, $errline) {
-            throw new \ErrorException($errstr, $errno, $errfile, $errline);
+            if (\E_USER_WARNING === $errno) {
+                throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+            }
         });
 
         try {
@@ -914,7 +916,9 @@ class MbstringTest extends TestCase
         $this->expectExceptionMessage('mb_trim(): Argument #3 ($encoding) must be a valid encoding, "NULL" given');
 
         set_error_handler(static function ($errno, $errstr, $errfile, $errline) {
-            throw new \ErrorException($errstr, $errno, $errfile, $errline);
+            if (\E_USER_WARNING === $errno) {
+                throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+            }
         });
 
         try {

--- a/tests/Php73/Php73Test.php
+++ b/tests/Php73/Php73Test.php
@@ -24,7 +24,11 @@ class Php73Test extends TestCase
         $this->assertTrue(is_countable([1, 2, '3']));
         $this->assertTrue(is_countable(new \ArrayIterator(['foo', 'bar', 'baz'])));
         $this->assertTrue(is_countable(new \ArrayIterator()));
-        $this->assertTrue(is_countable(new \SimpleXMLElement('<foo><bar/><bar/><bar/></foo>')));
+
+        if (\class_exists('\SimpleXMLElement')) {
+            $this->assertTrue(is_countable(new \SimpleXMLElement('<foo><bar/><bar/><bar/></foo>')));
+        }
+
         $this->assertFalse(is_countable(new \stdClass()));
 
         $endianBytes = unpack('S', "\x01\x00");

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -67,7 +67,9 @@ class Php83Test extends TestCase
         $this->expectExceptionMessage($expectedError);
 
         set_error_handler(static function ($errno, $errstr, $errfile, $errline) {
-            throw new \ErrorException($errstr, $errno, $errfile, $errline);
+            if (\E_USER_WARNING === $errno) {
+                throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+            }
         });
 
         try {

--- a/tests/Php84/PdoTest.php
+++ b/tests/Php84/PdoTest.php
@@ -239,6 +239,8 @@ class PdoTest extends TestCase
     }
 }
 
-class ExtendedPdoSqlite extends \Pdo\Sqlite
-{
+if (class_exists('\Pdo\Sqlite')) {
+    class ExtendedPdoSqlite extends \Pdo\Sqlite
+    {
+    }
 }

--- a/tests/Php84/Php84Test.php
+++ b/tests/Php84/Php84Test.php
@@ -247,7 +247,9 @@ class Php84Test extends TestCase
         $this->expectExceptionMessage('mb_trim(): Argument #3 ($encoding) must be a valid encoding, "NULL" given');
 
         set_error_handler(static function ($errno, $errstr, $errfile, $errline) {
-            throw new \ErrorException($errstr, $errno, $errfile, $errline);
+            if (\E_USER_WARNING === $errno) {
+                throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+            }
         });
 
         try {

--- a/tests/Php85/Php85Test.php
+++ b/tests/Php85/Php85Test.php
@@ -121,6 +121,9 @@ class Php85Test extends TestCase
         $this->assertTrue(class_exists(\Filter\FilterFailedException::class));
     }
 
+    /**
+     * @requires extension intl
+     */
     public function testLocaleIsRightToLeft()
     {
         $this->assertTrue(locale_is_right_to_left('ar'));


### PR DESCRIPTION
- Adds configuration to the testing matrix to test on both a minimal and maximal build of PHP.
- Fixes tests so that everything stays green.

Speaks to #613, but does _not_ address the issues with testing iconv/mbstring polyfills nor the issue with TestListener, which is still hiding failures even in this setup.