### PR TITLE
[DeepClone] Support closures declared in constant expressions

### DIFF
--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -38,6 +38,8 @@ final class DeepClone
     private static array $propertyScopes = []; // [class][key] = [declaring class, real name]; key is bare name, "\0*\0name", or "\0class\0name"
     private static array $protos = [];
     private static array $classInfo = [];
+    private static array $constExprIndex = [];
+    private static array $closureLiteralLines = [];
     private static \stdClass $sentinel;
 
     /**
@@ -641,18 +643,33 @@ final class DeepClone
                 goto handle_value;
             }
 
-            if ($value instanceof \Closure && ($r = new \ReflectionFunction($value)) && !(\PHP_VERSION_ID >= 80200 ? $r->isAnonymous() : str_contains($r->name, "@anonymous\0"))) {
+            if ($value instanceof \Closure) {
+                $r = new \ReflectionFunction($value);
+
+                if (!(\PHP_VERSION_ID >= 80200 ? $r->isAnonymous() : str_contains($r->name, "@anonymous\0"))) {
+                    if (null !== $allowedSet && !isset($allowedSet['closure'])) {
+                        throw new \ValueError('deepclone_to_array(): class "Closure" is not allowed');
+                    }
+                    $callable = [$r->getClosureThis() ?? (\PHP_VERSION_ID >= 80111 ? $r->getClosureCalledClass() : $r->getClosureScopeClass())?->name, $r->name];
+                    $rm = $callable[0] ? new \ReflectionMethod(...$callable) : null;
+                    $unused = null;
+                    $callable = self::prepare($callable, $objectsPool, $refsPool, $objectsCount, $valueIsStatic, $unused, $allowedSet);
+                    $value = !($rm?->isPublic() ?? true) ? [$callable, $rm->class, $rm->name] : $callable;
+                    $mask[$k] = 0;
+
+                    goto handle_value;
+                }
+
                 if (null !== $allowedSet && !isset($allowedSet['closure'])) {
                     throw new \ValueError('deepclone_to_array(): class "Closure" is not allowed');
                 }
-                $callable = [$r->getClosureThis() ?? (\PHP_VERSION_ID >= 80111 ? $r->getClosureCalledClass() : $r->getClosureScopeClass())?->name, $r->name];
-                $rm = $callable[0] ? new \ReflectionMethod(...$callable) : null;
-                $unused = null;
-                $callable = self::prepare($callable, $objectsPool, $refsPool, $objectsCount, $valueIsStatic, $unused, $allowedSet);
-                $value = !($rm?->isPublic() ?? true) ? [$callable, $rm->class, $rm->name] : $callable;
-                $mask[$k] = 0;
 
-                goto handle_value;
+                if (\PHP_VERSION_ID >= 80500 && null !== $ref = self::locateConstExprClosure($r)) {
+                    $value = $ref;
+                    $mask[$k] = 1;
+
+                    goto handle_value;
+                }
             }
 
             $class = $value::class;
@@ -853,7 +870,7 @@ final class DeepClone
         }
 
         foreach ($refMasks as $k => $m) {
-            $refs[$k] = self::resolveWithMask($refs[$k], $m, $objects, $refs);
+            $refs[$k] = self::resolveWithMask($refs[$k], $m, $objects, $refs, $allowedClasses);
         }
 
         // Finalize the remaining deferred objects: needsFullUnserialize objects
@@ -879,7 +896,7 @@ final class DeepClone
                         continue;
                     }
                     $class = $objectMeta[$zid][0];
-                    $resolvedProps = self::resolveWithMask($state[1] ?? null, $state[2], $objects, $refs);
+                    $resolvedProps = self::resolveWithMask($state[1] ?? null, $state[2], $objects, $refs, $allowedClasses);
                     $ser = serialize($resolvedProps);
                     if (false === $obj = unserialize('O:'.\strlen($class).':"'.$class.'"'.substr($ser, strpos($ser, ':', 1)))) {
                         throw new \ValueError('deepclone_from_array(): could not reconstruct "'.$class.'" via __unserialize()');
@@ -946,7 +963,7 @@ final class DeepClone
                     } elseif (0 === $marker) {
                         $scopeProps[$name][$id] = self::resolveNamedClosureScalar($scopeProps[$name][$id] ?? null, $objects, $refs);
                     } else {
-                        $scopeProps[$name][$id] = self::resolveWithMask($scopeProps[$name][$id] ?? null, $marker, $objects, $refs);
+                        $scopeProps[$name][$id] = self::resolveWithMask($scopeProps[$name][$id] ?? null, $marker, $objects, $refs, $allowedClasses);
                     }
                 }
             }
@@ -971,7 +988,7 @@ final class DeepClone
                     // Internal final class with __unserialize that rejects empty unserialize
                     // reconstruct via the full O: serialization form (same as PHP's unserialize).
                     $class = $objectMeta[$zid][0];
-                    $resolvedProps = isset($state[2]) ? self::resolveWithMask($sprops, $state[2], $objects, $refs) : $sprops;
+                    $resolvedProps = isset($state[2]) ? self::resolveWithMask($sprops, $state[2], $objects, $refs, $allowedClasses) : $sprops;
                     $ser = serialize($resolvedProps);
                     if (false === $obj = unserialize('O:'.\strlen($class).':"'.$class.'"'.substr($ser, strpos($ser, ':', 1)))) {
                         throw new \ValueError('deepclone_from_array(): could not reconstruct "'.$class.'" via __unserialize()');
@@ -991,7 +1008,7 @@ final class DeepClone
                 if (!method_exists($obj, '__unserialize')) {
                     throw new \ValueError('deepclone_from_array(): Argument #1 ($data) "states" entry references object id '.$zid.' whose class '.$objClass.' has no __unserialize() method');
                 }
-                $resolvedProps = isset($state[2]) ? self::resolveWithMask($sprops, $state[2], $objects, $refs) : $sprops;
+                $resolvedProps = isset($state[2]) ? self::resolveWithMask($sprops, $state[2], $objects, $refs, $allowedClasses) : $sprops;
                 $obj->__unserialize($resolvedProps);
             } elseif (\is_int($state)) {
                 if ($state < 0 || $state >= $numObjects) {
@@ -1033,7 +1050,7 @@ final class DeepClone
         }
 
         if (null !== $preparedMask) {
-            return self::resolveWithMask($prepared, $preparedMask, $objects, $refs);
+            return self::resolveWithMask($prepared, $preparedMask, $objects, $refs, $allowedClasses);
         }
 
         return $prepared;
@@ -1062,7 +1079,7 @@ final class DeepClone
         return true;
     }
 
-    private static function resolveWithMask($value, $mask, $objects, &$refs)
+    private static function resolveWithMask($value, $mask, $objects, &$refs, $allowedClasses = null)
     {
         if (true === $mask) {
             if (!\is_int($value)) {
@@ -1102,6 +1119,10 @@ final class DeepClone
 
         if (0 === $mask) {
             return self::resolveNamedClosureScalar($value, $objects, $refs);
+        }
+
+        if (1 === $mask) {
+            return self::resolveConstExprClosureScalar($value, $allowedClasses);
         }
 
         if ('e' === $mask) {
@@ -1146,7 +1167,7 @@ final class DeepClone
                 }
                 $value[$k] = &$refs[$rid];
             } else {
-                $value[$k] = self::resolveWithMask($value[$k] ?? null, $m, $objects, $refs);
+                $value[$k] = self::resolveWithMask($value[$k] ?? null, $m, $objects, $refs, $allowedClasses);
             }
         }
 
@@ -1208,9 +1229,382 @@ final class DeepClone
         return \is_object($obj) ? $obj->$name(...) : $obj::$name(...);
     }
 
+    /**
+     * Resolves an anonymous closure declared in a constant expression (attribute
+     * argument, class constant, property or parameter default) to its declaration
+     * site: [class, site, attribute index or null, closure index, start line].
+     */
+    private static function locateConstExprClosure(\ReflectionFunction $r): ?array
+    {
+        if (!$r->isStatic() || $r->getClosureThis() || $r->getClosureUsedVariables() || !($scope = $r->getClosureScopeClass())) {
+            return null;
+        }
+
+        [$index, $lines] = self::$constExprIndex[$scope->name] ??= self::indexConstExprClosures($scope);
+        $file = $r->getFileName();
+        $line = $r->getStartLine();
+
+        if (!$candidates = $index[$r->name.':'.$file.':'.$line.':'.$r->getEndLine().':'.self::closureSignature($r)] ?? null) {
+            return null;
+        }
+        $sites = [];
+        foreach ($candidates as $candidate) {
+            if (isset($sites[$siteKey = $candidate[0].'#'.$candidate[1]])) {
+                throw new \ValueError('deepclone_to_array(): cannot reference anonymous closure declared at '.$file.':'.$line.', multiple closures share this declaration site');
+            }
+            $sites[$siteKey] = true;
+        }
+
+        // Closures declared in method or hook attributes are named after that
+        // function, exactly like closures created at runtime in its body. When
+        // the source line holds more closure literals than the index knows
+        // about, a runtime literal may alias an indexed one; refuse rather
+        // than risk resolving to the wrong body.
+        if (preg_match('/\(\):\d+\}$/', $r->name) && ($lines[$file.':'.$line] ?? 0) < self::countClosureLiterals($file, $line)) {
+            throw new \ValueError('deepclone_to_array(): cannot reference anonymous closure declared at '.$file.':'.$line.', multiple closures share this declaration site');
+        }
+
+        return [$scope->name, $candidates[0][0], $candidates[0][1], $candidates[0][2], $line];
+    }
+
+    private static function countClosureLiterals(string $file, int $line): int
+    {
+        if (null === $counts = self::$closureLiteralLines[$file] ?? null) {
+            if (!is_file($file) || false === $code = @file_get_contents($file)) {
+                $counts = false;
+            } else {
+                $counts = [];
+                $tokens = token_get_all($code);
+                foreach ($tokens as $i => $t) {
+                    if (!\is_array($t) || (\T_FUNCTION !== $t[0] && \T_FN !== $t[0])) {
+                        continue;
+                    }
+                    while (isset($tokens[++$i])) {
+                        $t2 = $tokens[$i];
+                        if (!\is_array($t2) || (\T_WHITESPACE !== $t2[0] && \T_COMMENT !== $t2[0] && \T_DOC_COMMENT !== $t2[0])) {
+                            if ('(' === $t2 || '&' === $t2) {
+                                $counts[$t[2]] = ($counts[$t[2]] ?? 0) + 1;
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+            self::$closureLiteralLines[$file] = $counts;
+        }
+
+        if (false === $counts) {
+            throw new \ValueError('deepclone_to_array(): cannot reference anonymous closure declared at '.$file.':'.$line.', its source file cannot be read to tell same-line closures apart; install the "deepclone" extension, which resolves closures without reading source files');
+        }
+
+        return $counts[$line] ?? 0;
+    }
+
+    /**
+     * Maps every anonymous closure found in the constant expressions of a class to
+     * its declaration site. Sites are keyed by name:file:start:end:signature; the
+     * name encodes the lexical nesting chain, which keeps closures created at
+     * runtime inside a const-expr closure's body from matching the outer literal.
+     * The same literal can legitimately surface through several sites (an attribute
+     * argument referencing a class constant, a trait alias, a promoted default
+     * applied by a constructor evaluated in another site); candidates in distinct
+     * sites are interchangeable and the first one wins. Two candidates in the SAME
+     * site are distinct literals sharing a declaration line: those are ambiguous.
+     */
+    private static function indexConstExprClosures(\ReflectionClass $rc): array
+    {
+        $class = $rc->name;
+        $index = [];
+        $lines = [];
+        $retained = [];
+        $seen = [];
+        $add = static function ($values, string $site, ?int $attrIndex) use ($class, &$index, &$lines, &$retained, &$seen) {
+            $i = 0;
+            $objects = [];
+            $walk = static function ($value) use ($class, &$walk, &$i, &$index, &$lines, &$retained, &$seen, &$objects, $site, $attrIndex) {
+                if ($value instanceof \Closure) {
+                    $n = $i++;
+                    $retained[] = $value;
+                    if (isset($seen[$id = spl_object_id($value)])) {
+                        return;
+                    }
+                    $seen[$id] = true;
+                    $r = new \ReflectionFunction($value);
+                    if (!$r->isAnonymous() || $r->getClosureScopeClass()?->name !== $class) {
+                        return;
+                    }
+                    $index[$r->name.':'.$r->getFileName().':'.$r->getStartLine().':'.$r->getEndLine().':'.self::closureSignature($r)][] = [$site, $attrIndex, $n];
+                    $lines[$k = $r->getFileName().':'.$r->getStartLine()] = ($lines[$k] ?? 0) + 1;
+                } elseif (\is_array($value)) {
+                    foreach ($value as $v) {
+                        $walk($v);
+                    }
+                } elseif (\is_object($value) && !isset($objects[$id = spl_object_id($value)])) {
+                    $objects[$id] = true;
+                    foreach ((array) $value as $v) {
+                        $walk($v);
+                    }
+                }
+            };
+            $walk($values);
+            // Break the closure <-> &$walk reference cycle
+            $walk = null;
+        };
+
+        foreach ($rc->getAttributes() as $i => $a) {
+            try {
+                $add($a->getArguments(), '', $i);
+            } catch (\Throwable) {
+            }
+        }
+        foreach ($rc->getReflectionConstants() as $rcc) {
+            if ($rcc->getDeclaringClass()->name !== $class) {
+                continue;
+            }
+            foreach ($rcc->getAttributes() as $i => $a) {
+                try {
+                    $add($a->getArguments(), $rcc->name, $i);
+                } catch (\Throwable) {
+                }
+            }
+            try {
+                $add([$rcc->getValue()], $rcc->name, null);
+            } catch (\Throwable) {
+            }
+        }
+        foreach ($rc->getProperties() as $rp) {
+            if ($rp->class !== $class || $rp->isPromoted()) {
+                continue;
+            }
+            foreach ($rp->getAttributes() as $i => $a) {
+                try {
+                    $add($a->getArguments(), '$'.$rp->name, $i);
+                } catch (\Throwable) {
+                }
+            }
+            try {
+                if ($rp->hasDefaultValue()) {
+                    $add([$rp->getDefaultValue()], '$'.$rp->name, null);
+                }
+            } catch (\Throwable) {
+            }
+            foreach (['get', 'set'] as $hookName) {
+                if (!$hook = $rp->getHook(\PropertyHookType::from($hookName))) {
+                    continue;
+                }
+                $hSite = '$'.$rp->name.'::'.$hookName.'()';
+                foreach ($hook->getAttributes() as $i => $a) {
+                    try {
+                        $add($a->getArguments(), $hSite, $i);
+                    } catch (\Throwable) {
+                    }
+                }
+                foreach ($hook->getParameters() as $pi => $hp) {
+                    foreach ($hp->getAttributes() as $i => $a) {
+                        try {
+                            $add($a->getArguments(), $hSite.'#'.$pi, $i);
+                        } catch (\Throwable) {
+                        }
+                    }
+                }
+            }
+        }
+        foreach ($rc->getMethods() as $rm) {
+            if ($rm->class !== $class) {
+                continue;
+            }
+            $mSite = $rm->name.'()';
+            foreach ($rm->getAttributes() as $i => $a) {
+                try {
+                    $add($a->getArguments(), $mSite, $i);
+                } catch (\Throwable) {
+                }
+            }
+            foreach ($rm->getParameters() as $pi => $rp) {
+                foreach ($rp->getAttributes() as $i => $a) {
+                    try {
+                        $add($a->getArguments(), $mSite.'#'.$pi, $i);
+                    } catch (\Throwable) {
+                    }
+                }
+                try {
+                    if ($rp->isDefaultValueAvailable()) {
+                        $add([$rp->getDefaultValue()], $mSite.'#'.$pi, null);
+                    }
+                } catch (\Throwable) {
+                }
+            }
+        }
+
+        return [$index, $lines];
+    }
+
+    private static function closureSignature(\ReflectionFunction $r): string
+    {
+        $sig = '';
+        foreach ($r->getParameters() as $p) {
+            $sig .= ($p->isPassedByReference() ? '&' : '').($p->isVariadic() ? '...' : '').'$'.$p->name.':'.$p->getType().';';
+        }
+
+        return $sig.':'.$r->getReturnType();
+    }
+
+    private static function resolveConstExprClosureScalar($value, ?array $allowedClasses = null): \Closure
+    {
+        if (!\is_array($value)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must be of type array, '.self::valueName($value).' given');
+        }
+        if (!\array_key_exists(0, $value) || !\array_key_exists(1, $value) || !\array_key_exists(2, $value) || !\array_key_exists(3, $value) || !\array_key_exists(4, $value) || 5 !== \count($value)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must have 5 elements');
+        }
+        [$class, $site, $attrIndex, $closureIndex, $line] = $value;
+
+        if (!\is_string($class)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure class name must be of type string, '.self::valueName($class).' given');
+        }
+        if (!\is_string($site)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure site must be of type string, '.self::valueName($site).' given');
+        }
+        if (null !== $attrIndex && !\is_int($attrIndex)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure attribute index must be of type int or null, '.self::valueName($attrIndex).' given');
+        }
+        if (!\is_int($closureIndex)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure closure index must be of type int, '.self::valueName($closureIndex).' given');
+        }
+        if (!\is_int($line)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure line must be of type int, '.self::valueName($line).' given');
+        }
+
+        if (null !== $allowedClasses && !isset(array_change_key_case(array_flip($allowedClasses))[strtolower($class)])) {
+            throw new \ValueError('deepclone_from_array(): class "'.$class.'" is not allowed');
+        }
+
+        try {
+            $rc = new \ReflectionClass($class);
+        } catch (\ReflectionException) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown class "'.$class.'"');
+        }
+
+        if ('' === $site) {
+            $target = $rc;
+        } elseif ('$' === $site[0]) {
+            if (false !== $pos = strpos($site, '::')) {
+                $target = null;
+                $hookSpec = substr($site, $pos + 2);
+                $paramIndex = null;
+                if (false !== $hashPos = strpos($hookSpec, ')#')) {
+                    $paramIndex = substr($hookSpec, $hashPos + 2);
+                    $hookSpec = substr($hookSpec, 0, $hashPos + 1);
+                }
+                if (('get()' === $hookSpec || 'set()' === $hookSpec) && (null === $paramIndex || $paramIndex === (string) (int) $paramIndex)) {
+                    try {
+                        $target = $rc->getProperty(substr($site, 1, $pos - 1))->getHook(\PropertyHookType::from(substr($hookSpec, 0, 3)));
+                        if ($target && null !== $paramIndex) {
+                            $target = $target->getParameters()[(int) $paramIndex] ?? null;
+                        }
+                    } catch (\ReflectionException) {
+                    }
+                }
+                if (!$target) {
+                    throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown hook "'.$site.'"');
+                }
+            } else {
+                try {
+                    $target = $rc->getProperty(substr($site, 1));
+                } catch (\ReflectionException) {
+                    throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown property "'.$site.'"');
+                }
+            }
+        } elseif (false !== $pos = strpos($site, ')#')) {
+            $num = substr($site, $pos + 2);
+            $target = null;
+            if (2 <= $pos && '(' === $site[$pos - 1] && $num === (string) (int) $num) {
+                try {
+                    $target = $rc->getMethod(substr($site, 0, $pos - 1))->getParameters()[(int) $num] ?? null;
+                } catch (\ReflectionException) {
+                }
+            }
+            if (null === $target) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown parameter "'.$site.'"');
+            }
+        } elseif (str_ends_with($site, '()')) {
+            try {
+                $target = $rc->getMethod(substr($site, 0, -2));
+            } catch (\ReflectionException) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown method "'.$site.'"');
+            }
+        } elseif (!$target = $rc->getReflectionConstant($site)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown constant "'.$site.'"');
+        }
+
+        if (null !== $attrIndex) {
+            $attrs = $target->getAttributes();
+            if (!isset($attrs[$attrIndex])) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown attribute index '.$attrIndex);
+            }
+            try {
+                $values = $attrs[$attrIndex]->getArguments();
+            } catch (\Throwable $e) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure evaluation failed for site "'.$site.'"', 0, $e);
+            }
+        } elseif ($target instanceof \ReflectionClass || $target instanceof \ReflectionMethod) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure attribute index is required for site "'.$site.'"');
+        } else {
+            try {
+                if ($target instanceof \ReflectionClassConstant) {
+                    $values = [$target->getValue()];
+                } elseif ($target instanceof \ReflectionParameter) {
+                    $values = $target->isDefaultValueAvailable() ? [$target->getDefaultValue()] : [];
+                } else {
+                    $values = $target->hasDefaultValue() ? [$target->getDefaultValue()] : [];
+                }
+            } catch (\Throwable $e) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure evaluation failed for site "'.$site.'"', 0, $e);
+            }
+        }
+
+        $found = null;
+        $i = 0;
+        $objects = [];
+        $walk = static function ($value) use (&$walk, &$found, &$i, $closureIndex, &$objects) {
+            if ($value instanceof \Closure) {
+                if ($i++ === $closureIndex) {
+                    $found = $value;
+                }
+            } elseif (\is_array($value)) {
+                foreach ($value as $v) {
+                    $walk($v);
+                    if (null !== $found) {
+                        return;
+                    }
+                }
+            } elseif (\is_object($value) && !isset($objects[$id = spl_object_id($value)])) {
+                $objects[$id] = true;
+                foreach ((array) $value as $v) {
+                    $walk($v);
+                    if (null !== $found) {
+                        return;
+                    }
+                }
+            }
+        };
+        $walk($values);
+        // Break the closure <-> &$walk reference cycle
+        $walk = null;
+
+        if (null === $found) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown closure index '.$closureIndex);
+        }
+        if ($line !== $foundLine = (new \ReflectionFunction($found))->getStartLine()) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) stale payload, const-expr-closure moved from line '.$line.' to line '.$foundLine);
+        }
+
+        return $found;
+    }
+
     private static function maskHasClosure($mask): bool
     {
-        if (0 === $mask) {
+        if (0 === $mask || 1 === $mask) {
             return true;
         }
         if (\is_array($mask)) {

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -12,9 +12,13 @@
 namespace Symfony\Polyfill\Tests\DeepClone;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Polyfill\Util\TestListenerTrait;
 
 if (\PHP_VERSION_ID >= 80100) {
     require __DIR__.'/fixtures.php';
+}
+if (\PHP_VERSION_ID >= 80500) {
+    require __DIR__.'/fixtures85.php';
 }
 
 /**
@@ -2006,5 +2010,495 @@ class DeepCloneTest extends TestCase
         $this->expectException(\ValueError::class);
         $this->expectExceptionMessage('has an __unserialize() method but "objectMeta" does not flag it for an __unserialize state');
         deepclone_from_array($d);
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testToArrayConstExprClosureClassAttributeWireFormat()
+    {
+        $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
+        $line = (new \ReflectionFunction($closure))->getStartLine();
+
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprClosureFixture::class, '', 0, 0, $line], $d['prepared']);
+        $this->assertSame(1, $d['mask']);
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureClassAttributeRebindsScope()
+    {
+        $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
+
+        $clone = deepclone_from_array(deepclone_to_array($closure));
+
+        $this->assertInstanceOf(\Closure::class, $clone);
+        $this->assertNotSame($closure, $clone);
+        $this->assertSame('class-secret', $clone());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureNestedAttributeArgument()
+    {
+        $closure = (new \ReflectionProperty(ConstExprClosureFixture::class, 'tagged'))->getAttributes()[0]->getArguments()['cb'][1]['x'];
+        $line = (new \ReflectionFunction($closure))->getStartLine();
+
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprClosureFixture::class, '$tagged', 0, 0, $line], $d['prepared']);
+        $this->assertSame(6, deepclone_from_array($d)(3));
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureMultipleClosuresInOneAttribute()
+    {
+        $args = (new \ReflectionClassConstant(ConstExprClosureFixture::class, 'TAGGED'))->getAttributes()[0]->getArguments();
+
+        foreach (['multi-0', 'multi-1'] as $i => $expected) {
+            $line = (new \ReflectionFunction($args[$i]))->getStartLine();
+            $d = deepclone_to_array($args[$i]);
+
+            $this->assertSame([ConstExprClosureFixture::class, 'TAGGED', 0, $i, $line], $d['prepared']);
+            $this->assertSame($expected, deepclone_from_array($d)());
+        }
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureRepeatedAttribute()
+    {
+        $closure = (new \ReflectionMethod(ConstExprClosureFixture::class, 'tagged'))->getAttributes()[1]->getArguments()[0];
+        $line = (new \ReflectionFunction($closure))->getStartLine();
+
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprClosureFixture::class, 'tagged()', 1, 0, $line], $d['prepared']);
+        $this->assertSame('repeated', deepclone_from_array($d)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureParameterAttribute()
+    {
+        $closure = (new \ReflectionMethod(ConstExprClosureFixture::class, 'tagged'))->getParameters()[0]->getAttributes()[0]->getArguments()[0];
+        $line = (new \ReflectionFunction($closure))->getStartLine();
+
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprClosureFixture::class, 'tagged()#0', 0, 0, $line], $d['prepared']);
+        $this->assertSame('param-attr', deepclone_from_array($d)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureParameterDefault()
+    {
+        $closure = (new \ReflectionMethod(ConstExprClosureFixture::class, 'tagged'))->getParameters()[0]->getDefaultValue();
+        $line = (new \ReflectionFunction($closure))->getStartLine();
+
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprClosureFixture::class, 'tagged()#0', null, 0, $line], $d['prepared']);
+        $this->assertSame('param-default', deepclone_from_array($d)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosurePropertyDefault()
+    {
+        $closure = (new \ReflectionProperty(ConstExprClosureFixture::class, 'factory'))->getDefaultValue();
+        $line = (new \ReflectionFunction($closure))->getStartLine();
+
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprClosureFixture::class, '$factory', null, 0, $line], $d['prepared']);
+        $this->assertSame('prop-default', deepclone_from_array($d)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureStaticPropertyDefault()
+    {
+        $closure = (new \ReflectionProperty(ConstExprClosureFixture::class, 'staticFactory'))->getDefaultValue();
+        $line = (new \ReflectionFunction($closure))->getStartLine();
+
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprClosureFixture::class, '$staticFactory', null, 0, $line], $d['prepared']);
+        $this->assertSame('static-prop-default', deepclone_from_array($d)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureClassConstantValue()
+    {
+        $closure = ConstExprClosureFixture::CALLBACKS['first'];
+        $line = (new \ReflectionFunction($closure))->getStartLine();
+
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprClosureFixture::class, 'CALLBACKS', null, 0, $line], $d['prepared']);
+        $this->assertSame('const-value', deepclone_from_array($d)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureEnumCaseAttribute()
+    {
+        $closure = (new \ReflectionClassConstant(ConstExprEnumFixture::class, 'Active'))->getAttributes()[0]->getArguments()[0];
+        $line = (new \ReflectionFunction($closure))->getStartLine();
+
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprEnumFixture::class, 'Active', 0, 0, $line], $d['prepared']);
+        $this->assertSame('enum-case-attr', deepclone_from_array($d)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureEnumConstant()
+    {
+        $closure = ConstExprEnumFixture::FILTER;
+        $line = (new \ReflectionFunction($closure))->getStartLine();
+
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprEnumFixture::class, 'FILTER', null, 0, $line], $d['prepared']);
+        $this->assertSame('enum-const', deepclone_from_array($d)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureTraitMethodAttribute()
+    {
+        $closure = (new \ReflectionClass(ConstExprTraitUserFixture::class))->getMethod('traitTagged')->getAttributes()[0]->getArguments()[0];
+
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame(ConstExprTraitUserFixture::class, $d['prepared'][0]);
+        $this->assertSame('trait-attr', deepclone_from_array($d)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosurePromotedParameterAttribute()
+    {
+        $closure = (new \ReflectionProperty(ConstExprPromotedFixture::class, 'promoted'))->getAttributes()[0]->getArguments()[0];
+        $line = (new \ReflectionFunction($closure))->getStartLine();
+
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprPromotedFixture::class, '__construct()#0', 0, 0, $line], $d['prepared']);
+        $this->assertSame('promoted-attr', deepclone_from_array($d)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureSameLineDistinctSignatures()
+    {
+        $args = (new \ReflectionClass(ConstExprSameLineFixture::class))->getAttributes()[0]->getArguments();
+
+        $this->assertSame('noargs', deepclone_from_array(deepclone_to_array($args[0]))());
+        $this->assertSame('witharg', deepclone_from_array(deepclone_to_array($args[1]))(1));
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testToArrayConstExprClosureAmbiguousSameLine()
+    {
+        $args = (new \ReflectionClass(ConstExprAmbiguousFixture::class))->getAttributes()[0]->getArguments();
+
+        if (\extension_loaded('deepclone') && !TestListenerTrait::$enabledPolyfills) {
+            // The extension tells same-line closures apart by op_array identity.
+            $this->assertSame('first', deepclone_from_array(deepclone_to_array($args[0]))());
+            $this->assertSame('second', deepclone_from_array(deepclone_to_array($args[1]))());
+
+            return;
+        }
+
+        // The polyfill only knows file/line/signature, which cannot tell them apart.
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('multiple closures share this declaration site');
+        deepclone_to_array($args[0]);
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testToArrayRuntimeStaticClosureIsNotInstantiable()
+    {
+        $closure = static function (): string { return 'runtime'; };
+
+        $this->expectException(\DeepClone\NotInstantiableException::class);
+        $this->expectExceptionMessage('Type "Closure" is not instantiable.');
+        deepclone_to_array($closure);
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureInsideObjectGraph()
+    {
+        $classClosure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
+        $propClosure = (new \ReflectionProperty(ConstExprClosureFixture::class, 'tagged'))->getAttributes()[0]->getArguments()['cb'][1]['x'];
+        $graph = new ConstraintLikeFixture($classClosure, [new ConstraintLikeFixture($propClosure)]);
+
+        $clone = deepclone_from_array(deepclone_to_array($graph));
+
+        $this->assertInstanceOf(ConstraintLikeFixture::class, $clone);
+        $this->assertInstanceOf(\Closure::class, $clone->callback);
+        $this->assertSame('class-secret', ($clone->callback)());
+        $this->assertSame(6, ($clone->constraints[0]->callback)(3));
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testConstExprClosurePayloadSurvivesJsonRoundTrip()
+    {
+        $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
+        $graph = new ConstraintLikeFixture($closure);
+
+        $d = json_decode(json_encode(deepclone_to_array($graph)), true);
+
+        $this->assertSame('class-secret', (deepclone_from_array($d)->callback)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testFromArrayConstExprClosureStaleLineThrows()
+    {
+        $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
+        $d = deepclone_to_array($closure);
+        ++$d['prepared'][4];
+
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('stale payload');
+        deepclone_from_array($d);
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testToArrayAllowedClassesRejectsConstExprClosure()
+    {
+        $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
+
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('"Closure" is not allowed');
+        deepclone_to_array($closure, []);
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testFromArrayAllowedClassesRejectsConstExprClosureInMask()
+    {
+        $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
+        $d = deepclone_to_array($closure);
+
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('"Closure" is not allowed');
+        deepclone_from_array($d, []);
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureWithAllowedClasses()
+    {
+        $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
+
+        $clone = deepclone_from_array(deepclone_to_array($closure, ['Closure']), ['Closure', ConstExprClosureFixture::class]);
+
+        $this->assertSame('class-secret', $clone());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testFromArrayConstExprClosureClassMustBeAllowed()
+    {
+        $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
+        $d = deepclone_to_array($closure, ['Closure']);
+
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('class "'.ConstExprClosureFixture::class.'" is not allowed');
+        deepclone_from_array($d, ['Closure']);
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testToArrayConstExprClosureAllowedGatePrecedesAmbiguity()
+    {
+        $closure = (new \ReflectionClass(ConstExprAmbiguousFixture::class))->getAttributes()[0]->getArguments()[0];
+
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('class "Closure" is not allowed');
+        deepclone_to_array($closure, []);
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureFactoryConstant()
+    {
+        $outer = ConstExprFactoryFixture::FACTORY;
+
+        $this->assertSame('inner', deepclone_from_array(deepclone_to_array($outer))()());
+
+        $this->expectException(\DeepClone\NotInstantiableException::class);
+        deepclone_to_array($outer());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testToArrayRuntimeClosureCollidingWithConstExprSite()
+    {
+        $attrClosure = (new \ReflectionMethod(ConstExprRuntimeCollisionFixture::class, 'make'))->getAttributes()[0]->getArguments()[0];
+
+        if (\extension_loaded('deepclone') && !TestListenerTrait::$enabledPolyfills) {
+            // The extension tells the attribute literal and the same-line runtime
+            // literal apart by op_array identity.
+            $this->assertSame('const-expr', deepclone_from_array(deepclone_to_array($attrClosure))());
+
+            $this->expectException(\DeepClone\NotInstantiableException::class);
+            deepclone_to_array(ConstExprRuntimeCollisionFixture::make());
+
+            return;
+        }
+
+        // Both closures share the method-derived name, line and signature; the
+        // polyfill cannot tell them apart and refuses both.
+        try {
+            deepclone_to_array($attrClosure);
+            $this->fail('Expected ValueError was not thrown');
+        } catch (\ValueError $e) {
+            $this->assertStringContainsString('multiple closures share this declaration site', $e->getMessage());
+        }
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('multiple closures share this declaration site');
+        deepclone_to_array(ConstExprRuntimeCollisionFixture::make());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureEvaluatedThroughTwoSurfaces()
+    {
+        $closure = (new ConstExprDualSurfaceFixture())->cb;
+
+        $this->assertSame('dual-surface', deepclone_from_array(deepclone_to_array($closure))());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosureAliasedTraitMethod()
+    {
+        $closure = (new \ReflectionMethod(ConstExprTraitAliasFixture::class, 'traitTagged'))->getAttributes()[0]->getArguments()[0];
+
+        $this->assertSame('trait-attr', deepclone_from_array(deepclone_to_array($closure))());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testToArrayConstExprClosureWithoutSourcesInvitesExtension()
+    {
+        if (!class_exists('ConstExprNoSourcesFixture', false)) {
+            $file = sys_get_temp_dir().'/ConstExprNoSourcesFixture.php';
+            file_put_contents($file, '<?php class ConstExprNoSourcesFixture { #[Symfony\\Polyfill\\Tests\\DeepClone\\ConstExprAttr(static function (): string { return "no-sources"; })] public function m(): void {} }');
+            require $file;
+            unlink($file);
+        }
+        $closure = (new \ReflectionMethod(\ConstExprNoSourcesFixture::class, 'm'))->getAttributes()[0]->getArguments()[0];
+
+        if (\extension_loaded('deepclone') && !TestListenerTrait::$enabledPolyfills) {
+            // The extension matches op_arrays and needs no source files.
+            $this->assertSame('no-sources', deepclone_from_array(deepclone_to_array($closure))());
+
+            return;
+        }
+
+        // Method-scoped names require reading the file to rule out aliasing.
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('install the "deepclone" extension');
+        deepclone_to_array($closure);
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testRoundTripConstExprClosurePropertyHookAttributes()
+    {
+        $closure = (new \ReflectionProperty(ConstExprHookedFixture::class, 'virtual'))->getHook(\PropertyHookType::Get)->getAttributes()[0]->getArguments()[0];
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprHookedFixture::class, '$virtual::get()', 0, 0, (new \ReflectionFunction($closure))->getStartLine()], $d['prepared']);
+        $this->assertSame('get-hook-attr', deepclone_from_array($d)());
+
+        $closure = (new \ReflectionProperty(ConstExprHookedFixture::class, 'stored'))->getHook(\PropertyHookType::Set)->getParameters()[0]->getAttributes()[0]->getArguments()[0];
+        $d = deepclone_to_array($closure);
+
+        $this->assertSame([ConstExprHookedFixture::class, '$stored::set()#0', 0, 0, (new \ReflectionFunction($closure))->getStartLine()], $d['prepared']);
+        $this->assertSame('set-hook-param-attr', deepclone_from_array($d)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testFromArrayConstExprClosureMalformedPayloads()
+    {
+        $line = (new \ReflectionFunction((new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0]))->getStartLine();
+        $cases = [
+            ['foo', 'const-expr-closure value must be of type array, string given'],
+            [[ConstExprClosureFixture::class], 'const-expr-closure value must have 5 elements'],
+            [[42, '', 0, 0, $line], 'const-expr-closure class name must be of type string, int given'],
+            [['No\\Such\\ClassAtAll', '', 0, 0, $line], 'const-expr-closure references unknown class "No\\Such\\ClassAtAll"'],
+            [[ConstExprClosureFixture::class, 42, 0, 0, $line], 'const-expr-closure site must be of type string, int given'],
+            [[ConstExprClosureFixture::class, '', 'x', 0, $line], 'const-expr-closure attribute index must be of type int or null, string given'],
+            [[ConstExprClosureFixture::class, '', 0, 'x', $line], 'const-expr-closure closure index must be of type int, string given'],
+            [[ConstExprClosureFixture::class, '', 0, 0, 'x'], 'const-expr-closure line must be of type int, string given'],
+            [[ConstExprClosureFixture::class, '$nope', 0, 0, $line], 'const-expr-closure references unknown property "$nope"'],
+            [[ConstExprClosureFixture::class, 'nope()', 0, 0, $line], 'const-expr-closure references unknown method "nope()"'],
+            [[ConstExprClosureFixture::class, 'NOPE', 0, 0, $line], 'const-expr-closure references unknown constant "NOPE"'],
+            [[ConstExprClosureFixture::class, 'tagged()#9', 0, 0, $line], 'const-expr-closure references unknown parameter "tagged()#9"'],
+            [[ConstExprClosureFixture::class, '', 9, 0, $line], 'const-expr-closure references unknown attribute index 9'],
+            [[ConstExprClosureFixture::class, '', 0, 9, $line], 'const-expr-closure references unknown closure index 9'],
+            [[ConstExprClosureFixture::class, '', null, 0, $line], 'const-expr-closure attribute index is required for site ""'],
+            [[ConstExprClosureFixture::class, 'tagged()', null, 0, $line], 'const-expr-closure attribute index is required for site "tagged()"'],
+        ];
+
+        foreach ($cases as [$prepared, $expected]) {
+            try {
+                deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => $prepared, 'mask' => 1]);
+                $this->fail('Expected ValueError was not thrown for: '.$expected);
+            } catch (\ValueError $e) {
+                $this->assertStringContainsString($expected, $e->getMessage());
+            }
+        }
     }
 }

--- a/tests/DeepClone/fixtures85.php
+++ b/tests/DeepClone/fixtures85.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Tests\DeepClone;
+
+#[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
+class ConstExprAttr
+{
+    public array $args;
+
+    public function __construct(mixed ...$args)
+    {
+        $this->args = $args;
+    }
+}
+
+#[ConstExprAttr(static function (): string { return self::SECRET; })]
+class ConstExprClosureFixture
+{
+    private const SECRET = 'class-secret';
+
+    public const CALLBACKS = ['first' => static function (): string { return 'const-value'; }];
+
+    #[ConstExprAttr(
+        static function (): string { return 'multi-0'; },
+        static function (): string { return 'multi-1'; },
+    )]
+    public const TAGGED = 1;
+
+    #[ConstExprAttr(cb: [1, ['x' => static function (int $i): int { return $i * 2; }]])]
+    public string $tagged = 'v';
+
+    public ?\Closure $factory = static function (): string { return 'prop-default'; };
+
+    public static ?\Closure $staticFactory = static function (): string { return 'static-prop-default'; };
+
+    #[ConstExprAttr('not-a-closure')]
+    #[ConstExprAttr(static function (): string { return 'repeated'; })]
+    public function tagged(
+        #[ConstExprAttr(static function (): string { return 'param-attr'; })]
+        ?\Closure $cb = static function (): string { return 'param-default'; },
+    ): void {
+    }
+}
+
+#[ConstExprAttr(static function (): string { return 'first'; }, static function (): string { return 'second'; })]
+class ConstExprAmbiguousFixture
+{
+}
+
+#[ConstExprAttr(static function (): string { return 'noargs'; }, static function (int $x): string { return 'witharg'; })]
+class ConstExprSameLineFixture
+{
+}
+
+enum ConstExprEnumFixture: string
+{
+    #[ConstExprAttr(static function (): string { return 'enum-case-attr'; })]
+    case Active = 'A';
+
+    public const FILTER = static function (): string { return 'enum-const'; };
+}
+
+trait ConstExprTraitFixture
+{
+    #[ConstExprAttr(static function (): string { return 'trait-attr'; })]
+    public function traitTagged(): void
+    {
+    }
+}
+
+class ConstExprTraitUserFixture
+{
+    use ConstExprTraitFixture;
+}
+
+class ConstExprPromotedFixture
+{
+    public function __construct(
+        #[ConstExprAttr(static function (): string { return 'promoted-attr'; })]
+        public int $promoted = 1,
+    ) {
+    }
+}
+
+class ConstraintLikeFixture
+{
+    public function __construct(
+        public mixed $callback = null,
+        public array $constraints = [],
+    ) {
+    }
+}
+
+class ConstExprFactoryFixture
+{
+    public const FACTORY = static function (): \Closure { return static function (): string { return 'inner'; }; };
+}
+
+class ConstExprRuntimeCollisionFixture
+{
+    #[ConstExprAttr(static function (): string { return 'const-expr'; })] public static function make(): \Closure { return static function (): string { return 'runtime'; }; }
+}
+
+#[ConstExprAttr(new ConstExprDualSurfaceFixture())]
+class ConstExprDualSurfaceFixture
+{
+    public function __construct(
+        public ?\Closure $cb = static function (): string { return 'dual-surface'; },
+    ) {
+    }
+}
+
+class ConstExprTraitAliasFixture
+{
+    use ConstExprTraitFixture {
+        traitTagged as traitAliased;
+    }
+}
+
+class ConstExprHookedFixture
+{
+    public string $virtual {
+        #[ConstExprAttr(static function (): string { return 'get-hook-attr'; })]
+        get => 'vx';
+    }
+
+    public string $stored = 'init' {
+        set (#[ConstExprAttr(static function (): string { return 'set-hook-param-attr'; })] string $value) {
+            $this->stored = $value;
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | symfony/symfony#63228
| License       | MIT

PHP 8.5 allows anonymous closures in constant expressions: attribute arguments, class constants, property and parameter defaults, property hooks. Frameworks now meet them when reading attributes (e.g. `#[Assert\When(static function () { ... })]`) and can no longer cache the resulting metadata, since closures refuse `serialize()` and `deepclone_to_array()` alike.

Const-expr closures are compile-time checked to be static and capture-free, so they are fully described by their declaration site. `deepclone_to_array()` now encodes them under the new mask marker `1` as `[class, site, attrIndex|null, closureIndex, startLine]`, where `site` is `""` (the class), `"NAME"` (constant or enum case), `"$name"` (property), `"name()"` (method), `"name()#N"` (parameter) or `"$name::get()"` / `"$name::set()#N"` (property hooks). `deepclone_from_array()` re-evaluates the addressed constant expression through reflection, picks the Nth closure of a depth-first walk (arrays in order, objects through their array-cast properties) and verifies the declaration line still matches, so payloads that outlived a code change fail loudly (`stale payload`) instead of resolving to a moved closure.

- **Identification.** The extension matches literals by op_array identity; userland cannot, so the polyfill identifies them by closure name, file, line span and signature over a per-class index of every const-expr site. The closure name encodes nesting and method context, and a token-level count of closure literals per source line guards the remaining aliasing case: a closure created at runtime never silently resolves to a const-expr literal, declaration sites the polyfill cannot tell apart are refused. The same literal reached through several surfaces (an attribute argument referencing a class constant, a trait alias, a promoted default applied by a constructor evaluated elsewhere) resolves to the first site that exposes it; promoted properties are addressed through their constructor parameter, the canonical surface.
- **Source-less deployments.** The aliasing guard needs to read the declaring file for method- and hook-scoped closures. When the file is not there (deployments shipping only precompiled opcodes), the refusal says so explicitly and points to the extension, which matches literals by op_array identity and needs no sources.
- **Security.** The payload carries no code, only names and indices; the resolved code is whatever the loaded class declares. `allowed_classes` gates both directions: `Closure` must be allowed before any constant expression is evaluated on the `to_array` side, and the payload-named class must be allow-listed before it is autoloaded on the `from_array` side, so unserialization cannot drive autoloading or constructor execution for classes outside the allow-list.

Payloads are byte-identical and interchangeable with the extension's, covered by tests that run against both implementations (the few cases where op_array identity outperforms the userland heuristic branch per implementation). Closures created at runtime keep throwing `NotInstantiableException`.

Companion extension implementation: symfony/php-ext-deepclone#21
