### PR TITLE
[DeepClone] Reject from_array payloads that would build an uninitialized object

### DIFF
--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -789,7 +789,7 @@ final class DeepClone
     {
         $objects = [];
 
-        foreach ($objectMeta as $id => [$class]) {
+        foreach ($objectMeta as $id => [$class, $wakeup]) {
             if (':' === ($class[1] ?? null)) {
                 // The result is used as an object below; a malformed payload can
                 // carry any serialize form (i:…, s:…, a:…), so reject anything
@@ -803,6 +803,15 @@ final class DeepClone
                 self::$reflectors[$class] ??= self::getClassReflector($class);
             } catch (\DeepClone\ClassNotFoundException) {
                 throw new \DeepClone\ClassNotFoundException('Class "'.$class.'" not found.');
+            }
+
+            // A class with __unserialize() is only ever emitted (by
+            // deepclone_to_array()) as a negative-wakeup state replay; a payload
+            // that creates one without that flag could not initialize it (e.g.
+            // BcMath\Number's bc_num would stay NULL). Reject rather than build
+            // an unusable object, matching the extension.
+            if ($wakeup >= 0 && (self::$classInfo[$class][0] ??= self::$reflectors[$class]->hasMethod('__unserialize'))) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) object '.$id.' of class '.$class.' has an __unserialize() method but "objectMeta" does not flag it for an __unserialize state');
             }
 
             if (self::$needsFullUnserialize[$class] ?? false) {

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -1991,4 +1991,20 @@ class DeepCloneTest extends TestCase
         $deep = deepclone_from_array(deepclone_to_array((object) ['list' => [(object) ['r' => new \Random\Randomizer(new \Random\Engine\Mt19937(9))]]]));
         $this->assertInstanceOf(\Random\Randomizer::class, $deep->list[0]->r);
     }
+
+    public function testFromArrayRejectsUnserializeClassWithoutReplayFlag()
+    {
+        // A class with __unserialize() is always emitted as a negative-wakeup
+        // state replay. A crafted payload that clears that flag and drops the
+        // replay would leave the object uninitialized (e.g. a BcMath\Number
+        // with a NULL bc_num), so it is rejected rather than reconstructed,
+        // matching the extension.
+        $d = deepclone_to_array(new DeepCloneSerializeFixture('x', 1));
+        $d['objectMeta'][0][1] = 0; // clear the __unserialize flag
+        $d['states'] = [];          // drop the replay
+
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('has an __unserialize() method but "objectMeta" does not flag it for an __unserialize state');
+        deepclone_from_array($d);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Brings the polyfill in line with the extension's symfony/php-ext-deepclone#22.

`deepclone_to_array()` always emits a class that has `__unserialize()` as a negative-wakeup state replay. A crafted `deepclone_from_array()` payload that flags such a class for plain creation (`wakeup >= 0`, no replay) was reconstructed as an uninitialized object: the polyfill returned `null`, while the extension (before #22) built a bare shell, e.g. a `BcMath\Number` whose `bc_num` stays `NULL` and crashes on use.

`reconstruct()` now rejects such a payload with a `\ValueError` before building the object, using the same message as the extension. Well-formed payloads, which always carry the negative-wakeup replay for an `__unserialize` class, are unaffected.
