### PR TITLE
Fix newline handling in Php74 implementation of mb_str_split()

### DIFF
--- a/src/Php74/Php74.php
+++ b/src/Php74/Php74.php
@@ -60,7 +60,7 @@ final class Php74
         }
 
         if ('UTF-8' === $encoding || \in_array(strtoupper($encoding), ['UTF-8', 'UTF8'], true)) {
-            return preg_split("/(.{{$split_length}})/u", $string, -1, \PREG_SPLIT_DELIM_CAPTURE | \PREG_SPLIT_NO_EMPTY);
+            return preg_split("/(.{{$split_length}})/us", $string, -1, \PREG_SPLIT_DELIM_CAPTURE | \PREG_SPLIT_NO_EMPTY);
         }
 
         $result = [];

--- a/tests/Php74/Php74Test.php
+++ b/tests/Php74/Php74Test.php
@@ -91,6 +91,8 @@ class Php74Test extends TestCase
      */
     public function testStrSplit()
     {
+        $this->assertSame(['H', "\r", "\n", 'W'], mb_str_split("H\r\nW", 1));
+        $this->assertSame(['Hell', "o\nWo", 'rld!'], mb_str_split("Hello\nWorld!", 4));
         $this->assertSame(['한', '국', '어'], mb_str_split('한국어'));
         $this->assertSame(['по', 'бе', 'да'], mb_str_split('победа', 2));
         $this->assertSame(['źre', 'bię'], mb_str_split('źrebię', 3));


### PR DESCRIPTION
The `Php74` version of `mb_str_split()` is missing the `/s` modifier that the `Mbstring` version uses, resulting in a failure in `MbstringTest::testStrSplit()` in PHP < 7.4.