### PR TITLE
[Mbstring][Php3] Fix issues with mb_str_pad()

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -879,16 +879,6 @@ final class Mbstring
     /** @return string|false */
     public static function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = \STR_PAD_RIGHT, ?string $encoding = null)
     {
-        if (!\in_array($pad_type, [\STR_PAD_RIGHT, \STR_PAD_LEFT, \STR_PAD_BOTH], true)) {
-            if (\PHP_VERSION_ID < 80000) {
-                trigger_error('mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH', \E_USER_WARNING);
-
-                return false;
-            }
-
-            throw new \ValueError('mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH');
-        }
-
         if (null === $encoding) {
             $encoding = self::mb_internal_encoding();
         } elseif (!self::assertEncoding($encoding, 'mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "%s" given')) {
@@ -903,6 +893,16 @@ final class Mbstring
             }
 
             throw new \ValueError('mb_str_pad(): Argument #3 ($pad_string) must be a non-empty string');
+        }
+
+        if (!\in_array($pad_type, [\STR_PAD_RIGHT, \STR_PAD_LEFT, \STR_PAD_BOTH], true)) {
+            if (\PHP_VERSION_ID < 80000) {
+                trigger_error('mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH', \E_USER_WARNING);
+
+                return false;
+            }
+
+            throw new \ValueError('mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH');
         }
 
         $paddingRequired = $length - self::mb_strlen($string, $encoding);

--- a/src/Php83/Php83.php
+++ b/src/Php83/Php83.php
@@ -43,10 +43,6 @@ final class Php83
     /** @return string|false */
     public static function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = \STR_PAD_RIGHT, ?string $encoding = null)
     {
-        if (!\in_array($pad_type, [\STR_PAD_RIGHT, \STR_PAD_LEFT, \STR_PAD_BOTH], true)) {
-            throw new \ValueError('mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH');
-        }
-
         if (null === $encoding) {
             $encoding = mb_internal_encoding();
         }
@@ -62,6 +58,10 @@ final class Php83
 
         if (null === $errorToTrigger && mb_strlen($pad_string, $encoding) <= 0) {
             $errorToTrigger = 'mb_str_pad(): Argument #3 ($pad_string) must be a non-empty string';
+        }
+
+        if (null === $errorToTrigger && !\in_array($pad_type, [\STR_PAD_RIGHT, \STR_PAD_LEFT, \STR_PAD_BOTH], true)) {
+            $errorToTrigger = 'mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH';
         }
 
         if (null !== $errorToTrigger) {

--- a/tests/Mbstring/MbstringTest.php
+++ b/tests/Mbstring/MbstringTest.php
@@ -691,10 +691,6 @@ class MbstringTest extends TestCase
      */
     public function testMbStrPad(string $expectedResult, string $string, int $length, string $padString, int $padType, ?string $encoding = null)
     {
-        if ('UTF-32' === $encoding && \PHP_VERSION_ID < 73000) {
-            $this->markTestSkipped('PHP < 7.3 doesn\'t handle UTF-32 encoding properly');
-        }
-
         $this->assertSame($expectedResult, mb_convert_encoding(mb_str_pad($string, $length, $padString, $padType, $encoding), 'UTF-8', $encoding ?? mb_internal_encoding()));
     }
 
@@ -823,6 +819,8 @@ class MbstringTest extends TestCase
         yield ['mb_str_pad(): Argument #3 ($pad_string)', '▶▶', 6, '', \STR_PAD_BOTH];
         yield ['mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH', '▶▶', 6, ' ', 123456];
         yield ['mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "unexisting" given', '▶▶', 6, ' ', \STR_PAD_BOTH, 'unexisting'];
+        yield ['mb_str_pad(): Argument #3 ($pad_string)', '▶▶', 6, '', 123456];
+        yield ['mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "unexisting" given', '▶▶', 6, '', 123456, 'unexisting'];
     }
 
     public static function ucFirstDataProvider(): array

--- a/tests/Php83/Php83Test.php
+++ b/tests/Php83/Php83Test.php
@@ -148,6 +148,8 @@ class Php83Test extends TestCase
         yield ['mb_str_pad(): Argument #3 ($pad_string)', '▶▶', 6, '', \STR_PAD_BOTH];
         yield ['mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH', '▶▶', 6, ' ', 123456];
         yield ['mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "unexisting" given', '▶▶', 6, ' ', \STR_PAD_BOTH, 'unexisting'];
+        yield ['mb_str_pad(): Argument #3 ($pad_string)', '▶▶', 6, '', 123456];
+        yield ['mb_str_pad(): Argument #5 ($encoding) must be a valid encoding, "unexisting" given', '▶▶', 6, '', 123456, 'unexisting'];
     }
 
     /**


### PR DESCRIPTION
This PR does three things related to `mb_str_pad()`:
- It fixes another issue hidden by the TestListener (mentioned in #613 and seen during development of #619) where `ValueError` was being thrown on PHP 7 in the `Php83` version of `mb_str_pad()` instead of triggering the warning like is done in other mbstring situations, including the `Mbstring` implementation of `mb_str_pad()`.
- It rearranges the order of argument checks in both the `Php83` and `Mbstring` to match native PHP calls, and adds tests to back that up.
- It removes the skipping of UTF-32 checks in `MbstringTest`. #512 reported in 2024 that CI tests were failing on PHP 8 because of UTF-32, but I'm not seeing any evidence of that now (though #435 mentioned in 2023 that PHP 7.2 had issues with UTF-32 when mbstring was missing).