### PR TITLE
Polyfill more cURL constants

### DIFF
--- a/src/Php81/bootstrap.php
+++ b/src/Php81/bootstrap.php
@@ -19,6 +19,10 @@ if (defined('MYSQLI_REFRESH_SLAVE') && !defined('MYSQLI_REFRESH_REPLICA')) {
     define('MYSQLI_REFRESH_REPLICA', 64);
 }
 
+if (\extension_loaded('curl') && !defined('CURLOPT_ISSUERCERT_BLOB') && curl_version()['version_number'] >= 0x074700) {
+    define('CURLOPT_ISSUERCERT_BLOB', 40295);
+}
+
 if (!function_exists('array_is_list')) {
     function array_is_list(array $array): bool { return p\Php81::array_is_list($array); }
 }

--- a/src/Php82/bootstrap.php
+++ b/src/Php82/bootstrap.php
@@ -15,6 +15,10 @@ if (\PHP_VERSION_ID >= 80200) {
     return;
 }
 
+if (\extension_loaded('curl') && !defined('CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256') && curl_version()['version_number'] >= 0x075000) {
+    define('CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256', 10311);
+}
+
 if (extension_loaded('odbc')) {
     if (!function_exists('odbc_connection_string_is_quoted')) {
         function odbc_connection_string_is_quoted(string $str): bool { return p\Php82::odbc_connection_string_is_quoted($str); }

--- a/src/Php84/bootstrap.php
+++ b/src/Php84/bootstrap.php
@@ -15,13 +15,17 @@ if (\PHP_VERSION_ID >= 80400) {
     return;
 }
 
-if (defined('CURL_VERSION_HTTP3') || \PHP_VERSION_ID < 80200 && function_exists('curl_version') && curl_version()['version'] >= 0x074200) { // libcurl >= 7.66.0
-    if (!defined('CURL_HTTP_VERSION_3')) {
-        define('CURL_HTTP_VERSION_3', 30);
-    }
+if (\extension_loaded('curl')) {
+    // CURL_VERSION_HTTP3 is defined by PHP 8.2+ when libcurl >= 7.66.0
+    if (defined('CURL_VERSION_HTTP3') || \PHP_VERSION_ID < 80200 && curl_version()['version_number'] >= 0x074200) {
+        if (!defined('CURL_HTTP_VERSION_3')) {
+            define('CURL_HTTP_VERSION_3', 30);
+        }
 
-    if (!defined('CURL_HTTP_VERSION_3ONLY') && defined('CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256')) { // libcurl >= 7.80.0 (7.88 would be better but is slow to check)
-        define('CURL_HTTP_VERSION_3ONLY', 31);
+        // CURL_HTTP_VERSION_3ONLY requires libcurl >= 7.88.0 and is not gated by any PHP-defined constant before 8.4
+        if (!defined('CURL_HTTP_VERSION_3ONLY') && curl_version()['version_number'] >= 0x075800) {
+            define('CURL_HTTP_VERSION_3ONLY', 31);
+        }
     }
 }
 

--- a/tests/Php81/Php81Test.php
+++ b/tests/Php81/Php81Test.php
@@ -42,4 +42,17 @@ class Php81Test extends TestCase
         $this->assertTrue(\defined('MYSQLI_REFRESH_REPLICA'));
         $this->assertSame(MYSQLI_REFRESH_SLAVE, MYSQLI_REFRESH_REPLICA);
     }
+
+    /**
+     * @requires extension curl
+     */
+    public function testCurlOptIssuerCertBlobDefined()
+    {
+        if (curl_version()['version_number'] < 0x074700) {
+            $this->markTestSkipped('Requires libcurl >= 7.71.0');
+        }
+
+        $this->assertTrue(\defined('CURLOPT_ISSUERCERT_BLOB'));
+        $this->assertSame(40295, \CURLOPT_ISSUERCERT_BLOB);
+    }
 }

--- a/tests/Php82/Php82Test.php
+++ b/tests/Php82/Php82Test.php
@@ -49,6 +49,19 @@ class Php82Test extends TestCase
     }
 
     /**
+     * @requires extension curl
+     */
+    public function testCurlOptSshHostPublicKeySha256Defined()
+    {
+        if (curl_version()['version_number'] < 0x075000) {
+            $this->markTestSkipped('Requires libcurl >= 7.80.0');
+        }
+
+        $this->assertTrue(\defined('CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256'));
+        $this->assertSame(10311, \CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256);
+    }
+
+    /**
      * Test cases ported from upstream.
      *
      * @see https://github.com/php/php-src/blob/838f6bffff6363a204a2597cbfbaad1d7ee3f2b6/ext/odbc/tests/odbc_utils.phpt

--- a/tests/Php84/Php84Test.php
+++ b/tests/Php84/Php84Test.php
@@ -67,15 +67,29 @@ class Php84Test extends TestCase
     /**
      * @requires extension curl
      */
-    public function testCurlHttp3Constants()
+    public function testCurlHttpVersion3Constant()
     {
+        if (curl_version()['version_number'] < 0x074200) {
+            $this->markTestSkipped('Requires libcurl >= 7.66.0');
+        }
+
         $ch = curl_init();
 
         $this->assertIsBool(curl_setopt($ch, \CURLOPT_HTTP_VERSION, \CURL_HTTP_VERSION_3));
+    }
 
-        if (\defined('CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256')) {
-            $this->assertIsBool(curl_setopt($ch, \CURLOPT_HTTP_VERSION, \CURL_HTTP_VERSION_3ONLY));
+    /**
+     * @requires extension curl
+     */
+    public function testCurlHttpVersion3OnlyConstant()
+    {
+        if (curl_version()['version_number'] < 0x075800) {
+            $this->markTestSkipped('Requires libcurl >= 7.88.0');
         }
+
+        $ch = curl_init();
+
+        $this->assertIsBool(curl_setopt($ch, \CURLOPT_HTTP_VERSION, \CURL_HTTP_VERSION_3ONLY));
     }
 
     public static function ucFirstDataProvider(): array


### PR DESCRIPTION
This PR fixes how the Php84 polyfill detects libcurl support for `CURL_HTTP_VERSION_3` and `CURL_HTTP_VERSION_3ONLY`, and adds polyfills for the related `CURLOPT_ISSUERCERT_BLOB` (Php81) and `CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256` (Php82) constants when libcurl supports them.

### Php84

- Fix a latent bug: `curl_version()['version']` is a string and was being compared to the integer `0x074200`; replaced with `['version_number']`.
- Guard the whole block behind `extension_loaded('curl')` so `curl_version()` is never called when the extension isn't present.
- Keep the `\PHP_VERSION_ID < 80200` short-circuit so opcache can fold the branch away on PHP 8.2+ (per review feedback in #617).
- For `CURL_HTTP_VERSION_3ONLY`, check libcurl `>= 7.88.0` explicitly instead of using `CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256` as a (loose, libcurl 7.80.0) proxy.
- Split the test into one per constant and skip each with the appropriate libcurl version requirement.

### Php81 / Php82

- Polyfill `CURLOPT_ISSUERCERT_BLOB` (added in PHP 8.1, libcurl 7.71.0) when libcurl supports it.
- Polyfill `CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256` (added in PHP 8.2, libcurl 7.80.0) when libcurl supports it.
- Add tests verifying both constants resolve to their canonical integer values.

Note: the polyfill packages are independent (Php84 does not require Php82), so the Php84 bootstrap still does its own explicit `curl_version()` checks rather than relying on the new constants being defined.