### PR TITLE
[Mbstring] Fix issues with mb_scrub()

### DIFF
--- a/src/Mbstring/Mbstring.php
+++ b/src/Mbstring/Mbstring.php
@@ -157,10 +157,6 @@ final class Mbstring
             $fromEncoding = 'UTF-8';
         }
 
-        if ($fromEncoding === $toEncoding) {
-            return $s;
-        }
-
         return self::iconv($fromEncoding, $toEncoding, $s);
     }
 
@@ -874,6 +870,18 @@ final class Mbstring
         }
 
         return $code;
+    }
+
+    /** @return string|false */
+    public static function mb_scrub(?string $string, ?string $encoding = null): string
+    {
+        if (null === $encoding) {
+            $encoding = self::mb_internal_encoding();
+        } elseif (!self::assertEncoding($encoding, 'mb_scrub(): Argument #2 ($encoding) must be a valid encoding, "%s" given')) {
+            return false;
+        }
+
+        return self::mb_convert_encoding((string) $string, $encoding, $encoding);
     }
 
     /** @return string|false */

--- a/src/Mbstring/bootstrap72.php
+++ b/src/Mbstring/bootstrap72.php
@@ -122,7 +122,7 @@ if (!function_exists('mb_chr')) {
     function mb_chr($codepoint, $encoding = null) { return p\Mbstring::mb_chr($codepoint, $encoding); }
 }
 if (!function_exists('mb_scrub')) {
-    function mb_scrub($string, $encoding = null) { $encoding = null === $encoding ? mb_internal_encoding() : $encoding; return mb_convert_encoding($string, $encoding, $encoding); }
+    function mb_scrub($string, $encoding = null) { return p\Mbstring::mb_scrub($string, $encoding); }
 }
 if (!function_exists('mb_str_split')) {
     function mb_str_split($string, $length = 1, $encoding = null) { return p\Mbstring::mb_str_split($string, $length, $encoding); }

--- a/src/Mbstring/bootstrap80.php
+++ b/src/Mbstring/bootstrap80.php
@@ -122,7 +122,7 @@ if (!function_exists('mb_chr')) {
     function mb_chr(?int $codepoint, ?string $encoding = null): string|false { return p\Mbstring::mb_chr((int) $codepoint, $encoding); }
 }
 if (!function_exists('mb_scrub')) {
-    function mb_scrub(?string $string, ?string $encoding = null): string { $encoding ??= mb_internal_encoding(); return mb_convert_encoding((string) $string, $encoding, $encoding); }
+    function mb_scrub(?string $string, ?string $encoding = null): string { return p\Mbstring::mb_scrub($string, $encoding); }
 }
 if (!function_exists('mb_str_split')) {
     function mb_str_split(?string $string, ?int $length = 1, ?string $encoding = null): array { return p\Mbstring::mb_str_split((string) $string, (int) $length, $encoding); }


### PR DESCRIPTION
- This moves the definition of `mb_scrub()` into the `Mbstring` class so that it can take advantage of other implementation details there, and can be checked by the TestListener for signature issues.
- This removes the iconv skip just added to `mb_convert_encoding()` in #607, which bypasses iconv when the input and output encodings are the same. Unlike the native PHP implementation (for UTF-8, anyway), it fails to account for invalid characters, which would be stripped by the call to iconv. This was causing `MbstringTest::testScrub()` to fail, because the invalid character was not being stripped.