### PR TITLE
[DeepClone] Reference const-expr closures through engine ids on PHP 8.6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Contribution Guidelines
+
+- Run tests using ./phpunit
+- Use TDD: write a failing test first, then implement the fix.
+- Use comments sparingly — only when they add real value, and don't reference issues in the code nor in tests.
+- no em-dashes, no Co-Authored-By field, no credit of Claude or Anthropic anywhere

--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -658,18 +658,23 @@ final class DeepClone
                 $r = new \ReflectionFunction($value);
 
                 if (!(\PHP_VERSION_ID >= 80200 ? $r->isAnonymous() : str_contains($r->name, "@anonymous\0"))) {
-                    // First-class callable. When it references a method of its
-                    // own declaring class declared in a constant expression
-                    // (e.g. #[When(self::isStrict(...))]), encode it as a
-                    // declaration-site reference like the extension does, so it
-                    // round-trips without the allow_named_closures opt-in.
-                    // Closure is allow-list-gated first, mirroring the
-                    // extension (reported before any const-expr is evaluated).
-                    if (\PHP_VERSION_ID >= 80500 && !$r->getClosureThis() && $r->getClosureScopeClass()) {
+                    // First-class callable declared in a constant expression,
+                    // encoded as a declaration-site reference (like the
+                    // extension) so it round-trips without the
+                    // allow_named_closures opt-in. On PHP 8.6 the engine names
+                    // the declaring class (getConstExprClass), covering
+                    // cross-class (#[When(Validators::check(...))]) and global
+                    // (#[When(strlen(...))]) references; on 8.5 only a callable
+                    // over a method of its own declaring class is locatable.
+                    // Closure is allow-list-gated first, mirroring the extension.
+                    $declaringClass = \PHP_VERSION_ID >= 80600 ? $r->getConstExprClass() : null;
+                    if (\PHP_VERSION_ID >= 80500 && !$r->getClosureThis()
+                        && (null !== $declaringClass || $r->getClosureScopeClass())
+                    ) {
                         if (null !== $allowedSet && !isset($allowedSet['closure'])) {
                             throw new \ValueError('deepclone_to_array(): class "Closure" is not allowed');
                         }
-                        if (null !== $ref = self::locateConstExprClosure($r)) {
+                        if (null !== $ref = self::locateConstExprClosure($r, $declaringClass)) {
                             $value = $ref;
                             $mask[$k] = 1;
 
@@ -703,11 +708,28 @@ final class DeepClone
                     throw new \ValueError('deepclone_to_array(): class "Closure" is not allowed');
                 }
 
+                if (\PHP_VERSION_ID >= 80600 && null !== $id = $r->getConstExprId()) {
+                    // The engine gives a canonical per-class id to closures declared
+                    // in attribute arguments and in parameter default values; closures
+                    // declared in class constant values and in property default values
+                    // have no id and keep using the site-based reference below
+                    $value = [$r->getClosureScopeClass()->name, $id, $r->getStartLine()];
+                    $mask[$k] = 1;
+
+                    goto handle_value;
+                }
+
                 if (\PHP_VERSION_ID >= 80500 && null !== $ref = self::locateConstExprClosure($r)) {
                     $value = $ref;
                     $mask[$k] = 1;
 
                     goto handle_value;
+                }
+
+                if (\PHP_VERSION_ID >= 80600) {
+                    // No engine id and no usable declaration site: let
+                    // Closure::__serialize() throw the engine's refusal
+                    $value->__serialize();
                 }
             }
 
@@ -1273,14 +1295,28 @@ final class DeepClone
      * argument, class constant, property or parameter default) to its declaration
      * site: [class, site, attribute index or null, closure index, start line].
      */
-    private static function locateConstExprClosure(\ReflectionFunction $r): ?array
+    private static function locateConstExprClosure(\ReflectionFunction $r, ?string $declaringClass = null): ?array
     {
-        if (!$r->isStatic() || $r->getClosureThis() || $r->getClosureUsedVariables() || !($scope = $r->getClosureScopeClass())) {
+        if ($r->getClosureThis() || $r->getClosureUsedVariables()) {
+            return null;
+        }
+        if (null !== $declaringClass) {
+            // PHP 8.6: the engine named the declaring class (ReflectionFunction::
+            // getConstExprClass), which for a cross-class or global first-class
+            // callable differs from the closure's scope. Index that class.
+            try {
+                $scope = new \ReflectionClass($declaringClass);
+            } catch (\ReflectionException) {
+                return null;
+            }
+        } elseif (!$r->isStatic() || !($scope = $r->getClosureScopeClass())) {
             return null;
         }
 
         [$index, $lines] = self::$constExprIndex[$scope->name] ??= self::indexConstExprClosures($scope);
         $file = $r->getFileName();
+        // Raw value (false for an internal function) so it matches the key built
+        // by indexConstExprClosures(); normalized to 0 in the returned payload.
         $line = $r->getStartLine();
 
         if (!$candidates = $index[$r->name.':'.$file.':'.$line.':'.$r->getEndLine().':'.self::closureSignature($r)] ?? null) {
@@ -1290,11 +1326,24 @@ final class DeepClone
         // First-class callables are keyed by their target method's identity, so
         // several declaration sites can map to the same key; they are
         // equivalent and the first one wins, exactly like the extension. The
-        // anonymous-only checks below (the same-site ambiguity guard and the
-        // runtime-aliasing refusal) only concern anonymous closure literals,
-        // which are told apart by source position.
+        // checks below (the 8.6 engine-id exclusion, the same-site ambiguity
+        // guard and the runtime-aliasing refusal) only concern anonymous
+        // closure literals, which are told apart by source position; an fcc has
+        // no engine id here and never reaches the engine-id encoder.
         if (!$r->isAnonymous()) {
-            return [$scope->name, $candidates[0][0], $candidates[0][1], $candidates[0][2], $line];
+            return [$scope->name, $candidates[0][0], $candidates[0][1], $candidates[0][2], $line ?: 0];
+        }
+
+        if (\PHP_VERSION_ID >= 80600) {
+            // Anonymous closures declared in attribute arguments and parameter
+            // default values carry an engine id and are encoded through it, so
+            // they never reach this lookup; a closure matching such a candidate
+            // merely shares its declaration site.
+            $candidates = array_values(array_filter($candidates, static fn ($c) => null === $c[1] && !preg_match('/\)#\d+$/', $c[0])));
+
+            if (!$candidates) {
+                return null;
+            }
         }
 
         $sites = [];
@@ -1314,7 +1363,7 @@ final class DeepClone
             throw new \ValueError('deepclone_to_array(): cannot reference anonymous closure declared at '.$file.':'.$line.', multiple closures share this declaration site');
         }
 
-        return [$scope->name, $candidates[0][0], $candidates[0][1], $candidates[0][2], $line];
+        return [$scope->name, $candidates[0][0], $candidates[0][1], $candidates[0][2], $line ?: 0];
     }
 
     private static function countClosureLiterals(string $file, int $line): int
@@ -1380,13 +1429,13 @@ final class DeepClone
                     }
                     $seen[$id] = true;
                     $r = new \ReflectionFunction($value);
-                    // Index anonymous closures declared in this class, and
-                    // first-class callables over a method of this class (their
-                    // scope is the target method's class): both are closures
-                    // the class declares about itself. Cross-class and
-                    // global-function callables have a different (or null)
-                    // scope and are addressed by name instead.
-                    if ($r->getClosureScopeClass()?->name !== $class) {
+                    // Index every first-class callable found in this class's
+                    // constant expressions, whatever its target (own method,
+                    // another class's method, or a global function) -- the class
+                    // declares the reference. Anonymous closures must be scoped
+                    // to this class (a foreign literal reached through a const
+                    // reference is not declared here).
+                    if ($r->isAnonymous() && $r->getClosureScopeClass()?->name !== $class) {
                         return;
                     }
                     $index[$r->name.':'.$r->getFileName().':'.$r->getStartLine().':'.$r->getEndLine().':'.self::closureSignature($r)][] = [$site, $attrIndex, $n];
@@ -1514,6 +1563,54 @@ final class DeepClone
         if (!\is_array($value)) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must be of type array, '.self::valueName($value).' given');
         }
+
+        // Engine-id reference [class, id, line], emitted on PHP >= 8.6; the type
+        // of element 1 (int id vs string site) discriminates it from the
+        // site-based reference handled below
+        if (\is_int($value[1] ?? null)) {
+            if (!\array_key_exists(0, $value) || !\array_key_exists(2, $value) || 3 !== \count($value)) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must have 3 elements');
+            }
+            [$class, $id, $line] = $value;
+
+            if (!\is_string($class)) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure class name must be of type string, '.self::valueName($class).' given');
+            }
+            if (!\is_int($line)) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure line must be of type int, '.self::valueName($line).' given');
+            }
+
+            if (null !== $allowedClasses && !isset(array_change_key_case(array_flip($allowedClasses))[strtolower($class)])) {
+                throw new \ValueError('deepclone_from_array(): class "'.$class.'" is not allowed');
+            }
+
+            if (\PHP_VERSION_ID < 80600) {
+                throw new \ValueError('deepclone_from_array(): const-expr-closure payload was created on PHP 8.6 or later and cannot be resolved on PHP '.\PHP_VERSION);
+            }
+
+            try {
+                new \ReflectionClass($class);
+            } catch (\ReflectionException) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown class "'.$class.'"');
+            }
+
+            try {
+                $found = \Closure::fromConstExpr($class, $id);
+            } catch (\ValueError) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown closure id '.$id.' in class "'.$class.'"');
+            }
+
+            $r = new \ReflectionFunction($found);
+            if (!str_contains($r->name, '{closure')) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references a first-class callable site');
+            }
+            if ($line !== $foundLine = $r->getStartLine()) {
+                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) stale payload, const-expr-closure moved from line '.$line.' to line '.$foundLine);
+            }
+
+            return $found;
+        }
+
         if (!\array_key_exists(0, $value) || !\array_key_exists(1, $value) || !\array_key_exists(2, $value) || !\array_key_exists(3, $value) || !\array_key_exists(4, $value) || 5 !== \count($value)) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must have 5 elements');
         }

--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -713,10 +713,10 @@ final class DeepClone
                     // in parameter default values by an element-scoped "<site>@<rank>"
                     // id, the exact reference the site-based lookup below derives;
                     // closures declared in class constant values and in property
-                    // default values have no engine id and use the lookup. The line
-                    // is stored relative to the declaring class (its scope class).
-                    $scope = $r->getClosureScopeClass();
-                    $value = [$scope->name, $id, $r->getStartLine() - $scope->getStartLine()];
+                    // default values have no engine id and use the lookup. The id
+                    // already carries a "#<hash>" of the closure's code, so the
+                    // reference needs no separate staleness field.
+                    $value = [$r->getClosureScopeClass()->name, $id];
                     $mask[$k] = 1;
 
                     goto handle_value;
@@ -1321,10 +1321,6 @@ final class DeepClone
         // Raw value (false for an internal function) so it matches the key built
         // by indexConstExprClosures().
         $line = $r->getStartLine();
-        // The payload line is relative to the declaring class, so an edit above
-        // the class does not invalidate the reference (matches the extension);
-        // an internal function has no line and stores 0.
-        $relLine = false === $line ? 0 : $line - $scope->getStartLine();
 
         if (!$candidates = $index[$r->name.':'.$file.':'.$line.':'.$r->getEndLine().':'.self::closureSignature($r)] ?? null) {
             return null;
@@ -1338,7 +1334,7 @@ final class DeepClone
         // closure literals, which are told apart by source position; an fcc has
         // no engine id here and never reaches the engine-id encoder.
         if (!$r->isAnonymous()) {
-            return [$scope->name, $candidates[0][0].'@'.$candidates[0][1], $relLine];
+            return [$scope->name, $candidates[0][0].'@'.$candidates[0][1]];
         }
 
         if (\PHP_VERSION_ID >= 80600) {
@@ -1370,7 +1366,7 @@ final class DeepClone
             throw new \ValueError('deepclone_to_array(): cannot reference anonymous closure declared at '.$file.':'.$line.', multiple closures share this declaration site');
         }
 
-        return [$scope->name, $candidates[0][0].'@'.$candidates[0][1], $relLine];
+        return [$scope->name, $candidates[0][0].'@'.$candidates[0][1]];
     }
 
     private static function countClosureLiterals(string $file, int $line): int
@@ -1613,10 +1609,10 @@ final class DeepClone
         if (!\is_array($value)) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must be of type array, '.self::valueName($value).' given');
         }
-        if (!\array_key_exists(0, $value) || !\array_key_exists(1, $value) || !\array_key_exists(2, $value) || 3 !== \count($value)) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must have 3 elements');
+        if (!\array_key_exists(0, $value) || !\array_key_exists(1, $value) || 2 !== \count($value)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must have 2 elements');
         }
-        [$class, $id, $line] = $value;
+        [$class, $id] = $value;
 
         if (!\is_string($class)) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure class name must be of type string, '.self::valueName($class).' given');
@@ -1624,19 +1620,23 @@ final class DeepClone
         if (!\is_string($id)) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure id must be of type string, '.self::valueName($id).' given');
         }
-        if (!\is_int($line)) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure line must be of type int, '.self::valueName($line).' given');
-        }
 
         if (null !== $allowedClasses && !isset(array_change_key_case(array_flip($allowedClasses))[strtolower($class)])) {
             throw new \ValueError('deepclone_from_array(): class "'.$class.'" is not allowed');
         }
 
-        $rank = false === ($at = strrpos($id, '@')) ? '' : substr($id, $at + 1);
+        // An engine-produced id may carry a "#<hash>" code fingerprint after the
+        // rank. The polyfill cannot recompute it (the closure's source is
+        // discarded at compile time), so on the value-walk below the hash is
+        // stripped and the reference resolves positionally; on 8.6 the
+        // hash-bearing id is verified by Closure::fromConstExpr first.
+        $hasHash = false !== ($sharp = strrpos($id, '#'));
+        $coreId = $hasHash ? substr($id, 0, $sharp) : $id;
+        $rank = false === ($at = strrpos($coreId, '@')) ? '' : substr($coreId, $at + 1);
         if ('' === $rank || \strlen($rank) !== strspn($rank, '0123456789') || ('0' === $rank[0] && '0' !== $rank)) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure id must be of the form "<site>@<rank>", "'.$id.'" given');
         }
-        $site = substr($id, 0, $at);
+        $site = substr($coreId, 0, $at);
         $rank = (int) $rank;
 
         try {
@@ -1646,20 +1646,19 @@ final class DeepClone
         }
 
         if (\PHP_VERSION_ID >= 80600) {
-            // The engine resolves its own ids fastest. Its walk reads the raw
-            // constant expressions though, while this reference counts evaluated
-            // values, so fall back to the evaluating walk below when the engine
-            // does not know the id or resolves it to another line. The stored
-            // line is relative to the declaring class; internal functions
-            // (e.g. a global strlen(...) reference) have no start line and
-            // store 0, like on the encoding side.
+            // The engine resolves its own ids, verifying the "#<hash>"
+            // fingerprint. Its walk reads the raw constant expressions, while
+            // this reference counts evaluated values, so a hash-less id the
+            // engine does not know (a closure in a constant or property value)
+            // falls through to the evaluating walk. A hash-bearing id is fully
+            // the engine's to judge: if it rejects one, the reference is stale,
+            // so surface that instead of healing positionally.
             try {
-                $found = \Closure::fromConstExpr($class, $id);
-                $fl = (new \ReflectionFunction($found))->getStartLine();
-                if ($line === (false === $fl ? 0 : $fl - $rc->getStartLine())) {
-                    return $found;
+                return \Closure::fromConstExpr($class, $id);
+            } catch (\ValueError $e) {
+                if ($hasHash) {
+                    throw $e;
                 }
-            } catch (\ValueError) {
             }
         }
 
@@ -1819,12 +1818,10 @@ final class DeepClone
         if (null === $found) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown closure id "'.$id.'" in class "'.$class.'"');
         }
-        $fl = (new \ReflectionFunction($found))->getStartLine();
-        $foundLine = false === $fl ? 0 : $fl - $rc->getStartLine();
-        if ($line !== $foundLine) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) stale payload, const-expr-closure moved from class-relative line '.$line.' to '.$foundLine);
-        }
 
+        // This value-walk resolves positionally: a hash-less id carries no
+        // staleness check (the polyfill cannot recompute the engine's code
+        // hash), so the rank alone selects the closure.
         return $found;
     }
 

--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -659,8 +659,9 @@ final class DeepClone
                 $r = new \ReflectionFunction($value);
 
                 // On an engine that serializes const-expr closures natively, use
-                // that first: Closure::__serialize() yields the [class, id]
-                // declaration-site reference for the closures it addresses
+                // that first: Closure::__serialize() yields the
+                // [class, site, key, hash] declaration-site reference for the
+                // closures it addresses
                 // (attribute arguments and parameter defaults, cross-class and
                 // global first-class callables included) and throws for the rest,
                 // which fall through to the reflection-based lookup below. Such a
@@ -1300,9 +1301,9 @@ final class DeepClone
     }
 
     /**
-     * Reads a const-expr closure's [class, id] declaration-site reference out of
-     * the engine's native Closure::__serialize(), which yields
-     *   [ [], ["const-expr", [class, id]] ]
+     * Reads a const-expr closure's [class, site, key, hash] declaration-site
+     * reference out of the engine's native Closure::__serialize(), which yields
+     *   [ [], ["const-expr", [class, site, key, hash]] ]
      * for the closures it addresses and throws for the rest. Returns null (rather
      * than throwing) for a closure the engine does not address, so the caller
      * falls back to the reflection-based lookup.
@@ -1316,10 +1317,11 @@ final class DeepClone
         }
 
         if (isset($data[1][0], $data[1][1]) && 'const-expr' === $data[1][0]
-            && \is_array($ref = $data[1][1]) && 2 === \count($ref)
-            && isset($ref[0], $ref[1]) && \is_string($ref[0]) && \is_string($ref[1])
+            && \is_array($ref = $data[1][1]) && 4 === \count($ref)
+            && \array_key_exists(0, $ref) && \array_key_exists(1, $ref) && \array_key_exists(2, $ref) && \array_key_exists(3, $ref)
+            && \is_string($ref[0]) && \is_string($ref[1]) && (\is_int($ref[2]) || \is_string($ref[2])) && \is_int($ref[3])
         ) {
-            return [$ref[0], $ref[1]];
+            return [$ref[0], $ref[1], $ref[2], $ref[3]];
         }
 
         return null;
@@ -1327,17 +1329,18 @@ final class DeepClone
 
     /**
      * deepclone_from_array() counterpart of nativeConstExprRef(): resolves a
-     * [class, id] reference through the engine's own Closure unserialization,
-     * which re-evaluates the reference bounded to what the class declares and
-     * verifies any "#<hash>" fingerprint. The serialized form is synthesized
-     * directly (the class and id are length-prefixed, so no escaping is needed);
-     * $allowedClasses gates the Closure the payload instantiates. Throws the
-     * engine's exception when the reference is stale or unknown; returns null if
-     * unserialization yields anything other than a Closure.
+     * [class, site, key, hash] reference through the engine's own Closure
+     * unserialization, which re-evaluates the reference bounded to what the class
+     * declares and verifies a non-zero hash. The serialized form is synthesized
+     * directly (the strings are length-prefixed, so no escaping is needed; the key
+     * is a rank (int) or a callable name (string)); $allowedClasses gates the
+     * Closure the payload instantiates. Throws the engine's exception when the
+     * reference is stale or unknown; returns null if unserialization yields
+     * anything other than a Closure.
      */
-    private static function nativeConstExprResolve(string $class, string $id, ?array $allowedClasses): ?\Closure
+    private static function nativeConstExprResolve(string $class, string $site, $key, int $hash, ?array $allowedClasses): ?\Closure
     {
-        $payload = 'O:7:"Closure":'.substr(serialize([[], ['const-expr', [$class, $id]]]), 2);
+        $payload = 'O:7:"Closure":'.substr(serialize([[], ['const-expr', [$class, $site, $key, $hash]]]), 2);
         $result = unserialize($payload, ['allowed_classes' => $allowedClasses ?? true]);
 
         return $result instanceof \Closure ? $result : null;
@@ -1346,9 +1349,10 @@ final class DeepClone
     /**
      * Resolves a closure declared in a constant expression (attribute argument,
      * class constant, property or parameter default) to its element-scoped
-     * declaration-site reference: [class, "<site>@<rank>", start line], where
-     * site names the declaring reflection element and rank is the closure's
-     * position among the element's closures.
+     * declaration-site reference: [class, site, rank, 0], where site names the
+     * declaring reflection element and rank is the closure's position among the
+     * element's closures. The hash is always 0: the polyfill cannot recompute the
+     * engine's code hash, so its references resolve positionally.
      */
     private static function locateConstExprClosure(\ReflectionFunction $r): ?array
     {
@@ -1380,7 +1384,7 @@ final class DeepClone
         // closure literals, which are told apart by source position; an fcc has
         // no engine id here and never reaches the engine-id encoder.
         if (!$r->isAnonymous()) {
-            return [$scope->name, $candidates[0][0].'@'.$candidates[0][1]];
+            return [$scope->name, $candidates[0][0], $candidates[0][1], 0];
         }
 
         if (\PHP_VERSION_ID >= 80600) {
@@ -1412,7 +1416,7 @@ final class DeepClone
             throw new \ValueError('deepclone_to_array(): cannot reference anonymous closure declared at '.$file.':'.$line.', multiple closures share this declaration site');
         }
 
-        return [$scope->name, $candidates[0][0].'@'.$candidates[0][1]];
+        return [$scope->name, $candidates[0][0], $candidates[0][1], 0];
     }
 
     private static function countClosureLiterals(string $file, int $line): int
@@ -1655,16 +1659,13 @@ final class DeepClone
         if (!\is_array($value)) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must be of type array, '.self::valueName($value).' given');
         }
-        if (!\array_key_exists(0, $value) || !\array_key_exists(1, $value) || 2 !== \count($value)) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must have 2 elements');
+        if (!\array_key_exists(0, $value) || !\array_key_exists(1, $value) || !\array_key_exists(2, $value) || !\array_key_exists(3, $value) || 4 !== \count($value)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must have 4 elements');
         }
-        [$class, $id] = $value;
+        [$class, $site, $key, $hash] = $value;
 
-        if (!\is_string($class)) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure class name must be of type string, '.self::valueName($class).' given');
-        }
-        if (!\is_string($id)) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure id must be of type string, '.self::valueName($id).' given');
+        if (!\is_string($class) || !\is_string($site) || !(\is_int($key) || \is_string($key)) || !\is_int($hash)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure reference must be [string class, string site, int|string key, int hash]');
         }
 
         if (null !== $allowedClasses && !isset(array_change_key_case(array_flip($allowedClasses))[strtolower($class)])) {
@@ -1676,24 +1677,23 @@ final class DeepClone
             throw new \ValueError('deepclone_from_array(): class "Closure" is not allowed');
         }
 
-        // An engine-produced id may carry a "#<hash>" code fingerprint after the
-        // rank. The polyfill cannot recompute it (the closure's source is
-        // discarded at compile time), so on the value-walk below the hash is
-        // stripped and the reference resolves positionally.
-        $hasHash = false !== ($sharp = strrpos($id, '#'));
+        // The polyfill cannot recompute the engine's code hash (the closure's
+        // source is discarded at compile time), so its own value-walk references
+        // carry hash 0 and resolve positionally. A non-zero hash comes from the
+        // engine.
+        $hasHash = 0 !== $hash;
 
         if (self::$nativeConstExpr ??= method_exists('Closure', '__serialize')) {
             // Resolve through the engine's own unserialization first: it reads the
-            // raw constant expressions, verifies the "#<hash>" fingerprint, and
-            // alone understands the engine's first-class-callable ids (a
-            // "<site>@<name>" the rank parse below would reject). A hash-bearing id
-            // is fully the engine's to judge (a rejection means the reference is
-            // stale, surfaced rather than healed positionally); a hash-less id it
-            // does not know (a closure counted among a constant or property's
-            // evaluated values, or one written by an older producer) falls through
-            // to the value-walk.
+            // raw constant expressions, verifies a non-zero hash, and alone
+            // understands a first-class-callable name key (the value-walk below is
+            // by rank only). A non-zero hash is fully the engine's to judge (a
+            // rejection means the reference is stale, surfaced rather than healed
+            // positionally); a hash-less reference it does not know (a closure
+            // counted among a constant or property's evaluated values, or one
+            // written by an older producer) falls through to the value-walk.
             try {
-                if (null !== $c = self::nativeConstExprResolve($class, $id, $allowedClasses)) {
+                if (null !== $c = self::nativeConstExprResolve($class, $site, $key, $hash, $allowedClasses)) {
                     return $c;
                 }
             } catch (\Exception $e) {
@@ -1703,13 +1703,13 @@ final class DeepClone
             }
         }
 
-        $coreId = $hasHash ? substr($id, 0, $sharp) : $id;
-        $rank = false === ($at = strrpos($coreId, '@')) ? '' : substr($coreId, $at + 1);
-        if ('' === $rank || \strlen($rank) !== strspn($rank, '0123456789') || ('0' === $rank[0] && '0' !== $rank)) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure id must be of the form "<site>@<rank>", "'.$id.'" given');
+        // The value-walk resolves an anonymous closure by position; a first-class
+        // callable name key (string) is not positionally resolvable here (on 8.6
+        // the engine resolves it above).
+        if (!\is_int($key) || $key < 0) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown closure at site "'.$site.'" of class "'.$class.'"');
         }
-        $site = substr($coreId, 0, $at);
-        $rank = (int) $rank;
+        $rank = $key;
 
         try {
             $rc = new \ReflectionClass($class);
@@ -1871,7 +1871,7 @@ final class DeepClone
         }
 
         if (null === $found) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown closure id "'.$id.'" in class "'.$class.'"');
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown closure "'.$site.'@'.$rank.'" in class "'.$class.'"');
         }
 
         // This value-walk resolves positionally: a hash-less id carries no

--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -713,8 +713,10 @@ final class DeepClone
                     // in parameter default values by an element-scoped "<site>@<rank>"
                     // id, the exact reference the site-based lookup below derives;
                     // closures declared in class constant values and in property
-                    // default values have no engine id and use the lookup
-                    $value = [$r->getClosureScopeClass()->name, $id, $r->getStartLine()];
+                    // default values have no engine id and use the lookup. The line
+                    // is stored relative to the declaring class (its scope class).
+                    $scope = $r->getClosureScopeClass();
+                    $value = [$scope->name, $id, $r->getStartLine() - $scope->getStartLine()];
                     $mask[$k] = 1;
 
                     goto handle_value;
@@ -1317,8 +1319,12 @@ final class DeepClone
         [$index, $lines] = self::$constExprIndex[$scope->name] ??= self::indexConstExprClosures($scope);
         $file = $r->getFileName();
         // Raw value (false for an internal function) so it matches the key built
-        // by indexConstExprClosures(); normalized to 0 in the returned payload.
+        // by indexConstExprClosures().
         $line = $r->getStartLine();
+        // The payload line is relative to the declaring class, so an edit above
+        // the class does not invalidate the reference (matches the extension);
+        // an internal function has no line and stores 0.
+        $relLine = false === $line ? 0 : $line - $scope->getStartLine();
 
         if (!$candidates = $index[$r->name.':'.$file.':'.$line.':'.$r->getEndLine().':'.self::closureSignature($r)] ?? null) {
             return null;
@@ -1332,7 +1338,7 @@ final class DeepClone
         // closure literals, which are told apart by source position; an fcc has
         // no engine id here and never reaches the engine-id encoder.
         if (!$r->isAnonymous()) {
-            return [$scope->name, $candidates[0][0].'@'.$candidates[0][1], $line ?: 0];
+            return [$scope->name, $candidates[0][0].'@'.$candidates[0][1], $relLine];
         }
 
         if (\PHP_VERSION_ID >= 80600) {
@@ -1364,7 +1370,7 @@ final class DeepClone
             throw new \ValueError('deepclone_to_array(): cannot reference anonymous closure declared at '.$file.':'.$line.', multiple closures share this declaration site');
         }
 
-        return [$scope->name, $candidates[0][0].'@'.$candidates[0][1], $line ?: 0];
+        return [$scope->name, $candidates[0][0].'@'.$candidates[0][1], $relLine];
     }
 
     private static function countClosureLiterals(string $file, int $line): int
@@ -1643,13 +1649,14 @@ final class DeepClone
             // The engine resolves its own ids fastest. Its walk reads the raw
             // constant expressions though, while this reference counts evaluated
             // values, so fall back to the evaluating walk below when the engine
-            // does not know the id or resolves it to another line; internal
-            // functions (e.g. a global strlen(...) reference) have no start
-            // line, getStartLine() returns false, normalized to 0 like on the
-            // encoding side.
+            // does not know the id or resolves it to another line. The stored
+            // line is relative to the declaring class; internal functions
+            // (e.g. a global strlen(...) reference) have no start line and
+            // store 0, like on the encoding side.
             try {
                 $found = \Closure::fromConstExpr($class, $id);
-                if ($line === ((new \ReflectionFunction($found))->getStartLine() ?: 0)) {
+                $fl = (new \ReflectionFunction($found))->getStartLine();
+                if ($line === (false === $fl ? 0 : $fl - $rc->getStartLine())) {
                     return $found;
                 }
             } catch (\ValueError) {
@@ -1812,9 +1819,10 @@ final class DeepClone
         if (null === $found) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown closure id "'.$id.'" in class "'.$class.'"');
         }
-        $foundLine = (new \ReflectionFunction($found))->getStartLine() ?: 0;
+        $fl = (new \ReflectionFunction($found))->getStartLine();
+        $foundLine = false === $fl ? 0 : $fl - $rc->getStartLine();
         if ($line !== $foundLine) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) stale payload, const-expr-closure moved from line '.$line.' to line '.$foundLine);
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) stale payload, const-expr-closure moved from class-relative line '.$line.' to '.$foundLine);
         }
 
         return $found;

--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -332,7 +332,7 @@ final class DeepClone
         // closure references (marker 1) are unaffected. The scan runs before
         // anything is instantiated so such a payload is rejected wholesale.
         if (!$allow_named_closures && self::payloadHasNamedClosure($data)) {
-            throw new \ValueError('deepclone_from_array(): resolving a closure over a named callable requires enabling the allow_named_closures option');
+            throw new \ValueError('deepclone_from_array(): resolving a closure over a named callable requires enabling the "allow_named_closures" option');
         }
 
         // $expectedStates maps ids that flag a state replay to their wakeup
@@ -709,10 +709,11 @@ final class DeepClone
                 }
 
                 if (\PHP_VERSION_ID >= 80600 && null !== $id = $r->getConstExprId()) {
-                    // The engine gives a canonical per-class id to closures declared
-                    // in attribute arguments and in parameter default values; closures
-                    // declared in class constant values and in property default values
-                    // have no id and keep using the site-based reference below
+                    // The engine names closures declared in attribute arguments and
+                    // in parameter default values by an element-scoped "<site>@<rank>"
+                    // id, the exact reference the site-based lookup below derives;
+                    // closures declared in class constant values and in property
+                    // default values have no engine id and use the lookup
                     $value = [$r->getClosureScopeClass()->name, $id, $r->getStartLine()];
                     $mask[$k] = 1;
 
@@ -726,11 +727,9 @@ final class DeepClone
                     goto handle_value;
                 }
 
-                if (\PHP_VERSION_ID >= 80600) {
-                    // No engine id and no usable declaration site: let
-                    // Closure::__serialize() throw the engine's refusal
-                    $value->__serialize();
-                }
+                // Not declared in a constant expression: refuse like on PHP < 8.6,
+                // where the generic object path below reaches the same conclusion
+                throw new \DeepClone\NotInstantiableException('Type "Closure" is not instantiable.');
             }
 
             $class = $value::class;
@@ -1291,9 +1290,11 @@ final class DeepClone
     }
 
     /**
-     * Resolves an anonymous closure declared in a constant expression (attribute
-     * argument, class constant, property or parameter default) to its declaration
-     * site: [class, site, attribute index or null, closure index, start line].
+     * Resolves a closure declared in a constant expression (attribute argument,
+     * class constant, property or parameter default) to its element-scoped
+     * declaration-site reference: [class, "<site>@<rank>", start line], where
+     * site names the declaring reflection element and rank is the closure's
+     * position among the element's closures.
      */
     private static function locateConstExprClosure(\ReflectionFunction $r, ?string $declaringClass = null): ?array
     {
@@ -1326,12 +1327,12 @@ final class DeepClone
         // First-class callables are keyed by their target method's identity, so
         // several declaration sites can map to the same key; they are
         // equivalent and the first one wins, exactly like the extension. The
-        // checks below (the 8.6 engine-id exclusion, the same-site ambiguity
+        // checks below (the 8.6 engine-id exclusion, the same-element ambiguity
         // guard and the runtime-aliasing refusal) only concern anonymous
         // closure literals, which are told apart by source position; an fcc has
         // no engine id here and never reaches the engine-id encoder.
         if (!$r->isAnonymous()) {
-            return [$scope->name, $candidates[0][0], $candidates[0][1], $candidates[0][2], $line ?: 0];
+            return [$scope->name, $candidates[0][0].'@'.$candidates[0][1], $line ?: 0];
         }
 
         if (\PHP_VERSION_ID >= 80600) {
@@ -1339,7 +1340,7 @@ final class DeepClone
             // default values carry an engine id and are encoded through it, so
             // they never reach this lookup; a closure matching such a candidate
             // merely shares its declaration site.
-            $candidates = array_values(array_filter($candidates, static fn ($c) => null === $c[1] && !preg_match('/\)#\d+$/', $c[0])));
+            $candidates = array_values(array_filter($candidates, static fn ($c) => !$c[2]));
 
             if (!$candidates) {
                 return null;
@@ -1348,10 +1349,10 @@ final class DeepClone
 
         $sites = [];
         foreach ($candidates as $candidate) {
-            if (isset($sites[$siteKey = $candidate[0].'#'.$candidate[1]])) {
+            if (isset($sites[$candidate[0]])) {
                 throw new \ValueError('deepclone_to_array(): cannot reference anonymous closure declared at '.$file.':'.$line.', multiple closures share this declaration site');
             }
-            $sites[$siteKey] = true;
+            $sites[$candidate[0]] = true;
         }
 
         // Closures declared in method or hook attributes are named after that
@@ -1363,7 +1364,7 @@ final class DeepClone
             throw new \ValueError('deepclone_to_array(): cannot reference anonymous closure declared at '.$file.':'.$line.', multiple closures share this declaration site');
         }
 
-        return [$scope->name, $candidates[0][0], $candidates[0][1], $candidates[0][2], $line ?: 0];
+        return [$scope->name, $candidates[0][0].'@'.$candidates[0][1], $line ?: 0];
     }
 
     private static function countClosureLiterals(string $file, int $line): int
@@ -1400,15 +1401,23 @@ final class DeepClone
     }
 
     /**
-     * Maps every anonymous closure found in the constant expressions of a class to
-     * its declaration site. Sites are keyed by name:file:start:end:signature; the
-     * name encodes the lexical nesting chain, which keeps closures created at
-     * runtime inside a const-expr closure's body from matching the outer literal.
-     * The same literal can legitimately surface through several sites (an attribute
+     * Maps every closure found in the constant expressions of a class to its
+     * element-scoped declaration site: [site, rank, engine-addressable]. The rank
+     * counts the element's closures in evaluation order: attribute arguments
+     * (declaration order, arguments and their nested surfaces depth-first), then
+     * parameter defaults, then the constant or property default value itself.
+     * That order matches the engine's element walk, so for purely literal
+     * elements the rank equals the engine's; value sites, which the engine never
+     * addresses, extend each element's rank space past its attribute closures.
+     * Sites are keyed by name:file:start:end:signature; the name encodes the
+     * lexical nesting chain, which keeps closures created at runtime inside a
+     * const-expr closure's body from matching the outer literal. The same
+     * literal can legitimately surface through several elements (an attribute
      * argument referencing a class constant, a trait alias, a promoted default
-     * applied by a constructor evaluated in another site); candidates in distinct
-     * sites are interchangeable and the first one wins. Two candidates in the SAME
-     * site are distinct literals sharing a declaration line: those are ambiguous.
+     * applied by a constructor evaluated in another site); candidates in
+     * distinct elements are interchangeable and the first one wins. Two
+     * candidates in the SAME element are distinct literals sharing a declaration
+     * line: those are ambiguous.
      */
     private static function indexConstExprClosures(\ReflectionClass $rc): array
     {
@@ -1417,52 +1426,74 @@ final class DeepClone
         $lines = [];
         $retained = [];
         $seen = [];
-        $add = static function ($values, string $site, ?int $attrIndex) use ($class, &$index, &$lines, &$retained, &$seen) {
-            $i = 0;
-            $objects = [];
-            $walk = static function ($value) use ($class, &$walk, &$i, &$index, &$lines, &$retained, &$seen, &$objects, $site, $attrIndex) {
-                if ($value instanceof \Closure) {
-                    $n = $i++;
-                    $retained[] = $value;
-                    if (isset($seen[$id = spl_object_id($value)])) {
-                        return;
-                    }
+        $rank = 0;
+        $objects = [];
+        $add = static function ($value, string $site, bool $engineSpace) use ($class, &$add, &$index, &$lines, &$retained, &$seen, &$rank, &$objects) {
+            if ($value instanceof \Closure) {
+                $n = $rank++;
+                $retained[] = $value;
+                $r = new \ReflectionFunction($value);
+                if (!isset($seen[$id = spl_object_id($value)])) {
                     $seen[$id] = true;
-                    $r = new \ReflectionFunction($value);
                     // Index every first-class callable found in this class's
                     // constant expressions, whatever its target (own method,
-                    // another class's method, or a global function) -- the class
-                    // declares the reference. Anonymous closures must be scoped
-                    // to this class (a foreign literal reached through a const
-                    // reference is not declared here).
-                    if ($r->isAnonymous() && $r->getClosureScopeClass()?->name !== $class) {
-                        return;
+                    // another class's method, or a global function) -- the
+                    // class declares the reference. Anonymous closures must be
+                    // scoped to this class (a foreign literal reached through
+                    // a const reference is not declared here).
+                    if (!$r->isAnonymous() || $r->getClosureScopeClass()?->name === $class) {
+                        $index[$r->name.':'.$r->getFileName().':'.$r->getStartLine().':'.$r->getEndLine().':'.self::closureSignature($r)][] = [$site, $n, $engineSpace];
                     }
-                    $index[$r->name.':'.$r->getFileName().':'.$r->getStartLine().':'.$r->getEndLine().':'.self::closureSignature($r)][] = [$site, $attrIndex, $n];
                     if ($r->isAnonymous()) {
                         // The runtime-aliasing refusal keys off source lines and
                         // only concerns anonymous closure literals.
                         $lines[$k = $r->getFileName().':'.$r->getStartLine()] = ($lines[$k] ?? 0) + 1;
                     }
-                } elseif (\is_array($value)) {
-                    foreach ($value as $v) {
-                        $walk($v);
+                }
+                if ($r->isAnonymous()) {
+                    // The closure may itself declare closures in its attributes
+                    // or in its parameter default values; they rank right after
+                    // it, like in the engine's walk
+                    foreach ($r->getAttributes() as $a) {
+                        try {
+                            $add($a->getArguments(), $site, $engineSpace);
+                        } catch (\Throwable) {
+                        }
                     }
-                } elseif (\is_object($value) && !isset($objects[$id = spl_object_id($value)])) {
-                    $objects[$id] = true;
-                    foreach ((array) $value as $v) {
-                        $walk($v);
+                    foreach ($r->getParameters() as $p) {
+                        foreach ($p->getAttributes() as $a) {
+                            try {
+                                $add($a->getArguments(), $site, $engineSpace);
+                            } catch (\Throwable) {
+                            }
+                        }
+                    }
+                    foreach ($r->getParameters() as $p) {
+                        try {
+                            if ($p->isDefaultValueAvailable()) {
+                                $add($p->getDefaultValue(), $site, $engineSpace);
+                            }
+                        } catch (\Throwable) {
+                        }
                     }
                 }
-            };
-            $walk($values);
-            // Break the closure <-> &$walk reference cycle
-            $walk = null;
+            } elseif (\is_array($value)) {
+                foreach ($value as $v) {
+                    $add($v, $site, $engineSpace);
+                }
+            } elseif (\is_object($value) && !isset($objects[$id = spl_object_id($value)])) {
+                $objects[$id] = true;
+                foreach ((array) $value as $v) {
+                    $add($v, $site, $engineSpace);
+                }
+            }
         };
 
-        foreach ($rc->getAttributes() as $i => $a) {
+        $rank = 0;
+        $objects = [];
+        foreach ($rc->getAttributes() as $a) {
             try {
-                $add($a->getArguments(), '', $i);
+                $add($a->getArguments(), '', true);
             } catch (\Throwable) {
             }
         }
@@ -1470,14 +1501,16 @@ final class DeepClone
             if ($rcc->getDeclaringClass()->name !== $class) {
                 continue;
             }
-            foreach ($rcc->getAttributes() as $i => $a) {
+            $rank = 0;
+            $objects = [];
+            foreach ($rcc->getAttributes() as $a) {
                 try {
-                    $add($a->getArguments(), $rcc->name, $i);
+                    $add($a->getArguments(), $rcc->name, true);
                 } catch (\Throwable) {
                 }
             }
             try {
-                $add([$rcc->getValue()], $rcc->name, null);
+                $add([$rcc->getValue()], $rcc->name, false);
             } catch (\Throwable) {
             }
         }
@@ -1485,15 +1518,17 @@ final class DeepClone
             if ($rp->class !== $class || $rp->isPromoted()) {
                 continue;
             }
-            foreach ($rp->getAttributes() as $i => $a) {
+            $rank = 0;
+            $objects = [];
+            foreach ($rp->getAttributes() as $a) {
                 try {
-                    $add($a->getArguments(), '$'.$rp->name, $i);
+                    $add($a->getArguments(), '$'.$rp->name, true);
                 } catch (\Throwable) {
                 }
             }
             try {
                 if ($rp->hasDefaultValue()) {
-                    $add([$rp->getDefaultValue()], '$'.$rp->name, null);
+                    $add([$rp->getDefaultValue()], '$'.$rp->name, false);
                 }
             } catch (\Throwable) {
             }
@@ -1501,17 +1536,20 @@ final class DeepClone
                 if (!$hook = $rp->getHook(\PropertyHookType::from($hookName))) {
                     continue;
                 }
+                $rank = 0;
+                $objects = [];
+            $objects = [];
                 $hSite = '$'.$rp->name.'::'.$hookName.'()';
-                foreach ($hook->getAttributes() as $i => $a) {
+                foreach ($hook->getAttributes() as $a) {
                     try {
-                        $add($a->getArguments(), $hSite, $i);
+                        $add($a->getArguments(), $hSite, true);
                     } catch (\Throwable) {
                     }
                 }
-                foreach ($hook->getParameters() as $pi => $hp) {
-                    foreach ($hp->getAttributes() as $i => $a) {
+                foreach ($hook->getParameters() as $hp) {
+                    foreach ($hp->getAttributes() as $a) {
                         try {
-                            $add($a->getArguments(), $hSite.'#'.$pi, $i);
+                            $add($a->getArguments(), $hSite, true);
                         } catch (\Throwable) {
                         }
                     }
@@ -1522,28 +1560,34 @@ final class DeepClone
             if ($rm->class !== $class) {
                 continue;
             }
+            $rank = 0;
+            $objects = [];
             $mSite = $rm->name.'()';
-            foreach ($rm->getAttributes() as $i => $a) {
+            foreach ($rm->getAttributes() as $a) {
                 try {
-                    $add($a->getArguments(), $mSite, $i);
+                    $add($a->getArguments(), $mSite, true);
                 } catch (\Throwable) {
                 }
             }
-            foreach ($rm->getParameters() as $pi => $rp) {
-                foreach ($rp->getAttributes() as $i => $a) {
+            foreach ($rm->getParameters() as $rp) {
+                foreach ($rp->getAttributes() as $a) {
                     try {
-                        $add($a->getArguments(), $mSite.'#'.$pi, $i);
+                        $add($a->getArguments(), $mSite, true);
                     } catch (\Throwable) {
                     }
                 }
+            }
+            foreach ($rm->getParameters() as $rp) {
                 try {
                     if ($rp->isDefaultValueAvailable()) {
-                        $add([$rp->getDefaultValue()], $mSite.'#'.$pi, null);
+                        $add([$rp->getDefaultValue()], $mSite, true);
                     }
                 } catch (\Throwable) {
                 }
             }
         }
+        // Break the closure <-> &$add reference cycle
+        $add = null;
 
         return [$index, $lines];
     }
@@ -1563,70 +1607,16 @@ final class DeepClone
         if (!\is_array($value)) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must be of type array, '.self::valueName($value).' given');
         }
-
-        // Engine-id reference [class, id, line], emitted on PHP >= 8.6; the type
-        // of element 1 (int id vs string site) discriminates it from the
-        // site-based reference handled below
-        if (\is_int($value[1] ?? null)) {
-            if (!\array_key_exists(0, $value) || !\array_key_exists(2, $value) || 3 !== \count($value)) {
-                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must have 3 elements');
-            }
-            [$class, $id, $line] = $value;
-
-            if (!\is_string($class)) {
-                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure class name must be of type string, '.self::valueName($class).' given');
-            }
-            if (!\is_int($line)) {
-                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure line must be of type int, '.self::valueName($line).' given');
-            }
-
-            if (null !== $allowedClasses && !isset(array_change_key_case(array_flip($allowedClasses))[strtolower($class)])) {
-                throw new \ValueError('deepclone_from_array(): class "'.$class.'" is not allowed');
-            }
-
-            if (\PHP_VERSION_ID < 80600) {
-                throw new \ValueError('deepclone_from_array(): const-expr-closure payload was created on PHP 8.6 or later and cannot be resolved on PHP '.\PHP_VERSION);
-            }
-
-            try {
-                new \ReflectionClass($class);
-            } catch (\ReflectionException) {
-                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown class "'.$class.'"');
-            }
-
-            try {
-                $found = \Closure::fromConstExpr($class, $id);
-            } catch (\ValueError) {
-                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown closure id '.$id.' in class "'.$class.'"');
-            }
-
-            $r = new \ReflectionFunction($found);
-            if (!str_contains($r->name, '{closure')) {
-                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references a first-class callable site');
-            }
-            if ($line !== $foundLine = $r->getStartLine()) {
-                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) stale payload, const-expr-closure moved from line '.$line.' to line '.$foundLine);
-            }
-
-            return $found;
+        if (!\array_key_exists(0, $value) || !\array_key_exists(1, $value) || !\array_key_exists(2, $value) || 3 !== \count($value)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must have 3 elements');
         }
-
-        if (!\array_key_exists(0, $value) || !\array_key_exists(1, $value) || !\array_key_exists(2, $value) || !\array_key_exists(3, $value) || !\array_key_exists(4, $value) || 5 !== \count($value)) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure value must have 5 elements');
-        }
-        [$class, $site, $attrIndex, $closureIndex, $line] = $value;
+        [$class, $id, $line] = $value;
 
         if (!\is_string($class)) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure class name must be of type string, '.self::valueName($class).' given');
         }
-        if (!\is_string($site)) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure site must be of type string, '.self::valueName($site).' given');
-        }
-        if (null !== $attrIndex && !\is_int($attrIndex)) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure attribute index must be of type int or null, '.self::valueName($attrIndex).' given');
-        }
-        if (!\is_int($closureIndex)) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure closure index must be of type int, '.self::valueName($closureIndex).' given');
+        if (!\is_string($id)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure id must be of type string, '.self::valueName($id).' given');
         }
         if (!\is_int($line)) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure line must be of type int, '.self::valueName($line).' given');
@@ -1636,97 +1626,115 @@ final class DeepClone
             throw new \ValueError('deepclone_from_array(): class "'.$class.'" is not allowed');
         }
 
+        $rank = false === ($at = strrpos($id, '@')) ? '' : substr($id, $at + 1);
+        if ('' === $rank || \strlen($rank) !== strspn($rank, '0123456789') || ('0' === $rank[0] && '0' !== $rank)) {
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure id must be of the form "<site>@<rank>", "'.$id.'" given');
+        }
+        $site = substr($id, 0, $at);
+        $rank = (int) $rank;
+
         try {
             $rc = new \ReflectionClass($class);
         } catch (\ReflectionException) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown class "'.$class.'"');
         }
 
+        if (\PHP_VERSION_ID >= 80600) {
+            // The engine resolves its own ids fastest. Its walk reads the raw
+            // constant expressions though, while this reference counts evaluated
+            // values, so fall back to the evaluating walk below when the engine
+            // does not know the id or resolves it to another line; internal
+            // functions (e.g. a global strlen(...) reference) have no start
+            // line, getStartLine() returns false, normalized to 0 like on the
+            // encoding side.
+            try {
+                $found = \Closure::fromConstExpr($class, $id);
+                if ($line === ((new \ReflectionFunction($found))->getStartLine() ?: 0)) {
+                    return $found;
+                }
+            } catch (\ValueError) {
+            }
+        }
+
         if ('' === $site) {
-            $target = $rc;
+            $element = $rc;
         } elseif ('$' === $site[0]) {
             if (false !== $pos = strpos($site, '::')) {
-                $target = null;
+                $element = null;
                 $hookSpec = substr($site, $pos + 2);
-                $paramIndex = null;
-                if (false !== $hashPos = strpos($hookSpec, ')#')) {
-                    $paramIndex = substr($hookSpec, $hashPos + 2);
-                    $hookSpec = substr($hookSpec, 0, $hashPos + 1);
-                }
-                if (('get()' === $hookSpec || 'set()' === $hookSpec) && (null === $paramIndex || $paramIndex === (string) (int) $paramIndex)) {
+                if ('get()' === $hookSpec || 'set()' === $hookSpec) {
                     try {
-                        $target = $rc->getProperty(substr($site, 1, $pos - 1))->getHook(\PropertyHookType::from(substr($hookSpec, 0, 3)));
-                        if ($target && null !== $paramIndex) {
-                            $target = $target->getParameters()[(int) $paramIndex] ?? null;
-                        }
+                        $element = $rc->getProperty(substr($site, 1, $pos - 1))->getHook(\PropertyHookType::from(substr($hookSpec, 0, 3)));
                     } catch (\ReflectionException) {
                     }
                 }
-                if (!$target) {
+                if (!$element) {
                     throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown hook "'.$site.'"');
                 }
             } else {
                 try {
-                    $target = $rc->getProperty(substr($site, 1));
+                    $element = $rc->getProperty(substr($site, 1));
                 } catch (\ReflectionException) {
                     throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown property "'.$site.'"');
                 }
             }
-        } elseif (false !== $pos = strpos($site, ')#')) {
-            $num = substr($site, $pos + 2);
-            $target = null;
-            if (2 <= $pos && '(' === $site[$pos - 1] && $num === (string) (int) $num) {
-                try {
-                    $target = $rc->getMethod(substr($site, 0, $pos - 1))->getParameters()[(int) $num] ?? null;
-                } catch (\ReflectionException) {
-                }
-            }
-            if (null === $target) {
-                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown parameter "'.$site.'"');
-            }
         } elseif (str_ends_with($site, '()')) {
             try {
-                $target = $rc->getMethod(substr($site, 0, -2));
+                $element = $rc->getMethod(substr($site, 0, -2));
             } catch (\ReflectionException) {
                 throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown method "'.$site.'"');
             }
-        } elseif (!$target = $rc->getReflectionConstant($site)) {
+        } elseif (!$element = $rc->getReflectionConstant($site)) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown constant "'.$site.'"');
         }
 
-        if (null !== $attrIndex) {
-            $attrs = $target->getAttributes();
-            if (!isset($attrs[$attrIndex])) {
-                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown attribute index '.$attrIndex);
-            }
-            try {
-                $values = $attrs[$attrIndex]->getArguments();
-            } catch (\Throwable $e) {
-                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure evaluation failed for site "'.$site.'"', 0, $e);
-            }
-        } elseif ($target instanceof \ReflectionClass || $target instanceof \ReflectionMethod) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure attribute index is required for site "'.$site.'"');
-        } else {
-            try {
-                if ($target instanceof \ReflectionClassConstant) {
-                    $values = [$target->getValue()];
-                } elseif ($target instanceof \ReflectionParameter) {
-                    $values = $target->isDefaultValueAvailable() ? [$target->getDefaultValue()] : [];
-                } else {
-                    $values = $target->hasDefaultValue() ? [$target->getDefaultValue()] : [];
-                }
-            } catch (\Throwable $e) {
-                throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure evaluation failed for site "'.$site.'"', 0, $e);
-            }
-        }
-
+        // Enumerate the element's closures in the rank order used by
+        // indexConstExprClosures(): attribute arguments in declaration order,
+        // nested const-expr surfaces depth-first, then parameter defaults, then
+        // the constant or property default value
         $found = null;
         $i = 0;
         $objects = [];
-        $walk = static function ($value) use (&$walk, &$found, &$i, $closureIndex, &$objects) {
+        $walk = static function ($value) use (&$walk, &$found, &$i, $rank, &$objects) {
             if ($value instanceof \Closure) {
-                if ($i++ === $closureIndex) {
+                if ($i++ === $rank) {
                     $found = $value;
+
+                    return;
+                }
+                $r = new \ReflectionFunction($value);
+                if ($r->isAnonymous()) {
+                    foreach ($r->getAttributes() as $a) {
+                        try {
+                            $walk($a->getArguments());
+                        } catch (\Throwable) {
+                        }
+                        if (null !== $found) {
+                            return;
+                        }
+                    }
+                    foreach ($r->getParameters() as $p) {
+                        foreach ($p->getAttributes() as $a) {
+                            try {
+                                $walk($a->getArguments());
+                            } catch (\Throwable) {
+                            }
+                            if (null !== $found) {
+                                return;
+                            }
+                        }
+                    }
+                    foreach ($r->getParameters() as $p) {
+                        try {
+                            if ($p->isDefaultValueAvailable()) {
+                                $walk($p->getDefaultValue());
+                            }
+                        } catch (\Throwable) {
+                        }
+                        if (null !== $found) {
+                            return;
+                        }
+                    }
                 }
             } elseif (\is_array($value)) {
                 foreach ($value as $v) {
@@ -1745,16 +1753,65 @@ final class DeepClone
                 }
             }
         };
-        $walk($values);
-        // Break the closure <-> &$walk reference cycle
-        $walk = null;
+
+        try {
+            foreach ($element->getAttributes() as $a) {
+                try {
+                    $walk($a->getArguments());
+                } catch (\Throwable $e) {
+                    throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure evaluation failed for site "'.$site.'"', 0, $e);
+                }
+                if (null !== $found) {
+                    break;
+                }
+            }
+            if (null === $found && $element instanceof \ReflectionMethod) {
+                foreach ($element->getParameters() as $p) {
+                    foreach ($p->getAttributes() as $a) {
+                        try {
+                            $walk($a->getArguments());
+                        } catch (\Throwable $e) {
+                            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure evaluation failed for site "'.$site.'"', 0, $e);
+                        }
+                        if (null !== $found) {
+                            break 2;
+                        }
+                    }
+                }
+                foreach ($element->getParameters() as $p) {
+                    try {
+                        if ($p->isDefaultValueAvailable()) {
+                            $walk($p->getDefaultValue());
+                        }
+                    } catch (\Throwable $e) {
+                        throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure evaluation failed for site "'.$site.'"', 0, $e);
+                    }
+                    if (null !== $found) {
+                        break;
+                    }
+                }
+            }
+            if (null === $found) {
+                try {
+                    if ($element instanceof \ReflectionClassConstant) {
+                        $walk($element->getValue());
+                    } elseif ($element instanceof \ReflectionProperty && $element->hasDefaultValue()) {
+                        $walk($element->getDefaultValue());
+                    }
+                } catch (\ValueError $e) {
+                    throw $e;
+                } catch (\Throwable $e) {
+                    throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure evaluation failed for site "'.$site.'"', 0, $e);
+                }
+            }
+        } finally {
+            // Break the closure <-> &$walk reference cycle
+            $walk = null;
+        }
 
         if (null === $found) {
-            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown closure index '.$closureIndex);
+            throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown closure id "'.$id.'" in class "'.$class.'"');
         }
-        // Internal functions (e.g. a global strlen(...) reference) have no
-        // start line; getStartLine() returns false, which the extension encodes
-        // as 0. Normalize so such a reference does not look stale.
         $foundLine = (new \ReflectionFunction($found))->getStartLine() ?: 0;
         if ($line !== $foundLine) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) stale payload, const-expr-closure moved from line '.$line.' to line '.$foundLine);

--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -40,6 +40,7 @@ final class DeepClone
     private static array $classInfo = [];
     private static array $constExprIndex = [];
     private static array $closureLiteralLines = [];
+    private static ?bool $nativeConstExpr = null;
     private static \stdClass $sentinel;
 
     /**
@@ -657,24 +658,41 @@ final class DeepClone
             if ($value instanceof \Closure) {
                 $r = new \ReflectionFunction($value);
 
+                // On an engine that serializes const-expr closures natively, use
+                // that first: Closure::__serialize() yields the [class, id]
+                // declaration-site reference for the closures it addresses
+                // (attribute arguments and parameter defaults, cross-class and
+                // global first-class callables included) and throws for the rest,
+                // which fall through to the reflection-based lookup below. Such a
+                // reference round-trips without the allow_named_closures opt-in;
+                // Closure is allow-list-gated, as in the by-name and lookup paths.
+                if ((self::$nativeConstExpr ??= method_exists('Closure', '__serialize'))
+                    && null !== $ref = self::nativeConstExprRef($value)
+                ) {
+                    if (null !== $allowedSet && !isset($allowedSet['closure'])) {
+                        throw new \ValueError('deepclone_to_array(): class "Closure" is not allowed');
+                    }
+                    $value = $ref;
+                    $mask[$k] = 1;
+
+                    goto handle_value;
+                }
+
                 if (!(\PHP_VERSION_ID >= 80200 ? $r->isAnonymous() : str_contains($r->name, "@anonymous\0"))) {
-                    // First-class callable declared in a constant expression,
-                    // encoded as a declaration-site reference (like the
-                    // extension) so it round-trips without the
-                    // allow_named_closures opt-in. On PHP 8.6 the engine names
-                    // the declaring class (getConstExprClass), covering
-                    // cross-class (#[When(Validators::check(...))]) and global
-                    // (#[When(strlen(...))]) references; on 8.5 only a callable
-                    // over a method of its own declaring class is locatable.
-                    // Closure is allow-list-gated first, mirroring the extension.
-                    $declaringClass = \PHP_VERSION_ID >= 80600 ? $r->getConstExprClass() : null;
-                    if (\PHP_VERSION_ID >= 80500 && !$r->getClosureThis()
-                        && (null !== $declaringClass || $r->getClosureScopeClass())
-                    ) {
+                    // First-class callable declared in a constant expression over
+                    // a method of its own declaring class, encoded as a
+                    // declaration-site reference (like the extension) so it
+                    // round-trips without the allow_named_closures opt-in. On 8.6
+                    // the engine-addressable references, cross-class and global
+                    // ones included, are handled natively above; this reflection
+                    // lookup covers PHP 8.5, where only a callable over a method
+                    // of its own declaring class is locatable. Closure is
+                    // allow-list-gated first, mirroring the extension.
+                    if (\PHP_VERSION_ID >= 80500 && !$r->getClosureThis() && $r->getClosureScopeClass()) {
                         if (null !== $allowedSet && !isset($allowedSet['closure'])) {
                             throw new \ValueError('deepclone_to_array(): class "Closure" is not allowed');
                         }
-                        if (null !== $ref = self::locateConstExprClosure($r, $declaringClass)) {
+                        if (null !== $ref = self::locateConstExprClosure($r)) {
                             $value = $ref;
                             $mask[$k] = 1;
 
@@ -708,20 +726,10 @@ final class DeepClone
                     throw new \ValueError('deepclone_to_array(): class "Closure" is not allowed');
                 }
 
-                if (\PHP_VERSION_ID >= 80600 && null !== $id = $r->getConstExprId()) {
-                    // The engine names closures declared in attribute arguments and
-                    // in parameter default values by an element-scoped "<site>@<rank>"
-                    // id, the exact reference the site-based lookup below derives;
-                    // closures declared in class constant values and in property
-                    // default values have no engine id and use the lookup. The id
-                    // already carries a "#<hash>" of the closure's code, so the
-                    // reference needs no separate staleness field.
-                    $value = [$r->getClosureScopeClass()->name, $id];
-                    $mask[$k] = 1;
-
-                    goto handle_value;
-                }
-
+                // Anonymous const-expr closures the engine addresses are handled
+                // natively above (on 8.6); this reflection lookup covers PHP 8.5
+                // and, on 8.6, the closures the engine does not address (constant
+                // and property default values).
                 if (\PHP_VERSION_ID >= 80500 && null !== $ref = self::locateConstExprClosure($r)) {
                     $value = $ref;
                     $mask[$k] = 1;
@@ -1292,27 +1300,65 @@ final class DeepClone
     }
 
     /**
+     * Reads a const-expr closure's [class, id] declaration-site reference out of
+     * the engine's native Closure::__serialize(), which yields
+     *   [ [], ["const-expr", [class, id]] ]
+     * for the closures it addresses and throws for the rest. Returns null (rather
+     * than throwing) for a closure the engine does not address, so the caller
+     * falls back to the reflection-based lookup.
+     */
+    private static function nativeConstExprRef(\Closure $closure): ?array
+    {
+        try {
+            $data = $closure->__serialize();
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (isset($data[1][0], $data[1][1]) && 'const-expr' === $data[1][0]
+            && \is_array($ref = $data[1][1]) && 2 === \count($ref)
+            && isset($ref[0], $ref[1]) && \is_string($ref[0]) && \is_string($ref[1])
+        ) {
+            return [$ref[0], $ref[1]];
+        }
+
+        return null;
+    }
+
+    /**
+     * deepclone_from_array() counterpart of nativeConstExprRef(): resolves a
+     * [class, id] reference through the engine's own Closure unserialization,
+     * which re-evaluates the reference bounded to what the class declares and
+     * verifies any "#<hash>" fingerprint. The serialized form is synthesized
+     * directly (the class and id are length-prefixed, so no escaping is needed);
+     * $allowedClasses gates the Closure the payload instantiates. Throws the
+     * engine's exception when the reference is stale or unknown; returns null if
+     * unserialization yields anything other than a Closure.
+     */
+    private static function nativeConstExprResolve(string $class, string $id, ?array $allowedClasses): ?\Closure
+    {
+        $payload = 'O:7:"Closure":'.substr(serialize([[], ['const-expr', [$class, $id]]]), 2);
+        $result = unserialize($payload, ['allowed_classes' => $allowedClasses ?? true]);
+
+        return $result instanceof \Closure ? $result : null;
+    }
+
+    /**
      * Resolves a closure declared in a constant expression (attribute argument,
      * class constant, property or parameter default) to its element-scoped
      * declaration-site reference: [class, "<site>@<rank>", start line], where
      * site names the declaring reflection element and rank is the closure's
      * position among the element's closures.
      */
-    private static function locateConstExprClosure(\ReflectionFunction $r, ?string $declaringClass = null): ?array
+    private static function locateConstExprClosure(\ReflectionFunction $r): ?array
     {
         if ($r->getClosureThis() || $r->getClosureUsedVariables()) {
             return null;
         }
-        if (null !== $declaringClass) {
-            // PHP 8.6: the engine named the declaring class (ReflectionFunction::
-            // getConstExprClass), which for a cross-class or global first-class
-            // callable differs from the closure's scope. Index that class.
-            try {
-                $scope = new \ReflectionClass($declaringClass);
-            } catch (\ReflectionException) {
-                return null;
-            }
-        } elseif (!$r->isStatic() || !($scope = $r->getClosureScopeClass())) {
+        // Only a callable over a method of its own declaring class is locatable
+        // here: the engine records no declaring class on 8.5, and on 8.6 the
+        // cross-class and global references are resolved natively before this.
+        if (!$r->isStatic() || !($scope = $r->getClosureScopeClass())) {
             return null;
         }
 
@@ -1624,13 +1670,39 @@ final class DeepClone
         if (null !== $allowedClasses && !isset(array_change_key_case(array_flip($allowedClasses))[strtolower($class)])) {
             throw new \ValueError('deepclone_from_array(): class "'.$class.'" is not allowed');
         }
+        // Closure is gated too, matching deepclone_to_array(): resolving a
+        // reference mints one.
+        if (null !== $allowedClasses && !isset(array_change_key_case(array_flip($allowedClasses))['closure'])) {
+            throw new \ValueError('deepclone_from_array(): class "Closure" is not allowed');
+        }
 
         // An engine-produced id may carry a "#<hash>" code fingerprint after the
         // rank. The polyfill cannot recompute it (the closure's source is
         // discarded at compile time), so on the value-walk below the hash is
-        // stripped and the reference resolves positionally; on 8.6 the
-        // hash-bearing id is verified by Closure::fromConstExpr first.
+        // stripped and the reference resolves positionally.
         $hasHash = false !== ($sharp = strrpos($id, '#'));
+
+        if (self::$nativeConstExpr ??= method_exists('Closure', '__serialize')) {
+            // Resolve through the engine's own unserialization first: it reads the
+            // raw constant expressions, verifies the "#<hash>" fingerprint, and
+            // alone understands the engine's first-class-callable ids (a
+            // "<site>@<name>" the rank parse below would reject). A hash-bearing id
+            // is fully the engine's to judge (a rejection means the reference is
+            // stale, surfaced rather than healed positionally); a hash-less id it
+            // does not know (a closure counted among a constant or property's
+            // evaluated values, or one written by an older producer) falls through
+            // to the value-walk.
+            try {
+                if (null !== $c = self::nativeConstExprResolve($class, $id, $allowedClasses)) {
+                    return $c;
+                }
+            } catch (\Exception $e) {
+                if ($hasHash) {
+                    throw $e;
+                }
+            }
+        }
+
         $coreId = $hasHash ? substr($id, 0, $sharp) : $id;
         $rank = false === ($at = strrpos($coreId, '@')) ? '' : substr($coreId, $at + 1);
         if ('' === $rank || \strlen($rank) !== strspn($rank, '0123456789') || ('0' === $rank[0] && '0' !== $rank)) {
@@ -1643,23 +1715,6 @@ final class DeepClone
             $rc = new \ReflectionClass($class);
         } catch (\ReflectionException) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown class "'.$class.'"');
-        }
-
-        if (\PHP_VERSION_ID >= 80600) {
-            // The engine resolves its own ids, verifying the "#<hash>"
-            // fingerprint. Its walk reads the raw constant expressions, while
-            // this reference counts evaluated values, so a hash-less id the
-            // engine does not know (a closure in a constant or property value)
-            // falls through to the evaluating walk. A hash-bearing id is fully
-            // the engine's to judge: if it rejects one, the reference is stale,
-            // so surface that instead of healing positionally.
-            try {
-                return \Closure::fromConstExpr($class, $id);
-            } catch (\ValueError $e) {
-                if ($hasHash) {
-                    throw $e;
-                }
-            }
         }
 
         if ('' === $site) {

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -594,7 +594,7 @@ class DeepCloneTest extends TestCase
     {
         $d = deepclone_to_array(\Closure::fromCallable('strlen'), allow_named_closures: true);
         $this->expectException(\ValueError::class);
-        $this->expectExceptionMessage('resolving a closure over a named callable requires enabling the allow_named_closures option');
+        $this->expectExceptionMessage('resolving a closure over a named callable requires enabling the "allow_named_closures" option');
         deepclone_from_array($d);
     }
 
@@ -608,7 +608,7 @@ class DeepCloneTest extends TestCase
             deepclone_from_array($d);
             $this->fail('Expected ValueError was not thrown');
         } catch (\ValueError $e) {
-            $this->assertStringContainsString('resolving a closure over a named callable requires enabling the allow_named_closures option', $e->getMessage());
+            $this->assertStringContainsString('resolving a closure over a named callable requires enabling the "allow_named_closures" option', $e->getMessage());
         }
 
         $clone = deepclone_from_array($d, allow_named_closures: true);
@@ -2050,18 +2050,15 @@ class DeepCloneTest extends TestCase
     }
 
     /**
-     * On PHP 8.6 closures declared in attribute arguments and in parameter
-     * default values are referenced as [class, engine id, line] instead of the
-     * site-based 5-element form.
+     * Element-scoped reference [class, "<site>@<rank>", line], identical on
+     * every PHP version and to the engine's own id for attribute and
+     * parameter-default closures.
      */
-    private static function expectedConstExprPayload(\Closure $closure, array $siteForm): array
+    private static function expectedConstExprPayload(\Closure $closure, string $id): array
     {
-        if (\PHP_VERSION_ID < 80600) {
-            return $siteForm;
-        }
         $r = new \ReflectionFunction($closure);
 
-        return [$r->getConstExprClass(), $r->getConstExprId(), $r->getStartLine()];
+        return [$r->getClosureScopeClass()->name, $id, $r->getStartLine()];
     }
 
     /**
@@ -2074,7 +2071,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprClosureFixture::class, '', 0, 0, $line]), $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, '@0'), $d['prepared']);
         $this->assertSame(1, $d['mask']);
     }
 
@@ -2102,7 +2099,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprClosureFixture::class, '$tagged', 0, 0, $line]), $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, '$tagged@0'), $d['prepared']);
         $this->assertSame(6, deepclone_from_array($d)(3));
     }
 
@@ -2117,7 +2114,7 @@ class DeepCloneTest extends TestCase
             $line = (new \ReflectionFunction($args[$i]))->getStartLine();
             $d = deepclone_to_array($args[$i]);
 
-            $this->assertSame(self::expectedConstExprPayload($args[$i], [ConstExprClosureFixture::class, 'TAGGED', 0, $i, $line]), $d['prepared']);
+            $this->assertSame(self::expectedConstExprPayload($args[$i], 'TAGGED@'.$i), $d['prepared']);
             $this->assertSame($expected, deepclone_from_array($d)());
         }
     }
@@ -2132,7 +2129,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprClosureFixture::class, 'tagged()', 1, 0, $line]), $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, 'tagged()@0'), $d['prepared']);
         $this->assertSame('repeated', deepclone_from_array($d)());
     }
 
@@ -2146,7 +2143,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprClosureFixture::class, 'tagged()#0', 0, 0, $line]), $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, 'tagged()@1'), $d['prepared']);
         $this->assertSame('param-attr', deepclone_from_array($d)());
     }
 
@@ -2160,7 +2157,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprClosureFixture::class, 'tagged()#0', null, 0, $line]), $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, 'tagged()@2'), $d['prepared']);
         $this->assertSame('param-default', deepclone_from_array($d)());
     }
 
@@ -2174,7 +2171,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprClosureFixture::class, '$factory', null, 0, $line], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, '$factory@0'), $d['prepared']);
         $this->assertSame('prop-default', deepclone_from_array($d)());
     }
 
@@ -2188,7 +2185,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprClosureFixture::class, '$staticFactory', null, 0, $line], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, '$staticFactory@0'), $d['prepared']);
         $this->assertSame('static-prop-default', deepclone_from_array($d)());
     }
 
@@ -2202,7 +2199,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprClosureFixture::class, 'CALLBACKS', null, 0, $line], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, 'CALLBACKS@0'), $d['prepared']);
         $this->assertSame('const-value', deepclone_from_array($d)());
     }
 
@@ -2216,7 +2213,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprEnumFixture::class, 'Active', 0, 0, $line]), $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, 'Active@0'), $d['prepared']);
         $this->assertSame('enum-case-attr', deepclone_from_array($d)());
     }
 
@@ -2230,7 +2227,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprEnumFixture::class, 'FILTER', null, 0, $line], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, 'FILTER@0'), $d['prepared']);
         $this->assertSame('enum-const', deepclone_from_array($d)());
     }
 
@@ -2257,7 +2254,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprPromotedFixture::class, '__construct()#0', 0, 0, $line]), $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, \PHP_VERSION_ID >= 80600 ? '$promoted@0' : '__construct()@0'), $d['prepared']);
         $this->assertSame('promoted-attr', deepclone_from_array($d)());
     }
 
@@ -2301,15 +2298,8 @@ class DeepCloneTest extends TestCase
     {
         $closure = static function (): string { return 'runtime'; };
 
-        if (\PHP_VERSION_ID >= 80600) {
-            // Closure::__serialize() exists and refuses closures that were not
-            // declared in a constant expression
-            $this->expectException(\Exception::class);
-            $this->expectExceptionMessage("Serialization of 'Closure' is not allowed");
-        } else {
-            $this->expectException(\DeepClone\NotInstantiableException::class);
-            $this->expectExceptionMessage('Type "Closure" is not instantiable.');
-        }
+        $this->expectException(\DeepClone\NotInstantiableException::class);
+        $this->expectExceptionMessage('Type "Closure" is not instantiable.');
         deepclone_to_array($closure);
     }
 
@@ -2350,7 +2340,7 @@ class DeepCloneTest extends TestCase
     {
         $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
         $d = deepclone_to_array($closure);
-        ++$d['prepared'][\PHP_VERSION_ID >= 80600 ? 2 : 4];
+        ++$d['prepared'][2];
 
         $this->expectException(\ValueError::class);
         $this->expectExceptionMessage('stale payload');
@@ -2441,11 +2431,11 @@ class DeepCloneTest extends TestCase
 
         if (\PHP_VERSION_ID >= 80600) {
             // Engine ids tell the attribute literal and the same-line runtime
-            // literal apart; the latter hits Closure::__serialize(), which refuses.
+            // literal apart; the latter is not declared in a constant
+            // expression and refuses.
             $this->assertSame('const-expr', deepclone_from_array(deepclone_to_array($attrClosure))());
 
-            $this->expectException(\Exception::class);
-            $this->expectExceptionMessage("Serialization of 'Closure' is not allowed");
+            $this->expectException(\DeepClone\NotInstantiableException::class);
             deepclone_to_array(ConstExprRuntimeCollisionFixture::make());
 
             return;
@@ -2530,13 +2520,13 @@ class DeepCloneTest extends TestCase
         $closure = (new \ReflectionProperty(ConstExprHookedFixture::class, 'virtual'))->getHook(\PropertyHookType::Get)->getAttributes()[0]->getArguments()[0];
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprHookedFixture::class, '$virtual::get()', 0, 0, (new \ReflectionFunction($closure))->getStartLine()]), $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, '$virtual::get()@0'), $d['prepared']);
         $this->assertSame('get-hook-attr', deepclone_from_array($d)());
 
         $closure = (new \ReflectionProperty(ConstExprHookedFixture::class, 'stored'))->getHook(\PropertyHookType::Set)->getParameters()[0]->getAttributes()[0]->getArguments()[0];
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprHookedFixture::class, '$stored::set()#0', 0, 0, (new \ReflectionFunction($closure))->getStartLine()]), $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, '$stored::set()@0'), $d['prepared']);
         $this->assertSame('set-hook-param-attr', deepclone_from_array($d)());
     }
 
@@ -2548,26 +2538,22 @@ class DeepCloneTest extends TestCase
         $line = (new \ReflectionFunction((new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0]))->getStartLine();
         $cases = [
             ['foo', 'const-expr-closure value must be of type array, string given'],
-            [[ConstExprClosureFixture::class], 'const-expr-closure value must have 5 elements'],
-            [[42, '', 0, 0, $line], 'const-expr-closure class name must be of type string, int given'],
-            [['No\\Such\\ClassAtAll', '', 0, 0, $line], 'const-expr-closure references unknown class "No\\Such\\ClassAtAll"'],
-            [[ConstExprClosureFixture::class, 42, 0, 0, $line], 'const-expr-closure value must have 3 elements'],
-            [[ConstExprClosureFixture::class, '', 'x', 0, $line], 'const-expr-closure attribute index must be of type int or null, string given'],
-            [[ConstExprClosureFixture::class, '', 0, 'x', $line], 'const-expr-closure closure index must be of type int, string given'],
-            [[ConstExprClosureFixture::class, '', 0, 0, 'x'], 'const-expr-closure line must be of type int, string given'],
-            [[ConstExprClosureFixture::class, '$nope', 0, 0, $line], 'const-expr-closure references unknown property "$nope"'],
-            [[ConstExprClosureFixture::class, 'nope()', 0, 0, $line], 'const-expr-closure references unknown method "nope()"'],
-            [[ConstExprClosureFixture::class, 'NOPE', 0, 0, $line], 'const-expr-closure references unknown constant "NOPE"'],
-            [[ConstExprClosureFixture::class, 'tagged()#9', 0, 0, $line], 'const-expr-closure references unknown parameter "tagged()#9"'],
-            [[ConstExprClosureFixture::class, '', 9, 0, $line], 'const-expr-closure references unknown attribute index 9'],
-            [[ConstExprClosureFixture::class, '', 0, 9, $line], 'const-expr-closure references unknown closure index 9'],
-            [[ConstExprClosureFixture::class, '', null, 0, $line], 'const-expr-closure attribute index is required for site ""'],
-            [[ConstExprClosureFixture::class, 'tagged()', null, 0, $line], 'const-expr-closure attribute index is required for site "tagged()"'],
-            // an int element 1 makes the payload an engine-id reference [class, id, line]
-            [[ConstExprClosureFixture::class, 0], 'const-expr-closure value must have 3 elements'],
-            [[ConstExprClosureFixture::class, 0, $line, 'x'], 'const-expr-closure value must have 3 elements'],
-            [[42, 0, $line], 'const-expr-closure class name must be of type string, int given'],
-            [[ConstExprClosureFixture::class, 0, 'x'], 'const-expr-closure line must be of type int, string given'],
+            [[ConstExprClosureFixture::class], 'const-expr-closure value must have 3 elements'],
+            [[ConstExprClosureFixture::class, '@0', $line, 'x'], 'const-expr-closure value must have 3 elements'],
+            [[42, '@0', $line], 'const-expr-closure class name must be of type string, int given'],
+            [[ConstExprClosureFixture::class, 0, $line], 'const-expr-closure id must be of type string, int given'],
+            [[ConstExprClosureFixture::class, '@0', 'x'], 'const-expr-closure line must be of type int, string given'],
+            [[ConstExprClosureFixture::class, 'nope', $line], 'const-expr-closure id must be of the form "<site>@<rank>", "nope" given'],
+            [[ConstExprClosureFixture::class, '@', $line], 'const-expr-closure id must be of the form "<site>@<rank>", "@" given'],
+            [[ConstExprClosureFixture::class, '@01', $line], 'const-expr-closure id must be of the form "<site>@<rank>", "@01" given'],
+            [[ConstExprClosureFixture::class, '@1x', $line], 'const-expr-closure id must be of the form "<site>@<rank>", "@1x" given'],
+            [['No\\Such\\ClassAtAll', '@0', $line], 'const-expr-closure references unknown class "No\\Such\\ClassAtAll"'],
+            [[ConstExprClosureFixture::class, '$nope@0', $line], 'const-expr-closure references unknown property "$nope"'],
+            [[ConstExprClosureFixture::class, 'nope()@0', $line], 'const-expr-closure references unknown method "nope()"'],
+            [[ConstExprClosureFixture::class, 'NOPE@0', $line], 'const-expr-closure references unknown constant "NOPE"'],
+            [[ConstExprClosureFixture::class, '$tagged::bad()@0', $line], 'const-expr-closure references unknown hook "$tagged::bad()"'],
+            [[ConstExprClosureFixture::class, '@9', $line], 'const-expr-closure references unknown closure id "@9" in class "'.ConstExprClosureFixture::class.'"'],
+            [[ConstExprClosureFixture::class, 'tagged()@9', $line], 'const-expr-closure references unknown closure id "tagged()@9" in class "'.ConstExprClosureFixture::class.'"'],
         ];
 
         foreach ($cases as [$prepared, $expected]) {
@@ -2609,7 +2595,7 @@ class DeepCloneTest extends TestCase
         // these (no reflection hook), but must decode them: ReflectionFunction
         // reports no start line for an internal function, so the line-0
         // reference must not be treated as stale.
-        $payload = ['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprGlobalFccFixture::class, '$p', 0, 0, 0], 'mask' => 1];
+        $payload = ['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprGlobalFccFixture::class, '$p@0', 0], 'mask' => 1];
 
         $r = deepclone_from_array($payload);
         $this->assertSame(5, $r('hello'));
@@ -2622,53 +2608,23 @@ class DeepCloneTest extends TestCase
     {
         $args = (new \ReflectionClass(ConstExprAmbiguousFixture::class))->getAttributes()[0]->getArguments();
 
-        $this->assertSame(0, deepclone_to_array($args[0])['prepared'][1]);
-        $this->assertSame(1, deepclone_to_array($args[1])['prepared'][1]);
+        $this->assertSame('@0', deepclone_to_array($args[0])['prepared'][1]);
+        $this->assertSame('@1', deepclone_to_array($args[1])['prepared'][1]);
     }
 
     /**
-     * @requires PHP 8.6
+     * @requires PHP 8.5
      */
-    public function testFromArrayConstExprClosureEngineIdErrorPayloads()
+    public function testFromArrayConstExprClosureResolvesFccByRank()
     {
-        $line = (new \ReflectionFunction((new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0]))->getStartLine();
-        $cases = [
-            [[ConstExprClosureFixture::class, 999, $line], 'const-expr-closure references unknown closure id 999 in class "'.ConstExprClosureFixture::class.'"'],
-            [['No\\Such\\ClassAtAll', 0, 1], 'const-expr-closure references unknown class "No\\Such\\ClassAtAll"'],
-            [[ConstExprFccFixture::class, 0, 1], 'const-expr-closure references a first-class callable site'],
-        ];
+        // A first-class callable consumes a rank in its element like any other
+        // closure; a reference to it resolves on every version. Its line is the
+        // target function's, like on the encoding side.
+        $line = (new \ReflectionMethod(ConstExprFccFixture::class, 'helper'))->getStartLine();
 
-        foreach ($cases as [$prepared, $expected]) {
-            try {
-                deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => $prepared, 'mask' => 1]);
-                $this->fail('Expected ValueError was not thrown for: '.$expected);
-            } catch (\ValueError $e) {
-                $this->assertStringContainsString($expected, $e->getMessage());
-            }
-        }
-    }
+        $r = deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprFccFixture::class, 'helper()@0', $line], 'mask' => 1]);
 
-    /**
-     * @requires PHP 8.6
-     */
-    public function testFromArrayConstExprClosureSiteFormWrittenOnPhp85StillResolves()
-    {
-        $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
-        $line = (new \ReflectionFunction($closure))->getStartLine();
-
-        $clone = deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprClosureFixture::class, '', 0, 0, $line], 'mask' => 1]);
-
-        $this->assertSame('class-secret', $clone());
-    }
-
-    /**
-     * @requires PHP < 8.6
-     */
-    public function testFromArrayConstExprClosureEngineIdPayloadRequiresPhp86()
-    {
-        $this->expectException(\ValueError::class);
-        $this->expectExceptionMessage('const-expr-closure payload was created on PHP 8.6 or later and cannot be resolved on PHP '.\PHP_VERSION);
-        deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => [\stdClass::class, 0, 1], 'mask' => 1]);
+        $this->assertTrue($r());
     }
 
     /**

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -2050,6 +2050,21 @@ class DeepCloneTest extends TestCase
     }
 
     /**
+     * On PHP 8.6 closures declared in attribute arguments and in parameter
+     * default values are referenced as [class, engine id, line] instead of the
+     * site-based 5-element form.
+     */
+    private static function expectedConstExprPayload(\Closure $closure, array $siteForm): array
+    {
+        if (\PHP_VERSION_ID < 80600) {
+            return $siteForm;
+        }
+        $r = new \ReflectionFunction($closure);
+
+        return [$r->getConstExprClass(), $r->getConstExprId(), $r->getStartLine()];
+    }
+
+    /**
      * @requires PHP 8.5
      */
     public function testToArrayConstExprClosureClassAttributeWireFormat()
@@ -2059,7 +2074,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprClosureFixture::class, '', 0, 0, $line], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprClosureFixture::class, '', 0, 0, $line]), $d['prepared']);
         $this->assertSame(1, $d['mask']);
     }
 
@@ -2087,7 +2102,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprClosureFixture::class, '$tagged', 0, 0, $line], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprClosureFixture::class, '$tagged', 0, 0, $line]), $d['prepared']);
         $this->assertSame(6, deepclone_from_array($d)(3));
     }
 
@@ -2102,7 +2117,7 @@ class DeepCloneTest extends TestCase
             $line = (new \ReflectionFunction($args[$i]))->getStartLine();
             $d = deepclone_to_array($args[$i]);
 
-            $this->assertSame([ConstExprClosureFixture::class, 'TAGGED', 0, $i, $line], $d['prepared']);
+            $this->assertSame(self::expectedConstExprPayload($args[$i], [ConstExprClosureFixture::class, 'TAGGED', 0, $i, $line]), $d['prepared']);
             $this->assertSame($expected, deepclone_from_array($d)());
         }
     }
@@ -2117,7 +2132,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprClosureFixture::class, 'tagged()', 1, 0, $line], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprClosureFixture::class, 'tagged()', 1, 0, $line]), $d['prepared']);
         $this->assertSame('repeated', deepclone_from_array($d)());
     }
 
@@ -2131,7 +2146,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprClosureFixture::class, 'tagged()#0', 0, 0, $line], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprClosureFixture::class, 'tagged()#0', 0, 0, $line]), $d['prepared']);
         $this->assertSame('param-attr', deepclone_from_array($d)());
     }
 
@@ -2145,7 +2160,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprClosureFixture::class, 'tagged()#0', null, 0, $line], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprClosureFixture::class, 'tagged()#0', null, 0, $line]), $d['prepared']);
         $this->assertSame('param-default', deepclone_from_array($d)());
     }
 
@@ -2201,7 +2216,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprEnumFixture::class, 'Active', 0, 0, $line], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprEnumFixture::class, 'Active', 0, 0, $line]), $d['prepared']);
         $this->assertSame('enum-case-attr', deepclone_from_array($d)());
     }
 
@@ -2242,7 +2257,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprPromotedFixture::class, '__construct()#0', 0, 0, $line], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprPromotedFixture::class, '__construct()#0', 0, 0, $line]), $d['prepared']);
         $this->assertSame('promoted-attr', deepclone_from_array($d)());
     }
 
@@ -2264,8 +2279,9 @@ class DeepCloneTest extends TestCase
     {
         $args = (new \ReflectionClass(ConstExprAmbiguousFixture::class))->getAttributes()[0]->getArguments();
 
-        if (\extension_loaded('deepclone') && !TestListenerTrait::$enabledPolyfills) {
-            // The extension tells same-line closures apart by op_array identity.
+        if (\PHP_VERSION_ID >= 80600 || (\extension_loaded('deepclone') && !TestListenerTrait::$enabledPolyfills)) {
+            // Engine ids (PHP 8.6) and op_array identity (the extension) tell
+            // same-line closures apart.
             $this->assertSame('first', deepclone_from_array(deepclone_to_array($args[0]))());
             $this->assertSame('second', deepclone_from_array(deepclone_to_array($args[1]))());
 
@@ -2285,8 +2301,15 @@ class DeepCloneTest extends TestCase
     {
         $closure = static function (): string { return 'runtime'; };
 
-        $this->expectException(\DeepClone\NotInstantiableException::class);
-        $this->expectExceptionMessage('Type "Closure" is not instantiable.');
+        if (\PHP_VERSION_ID >= 80600) {
+            // Closure::__serialize() exists and refuses closures that were not
+            // declared in a constant expression
+            $this->expectException(\Exception::class);
+            $this->expectExceptionMessage("Serialization of 'Closure' is not allowed");
+        } else {
+            $this->expectException(\DeepClone\NotInstantiableException::class);
+            $this->expectExceptionMessage('Type "Closure" is not instantiable.');
+        }
         deepclone_to_array($closure);
     }
 
@@ -2327,7 +2350,7 @@ class DeepCloneTest extends TestCase
     {
         $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
         $d = deepclone_to_array($closure);
-        ++$d['prepared'][4];
+        ++$d['prepared'][\PHP_VERSION_ID >= 80600 ? 2 : 4];
 
         $this->expectException(\ValueError::class);
         $this->expectExceptionMessage('stale payload');
@@ -2405,7 +2428,7 @@ class DeepCloneTest extends TestCase
 
         $this->assertSame('inner', deepclone_from_array(deepclone_to_array($outer))()());
 
-        $this->expectException(\DeepClone\NotInstantiableException::class);
+        $this->expectException(\PHP_VERSION_ID >= 80600 ? \Exception::class : \DeepClone\NotInstantiableException::class);
         deepclone_to_array($outer());
     }
 
@@ -2415,6 +2438,18 @@ class DeepCloneTest extends TestCase
     public function testToArrayRuntimeClosureCollidingWithConstExprSite()
     {
         $attrClosure = (new \ReflectionMethod(ConstExprRuntimeCollisionFixture::class, 'make'))->getAttributes()[0]->getArguments()[0];
+
+        if (\PHP_VERSION_ID >= 80600) {
+            // Engine ids tell the attribute literal and the same-line runtime
+            // literal apart; the latter hits Closure::__serialize(), which refuses.
+            $this->assertSame('const-expr', deepclone_from_array(deepclone_to_array($attrClosure))());
+
+            $this->expectException(\Exception::class);
+            $this->expectExceptionMessage("Serialization of 'Closure' is not allowed");
+            deepclone_to_array(ConstExprRuntimeCollisionFixture::make());
+
+            return;
+        }
 
         if (\extension_loaded('deepclone') && !TestListenerTrait::$enabledPolyfills) {
             // The extension tells the attribute literal and the same-line runtime
@@ -2473,8 +2508,9 @@ class DeepCloneTest extends TestCase
         }
         $closure = (new \ReflectionMethod(\ConstExprNoSourcesFixture::class, 'm'))->getAttributes()[0]->getArguments()[0];
 
-        if (\extension_loaded('deepclone') && !TestListenerTrait::$enabledPolyfills) {
-            // The extension matches op_arrays and needs no source files.
+        if (\PHP_VERSION_ID >= 80600 || (\extension_loaded('deepclone') && !TestListenerTrait::$enabledPolyfills)) {
+            // Engine ids (PHP 8.6) and op_array identity (the extension) need
+            // no source files.
             $this->assertSame('no-sources', deepclone_from_array(deepclone_to_array($closure))());
 
             return;
@@ -2494,13 +2530,13 @@ class DeepCloneTest extends TestCase
         $closure = (new \ReflectionProperty(ConstExprHookedFixture::class, 'virtual'))->getHook(\PropertyHookType::Get)->getAttributes()[0]->getArguments()[0];
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprHookedFixture::class, '$virtual::get()', 0, 0, (new \ReflectionFunction($closure))->getStartLine()], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprHookedFixture::class, '$virtual::get()', 0, 0, (new \ReflectionFunction($closure))->getStartLine()]), $d['prepared']);
         $this->assertSame('get-hook-attr', deepclone_from_array($d)());
 
         $closure = (new \ReflectionProperty(ConstExprHookedFixture::class, 'stored'))->getHook(\PropertyHookType::Set)->getParameters()[0]->getAttributes()[0]->getArguments()[0];
         $d = deepclone_to_array($closure);
 
-        $this->assertSame([ConstExprHookedFixture::class, '$stored::set()#0', 0, 0, (new \ReflectionFunction($closure))->getStartLine()], $d['prepared']);
+        $this->assertSame(self::expectedConstExprPayload($closure, [ConstExprHookedFixture::class, '$stored::set()#0', 0, 0, (new \ReflectionFunction($closure))->getStartLine()]), $d['prepared']);
         $this->assertSame('set-hook-param-attr', deepclone_from_array($d)());
     }
 
@@ -2515,7 +2551,7 @@ class DeepCloneTest extends TestCase
             [[ConstExprClosureFixture::class], 'const-expr-closure value must have 5 elements'],
             [[42, '', 0, 0, $line], 'const-expr-closure class name must be of type string, int given'],
             [['No\\Such\\ClassAtAll', '', 0, 0, $line], 'const-expr-closure references unknown class "No\\Such\\ClassAtAll"'],
-            [[ConstExprClosureFixture::class, 42, 0, 0, $line], 'const-expr-closure site must be of type string, int given'],
+            [[ConstExprClosureFixture::class, 42, 0, 0, $line], 'const-expr-closure value must have 3 elements'],
             [[ConstExprClosureFixture::class, '', 'x', 0, $line], 'const-expr-closure attribute index must be of type int or null, string given'],
             [[ConstExprClosureFixture::class, '', 0, 'x', $line], 'const-expr-closure closure index must be of type int, string given'],
             [[ConstExprClosureFixture::class, '', 0, 0, 'x'], 'const-expr-closure line must be of type int, string given'],
@@ -2527,6 +2563,11 @@ class DeepCloneTest extends TestCase
             [[ConstExprClosureFixture::class, '', 0, 9, $line], 'const-expr-closure references unknown closure index 9'],
             [[ConstExprClosureFixture::class, '', null, 0, $line], 'const-expr-closure attribute index is required for site ""'],
             [[ConstExprClosureFixture::class, 'tagged()', null, 0, $line], 'const-expr-closure attribute index is required for site "tagged()"'],
+            // an int element 1 makes the payload an engine-id reference [class, id, line]
+            [[ConstExprClosureFixture::class, 0], 'const-expr-closure value must have 3 elements'],
+            [[ConstExprClosureFixture::class, 0, $line, 'x'], 'const-expr-closure value must have 3 elements'],
+            [[42, 0, $line], 'const-expr-closure class name must be of type string, int given'],
+            [[ConstExprClosureFixture::class, 0, 'x'], 'const-expr-closure line must be of type int, string given'],
         ];
 
         foreach ($cases as [$prepared, $expected]) {
@@ -2572,5 +2613,114 @@ class DeepCloneTest extends TestCase
 
         $r = deepclone_from_array($payload);
         $this->assertSame(5, $r('hello'));
+    }
+
+    /**
+     * @requires PHP 8.6
+     */
+    public function testToArrayConstExprClosureSameLineTwinsGetDistinctEngineIds()
+    {
+        $args = (new \ReflectionClass(ConstExprAmbiguousFixture::class))->getAttributes()[0]->getArguments();
+
+        $this->assertSame(0, deepclone_to_array($args[0])['prepared'][1]);
+        $this->assertSame(1, deepclone_to_array($args[1])['prepared'][1]);
+    }
+
+    /**
+     * @requires PHP 8.6
+     */
+    public function testFromArrayConstExprClosureEngineIdErrorPayloads()
+    {
+        $line = (new \ReflectionFunction((new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0]))->getStartLine();
+        $cases = [
+            [[ConstExprClosureFixture::class, 999, $line], 'const-expr-closure references unknown closure id 999 in class "'.ConstExprClosureFixture::class.'"'],
+            [['No\\Such\\ClassAtAll', 0, 1], 'const-expr-closure references unknown class "No\\Such\\ClassAtAll"'],
+            [[ConstExprFccFixture::class, 0, 1], 'const-expr-closure references a first-class callable site'],
+        ];
+
+        foreach ($cases as [$prepared, $expected]) {
+            try {
+                deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => $prepared, 'mask' => 1]);
+                $this->fail('Expected ValueError was not thrown for: '.$expected);
+            } catch (\ValueError $e) {
+                $this->assertStringContainsString($expected, $e->getMessage());
+            }
+        }
+    }
+
+    /**
+     * @requires PHP 8.6
+     */
+    public function testFromArrayConstExprClosureSiteFormWrittenOnPhp85StillResolves()
+    {
+        $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
+        $line = (new \ReflectionFunction($closure))->getStartLine();
+
+        $clone = deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprClosureFixture::class, '', 0, 0, $line], 'mask' => 1]);
+
+        $this->assertSame('class-secret', $clone());
+    }
+
+    /**
+     * @requires PHP < 8.6
+     */
+    public function testFromArrayConstExprClosureEngineIdPayloadRequiresPhp86()
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('const-expr-closure payload was created on PHP 8.6 or later and cannot be resolved on PHP '.\PHP_VERSION);
+        deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => [\stdClass::class, 0, 1], 'mask' => 1]);
+    }
+
+    /**
+     * @requires PHP 8.6
+     */
+    public function testConstExprClosureCrossClassAndGlobalFccUseDeclaringClass()
+    {
+        // On PHP 8.6 the engine names the declaring class (getConstExprClass),
+        // so a first-class callable over another class's method or a global
+        // function serializes -- with no allow_named_closures opt-in -- as a
+        // declaration-site reference rooted at the declaring class, not the
+        // target's scope. Userland could not do this before 8.6.
+        $p = \Symfony\Polyfill\DeepClone\DeepClone::class;
+        $rp = new \ReflectionClass(ConstExprCrossFccFixture::class);
+
+        $cross = $p::deepclone_to_array($rp->getProperty('x')->getAttributes()[0]->getArguments()[0]);
+        $this->assertSame(1, $cross['mask']);
+        $this->assertSame(ConstExprCrossFccFixture::class, $cross['prepared'][0]);
+        $this->assertTrue($p::deepclone_from_array($cross)());
+
+        $gi = $p::deepclone_to_array($rp->getProperty('g')->getAttributes()[0]->getArguments()[0]);
+        $this->assertSame(ConstExprCrossFccFixture::class, $gi['prepared'][0]);
+        $this->assertSame(5, $p::deepclone_from_array($gi)('hello'));
+
+        $gu = $p::deepclone_to_array($rp->getProperty('u')->getAttributes()[0]->getArguments()[0]);
+        $this->assertSame(ConstExprCrossFccFixture::class, $gu['prepared'][0]);
+        $this->assertSame(7, $p::deepclone_from_array($gu)());
+    }
+
+    /**
+     * @requires PHP 8.6
+     */
+    public function testConstExprClosureExtensionAndPolyfillPayloadsInterchange()
+    {
+        if (!\extension_loaded('deepclone')) {
+            $this->markTestSkipped('Requires the "deepclone" extension.');
+        }
+
+        $rx = new \ReflectionProperty(ConstExprCrossFccFixture::class, 'x');
+        $ru = new \ReflectionProperty(ConstExprCrossFccFixture::class, 'u');
+        foreach ([
+            (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0],
+            (new \ReflectionMethod(ConstExprClosureFixture::class, 'tagged'))->getParameters()[0]->getDefaultValue(),
+            $rx->getAttributes()[0]->getArguments()[0],   // cross-class first-class callable
+            $ru->getAttributes()[0]->getArguments()[0],   // global-function first-class callable
+        ] as $closure) {
+            $ext = \deepclone_to_array($closure);
+            $polyfill = \Symfony\Polyfill\DeepClone\DeepClone::deepclone_to_array($closure);
+
+            $this->assertSame($ext, $polyfill);
+            $this->assertSame($closure(), \deepclone_from_array($polyfill)());
+            $this->assertSame($closure(), \Symfony\Polyfill\DeepClone\DeepClone::deepclone_from_array($ext)());
+        }
     }
 }

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -2050,15 +2050,18 @@ class DeepCloneTest extends TestCase
     }
 
     /**
-     * A reference payload [class, "<site>@<rank>"] with any engine "#<hash>"
-     * suffix stripped from the actual, so a single expected value matches on
-     * both PHP 8.5 (no hash) and 8.6 (the engine suffixes the rank).
+     * A reference payload [class, site, key, hash] checked against the expected
+     * "<site>@<rank>" rendering. The hash (field 3) is an int, non-zero only for
+     * an anonymous closure the engine addresses (PHP 8.6), so it is not asserted
+     * here; a single expected value thus matches on both PHP 8.5 and 8.6.
      */
     private static function assertPrepared(\Closure $closure, string $id, array $prepared): void
     {
         $scope = (new \ReflectionFunction($closure))->getClosureScopeClass();
-        self::assertCount(2, $prepared);
-        self::assertSame([$scope->name, $id], [$prepared[0], preg_replace('/#[0-9a-f]{8}$/', '', $prepared[1])]);
+        $at = strrpos($id, '@');
+        self::assertCount(4, $prepared);
+        self::assertSame([$scope->name, substr($id, 0, $at), (int) substr($id, $at + 1)], [$prepared[0], $prepared[1], $prepared[2]]);
+        self::assertIsInt($prepared[3]);
     }
 
 
@@ -2339,14 +2342,13 @@ class DeepCloneTest extends TestCase
      */
     public function testFromArrayConstExprClosureStaleHashThrows()
     {
-        // On PHP 8.6 the id carries a "#<hash>" of the closure's code; tampering
-        // it is rejected by the engine's own unserialization. On 8.5 the polyfill
-        // cannot compute the hash, so references resolve positionally with no
-        // staleness check.
+        // On PHP 8.6 the reference carries a code hash of the anonymous closure;
+        // tampering it is rejected by the engine's own unserialization. On 8.5 the
+        // polyfill cannot compute the hash, so references resolve positionally
+        // with no staleness check.
         $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
         $d = deepclone_to_array($closure);
-        $id = $d['prepared'][1];
-        $d['prepared'][1] = substr($id, 0, -1).dechex(hexdec(substr($id, -1)) ^ 1);
+        $d['prepared'][3] ^= 1;
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('changed');
@@ -2541,23 +2543,27 @@ class DeepCloneTest extends TestCase
      */
     public function testFromArrayConstExprClosureMalformedPayloads()
     {
+        // The reference is [class, site, key, hash]. A hash of 0 means
+        // "unverified"; these all pass 0, so on PHP 8.6 the engine's own
+        // resolution throws and the polyfill heals positionally through its
+        // value-walk, surfacing these messages on every version.
         $cases = [
             ['foo', 'const-expr-closure value must be of type array, string given'],
-            [[ConstExprClosureFixture::class], 'const-expr-closure value must have 2 elements'],
-            [[ConstExprClosureFixture::class, '@0', 1], 'const-expr-closure value must have 2 elements'],
-            [[42, '@0'], 'const-expr-closure class name must be of type string, int given'],
-            [[ConstExprClosureFixture::class, 0], 'const-expr-closure id must be of type string, int given'],
-            [[ConstExprClosureFixture::class, 'nope'], 'const-expr-closure id must be of the form "<site>@<rank>", "nope" given'],
-            [[ConstExprClosureFixture::class, '@'], 'const-expr-closure id must be of the form "<site>@<rank>", "@" given'],
-            [[ConstExprClosureFixture::class, '@01'], 'const-expr-closure id must be of the form "<site>@<rank>", "@01" given'],
-            [[ConstExprClosureFixture::class, '@1x'], 'const-expr-closure id must be of the form "<site>@<rank>", "@1x" given'],
-            [['No\\Such\\ClassAtAll', '@0'], 'const-expr-closure references unknown class "No\\Such\\ClassAtAll"'],
-            [[ConstExprClosureFixture::class, '$nope@0'], 'const-expr-closure references unknown property "$nope"'],
-            [[ConstExprClosureFixture::class, 'nope()@0'], 'const-expr-closure references unknown method "nope()"'],
-            [[ConstExprClosureFixture::class, 'NOPE@0'], 'const-expr-closure references unknown constant "NOPE"'],
-            [[ConstExprClosureFixture::class, '$tagged::bad()@0'], 'const-expr-closure references unknown hook "$tagged::bad()"'],
-            [[ConstExprClosureFixture::class, '@9'], 'const-expr-closure references unknown closure id "@9" in class "'.ConstExprClosureFixture::class.'"'],
-            [[ConstExprClosureFixture::class, 'tagged()@9'], 'const-expr-closure references unknown closure id "tagged()@9" in class "'.ConstExprClosureFixture::class.'"'],
+            [[ConstExprClosureFixture::class], 'const-expr-closure value must have 4 elements'],
+            [[ConstExprClosureFixture::class, '', 0], 'const-expr-closure value must have 4 elements'],
+            [[ConstExprClosureFixture::class, '', 0, 0, 0], 'const-expr-closure value must have 4 elements'],
+            [[42, '', 0, 0], 'const-expr-closure reference must be [string class, string site, int|string key, int hash]'],
+            [[ConstExprClosureFixture::class, 0, 0, 0], 'const-expr-closure reference must be [string class, string site, int|string key, int hash]'],
+            [[ConstExprClosureFixture::class, '', [], 0], 'const-expr-closure reference must be [string class, string site, int|string key, int hash]'],
+            [[ConstExprClosureFixture::class, '', 0, '0'], 'const-expr-closure reference must be [string class, string site, int|string key, int hash]'],
+            [['No\\Such\\ClassAtAll', '', 0, 0], 'const-expr-closure references unknown class "No\\Such\\ClassAtAll"'],
+            [[ConstExprClosureFixture::class, '$nope', 0, 0], 'const-expr-closure references unknown property "$nope"'],
+            [[ConstExprClosureFixture::class, 'nope()', 0, 0], 'const-expr-closure references unknown method "nope()"'],
+            [[ConstExprClosureFixture::class, 'NOPE', 0, 0], 'const-expr-closure references unknown constant "NOPE"'],
+            [[ConstExprClosureFixture::class, '$tagged::bad()', 0, 0], 'const-expr-closure references unknown hook "$tagged::bad()"'],
+            [[ConstExprClosureFixture::class, '', 'x', 0], 'const-expr-closure references unknown closure at site "" of class "'.ConstExprClosureFixture::class.'"'],
+            [[ConstExprClosureFixture::class, '', 9, 0], 'const-expr-closure references unknown closure "@9" in class "'.ConstExprClosureFixture::class.'"'],
+            [[ConstExprClosureFixture::class, 'tagged()', 9, 0], 'const-expr-closure references unknown closure "tagged()@9" in class "'.ConstExprClosureFixture::class.'"'],
         ];
 
         foreach ($cases as [$prepared, $expected]) {
@@ -2596,7 +2602,7 @@ class DeepCloneTest extends TestCase
         // The extension can reference a global internal function declared in an
         // attribute (e.g. #[ConstExprAttr(strlen(...))]). The polyfill cannot
         // produce these (no reflection hook), but must decode them positionally.
-        $payload = ['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprGlobalFccFixture::class, '$p@0'], 'mask' => 1];
+        $payload = ['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprGlobalFccFixture::class, '$p', 0, 0], 'mask' => 1];
 
         $r = deepclone_from_array($payload);
         $this->assertSame(5, $r('hello'));
@@ -2609,9 +2615,15 @@ class DeepCloneTest extends TestCase
     {
         $args = (new \ReflectionClass(ConstExprAmbiguousFixture::class))->getAttributes()[0]->getArguments();
 
-        // Distinct ranks; the engine suffixes each with a "#<hash>" of its code.
-        $this->assertSame('@0', preg_replace('/#[0-9a-f]{8}$/', '', deepclone_to_array($args[0])['prepared'][1]));
-        $this->assertSame('@1', preg_replace('/#[0-9a-f]{8}$/', '', deepclone_to_array($args[1])['prepared'][1]));
+        $d0 = deepclone_to_array($args[0])['prepared'];
+        $d1 = deepclone_to_array($args[1])['prepared'];
+
+        // Same class-attribute site, distinct ranks; the engine also stamps each
+        // with a non-zero code hash (field 3), so the two references never collide.
+        $this->assertSame(['', 0], [$d0[1], $d0[2]]);
+        $this->assertSame(['', 1], [$d1[1], $d1[2]]);
+        $this->assertNotSame(0, $d0[3]);
+        $this->assertNotSame(0, $d1[3]);
     }
 
     /**
@@ -2621,7 +2633,7 @@ class DeepCloneTest extends TestCase
     {
         // A first-class callable consumes a rank in its element like any other
         // closure; a reference to it resolves positionally on every version.
-        $r = deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprFccFixture::class, 'helper()@0'], 'mask' => 1]);
+        $r = deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprFccFixture::class, 'helper()', 0, 0], 'mask' => 1]);
 
         $this->assertTrue($r());
     }

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -2340,14 +2340,15 @@ class DeepCloneTest extends TestCase
     public function testFromArrayConstExprClosureStaleHashThrows()
     {
         // On PHP 8.6 the id carries a "#<hash>" of the closure's code; tampering
-        // it is rejected. On 8.5 the polyfill cannot compute the hash, so
-        // references resolve positionally with no staleness check.
+        // it is rejected by the engine's own unserialization. On 8.5 the polyfill
+        // cannot compute the hash, so references resolve positionally with no
+        // staleness check.
         $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
         $d = deepclone_to_array($closure);
         $id = $d['prepared'][1];
         $d['prepared'][1] = substr($id, 0, -1).dechex(hexdec(substr($id, -1)) ^ 1);
 
-        $this->expectException(\ValueError::class);
+        $this->expectException(\Exception::class);
         $this->expectExceptionMessage('changed');
         deepclone_from_array($d);
     }

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -2050,18 +2050,17 @@ class DeepCloneTest extends TestCase
     }
 
     /**
-     * Element-scoped reference [class, "<site>@<rank>", line], identical on
-     * every PHP version and to the engine's own id for attribute and
-     * parameter-default closures.
+     * A reference payload [class, "<site>@<rank>"] with any engine "#<hash>"
+     * suffix stripped from the actual, so a single expected value matches on
+     * both PHP 8.5 (no hash) and 8.6 (the engine suffixes the rank).
      */
-    private static function expectedConstExprPayload(\Closure $closure, string $id): array
+    private static function assertPrepared(\Closure $closure, string $id, array $prepared): void
     {
-        $r = new \ReflectionFunction($closure);
-        $scope = $r->getClosureScopeClass();
-
-        // The stored line is relative to the declaring class.
-        return [$scope->name, $id, ($r->getStartLine() ?: 0) ? $r->getStartLine() - $scope->getStartLine() : 0];
+        $scope = (new \ReflectionFunction($closure))->getClosureScopeClass();
+        self::assertCount(2, $prepared);
+        self::assertSame([$scope->name, $id], [$prepared[0], preg_replace('/#[0-9a-f]{8}$/', '', $prepared[1])]);
     }
+
 
     /**
      * @requires PHP 8.5
@@ -2073,7 +2072,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, '@0'), $d['prepared']);
+        self::assertPrepared($closure, '@0', $d['prepared']);
         $this->assertSame(1, $d['mask']);
     }
 
@@ -2101,7 +2100,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, '$tagged@0'), $d['prepared']);
+        self::assertPrepared($closure, '$tagged@0', $d['prepared']);
         $this->assertSame(6, deepclone_from_array($d)(3));
     }
 
@@ -2116,7 +2115,7 @@ class DeepCloneTest extends TestCase
             $line = (new \ReflectionFunction($args[$i]))->getStartLine();
             $d = deepclone_to_array($args[$i]);
 
-            $this->assertSame(self::expectedConstExprPayload($args[$i], 'TAGGED@'.$i), $d['prepared']);
+            self::assertPrepared($args[$i], 'TAGGED@'.$i, $d['prepared']);
             $this->assertSame($expected, deepclone_from_array($d)());
         }
     }
@@ -2131,7 +2130,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, 'tagged()@0'), $d['prepared']);
+        self::assertPrepared($closure, 'tagged()@0', $d['prepared']);
         $this->assertSame('repeated', deepclone_from_array($d)());
     }
 
@@ -2145,7 +2144,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, 'tagged()@1'), $d['prepared']);
+        self::assertPrepared($closure, 'tagged()@1', $d['prepared']);
         $this->assertSame('param-attr', deepclone_from_array($d)());
     }
 
@@ -2159,7 +2158,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, 'tagged()@2'), $d['prepared']);
+        self::assertPrepared($closure, 'tagged()@2', $d['prepared']);
         $this->assertSame('param-default', deepclone_from_array($d)());
     }
 
@@ -2173,7 +2172,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, '$factory@0'), $d['prepared']);
+        self::assertPrepared($closure, '$factory@0', $d['prepared']);
         $this->assertSame('prop-default', deepclone_from_array($d)());
     }
 
@@ -2187,7 +2186,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, '$staticFactory@0'), $d['prepared']);
+        self::assertPrepared($closure, '$staticFactory@0', $d['prepared']);
         $this->assertSame('static-prop-default', deepclone_from_array($d)());
     }
 
@@ -2201,7 +2200,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, 'CALLBACKS@0'), $d['prepared']);
+        self::assertPrepared($closure, 'CALLBACKS@0', $d['prepared']);
         $this->assertSame('const-value', deepclone_from_array($d)());
     }
 
@@ -2215,7 +2214,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, 'Active@0'), $d['prepared']);
+        self::assertPrepared($closure, 'Active@0', $d['prepared']);
         $this->assertSame('enum-case-attr', deepclone_from_array($d)());
     }
 
@@ -2229,7 +2228,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, 'FILTER@0'), $d['prepared']);
+        self::assertPrepared($closure, 'FILTER@0', $d['prepared']);
         $this->assertSame('enum-const', deepclone_from_array($d)());
     }
 
@@ -2256,7 +2255,7 @@ class DeepCloneTest extends TestCase
 
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, \PHP_VERSION_ID >= 80600 ? '$promoted@0' : '__construct()@0'), $d['prepared']);
+        self::assertPrepared($closure, \PHP_VERSION_ID >= 80600 ? '$promoted@0' : '__construct()@0', $d['prepared']);
         $this->assertSame('promoted-attr', deepclone_from_array($d)());
     }
 
@@ -2336,16 +2335,20 @@ class DeepCloneTest extends TestCase
     }
 
     /**
-     * @requires PHP 8.5
+     * @requires PHP 8.6
      */
-    public function testFromArrayConstExprClosureStaleLineThrows()
+    public function testFromArrayConstExprClosureStaleHashThrows()
     {
+        // On PHP 8.6 the id carries a "#<hash>" of the closure's code; tampering
+        // it is rejected. On 8.5 the polyfill cannot compute the hash, so
+        // references resolve positionally with no staleness check.
         $closure = (new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0];
         $d = deepclone_to_array($closure);
-        ++$d['prepared'][2];
+        $id = $d['prepared'][1];
+        $d['prepared'][1] = substr($id, 0, -1).dechex(hexdec(substr($id, -1)) ^ 1);
 
         $this->expectException(\ValueError::class);
-        $this->expectExceptionMessage('stale payload');
+        $this->expectExceptionMessage('changed');
         deepclone_from_array($d);
     }
 
@@ -2522,13 +2525,13 @@ class DeepCloneTest extends TestCase
         $closure = (new \ReflectionProperty(ConstExprHookedFixture::class, 'virtual'))->getHook(\PropertyHookType::Get)->getAttributes()[0]->getArguments()[0];
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, '$virtual::get()@0'), $d['prepared']);
+        self::assertPrepared($closure, '$virtual::get()@0', $d['prepared']);
         $this->assertSame('get-hook-attr', deepclone_from_array($d)());
 
         $closure = (new \ReflectionProperty(ConstExprHookedFixture::class, 'stored'))->getHook(\PropertyHookType::Set)->getParameters()[0]->getAttributes()[0]->getArguments()[0];
         $d = deepclone_to_array($closure);
 
-        $this->assertSame(self::expectedConstExprPayload($closure, '$stored::set()@0'), $d['prepared']);
+        self::assertPrepared($closure, '$stored::set()@0', $d['prepared']);
         $this->assertSame('set-hook-param-attr', deepclone_from_array($d)());
     }
 
@@ -2537,25 +2540,23 @@ class DeepCloneTest extends TestCase
      */
     public function testFromArrayConstExprClosureMalformedPayloads()
     {
-        $line = (new \ReflectionFunction((new \ReflectionClass(ConstExprClosureFixture::class))->getAttributes()[0]->getArguments()[0]))->getStartLine();
         $cases = [
             ['foo', 'const-expr-closure value must be of type array, string given'],
-            [[ConstExprClosureFixture::class], 'const-expr-closure value must have 3 elements'],
-            [[ConstExprClosureFixture::class, '@0', $line, 'x'], 'const-expr-closure value must have 3 elements'],
-            [[42, '@0', $line], 'const-expr-closure class name must be of type string, int given'],
-            [[ConstExprClosureFixture::class, 0, $line], 'const-expr-closure id must be of type string, int given'],
-            [[ConstExprClosureFixture::class, '@0', 'x'], 'const-expr-closure line must be of type int, string given'],
-            [[ConstExprClosureFixture::class, 'nope', $line], 'const-expr-closure id must be of the form "<site>@<rank>", "nope" given'],
-            [[ConstExprClosureFixture::class, '@', $line], 'const-expr-closure id must be of the form "<site>@<rank>", "@" given'],
-            [[ConstExprClosureFixture::class, '@01', $line], 'const-expr-closure id must be of the form "<site>@<rank>", "@01" given'],
-            [[ConstExprClosureFixture::class, '@1x', $line], 'const-expr-closure id must be of the form "<site>@<rank>", "@1x" given'],
-            [['No\\Such\\ClassAtAll', '@0', $line], 'const-expr-closure references unknown class "No\\Such\\ClassAtAll"'],
-            [[ConstExprClosureFixture::class, '$nope@0', $line], 'const-expr-closure references unknown property "$nope"'],
-            [[ConstExprClosureFixture::class, 'nope()@0', $line], 'const-expr-closure references unknown method "nope()"'],
-            [[ConstExprClosureFixture::class, 'NOPE@0', $line], 'const-expr-closure references unknown constant "NOPE"'],
-            [[ConstExprClosureFixture::class, '$tagged::bad()@0', $line], 'const-expr-closure references unknown hook "$tagged::bad()"'],
-            [[ConstExprClosureFixture::class, '@9', $line], 'const-expr-closure references unknown closure id "@9" in class "'.ConstExprClosureFixture::class.'"'],
-            [[ConstExprClosureFixture::class, 'tagged()@9', $line], 'const-expr-closure references unknown closure id "tagged()@9" in class "'.ConstExprClosureFixture::class.'"'],
+            [[ConstExprClosureFixture::class], 'const-expr-closure value must have 2 elements'],
+            [[ConstExprClosureFixture::class, '@0', 1], 'const-expr-closure value must have 2 elements'],
+            [[42, '@0'], 'const-expr-closure class name must be of type string, int given'],
+            [[ConstExprClosureFixture::class, 0], 'const-expr-closure id must be of type string, int given'],
+            [[ConstExprClosureFixture::class, 'nope'], 'const-expr-closure id must be of the form "<site>@<rank>", "nope" given'],
+            [[ConstExprClosureFixture::class, '@'], 'const-expr-closure id must be of the form "<site>@<rank>", "@" given'],
+            [[ConstExprClosureFixture::class, '@01'], 'const-expr-closure id must be of the form "<site>@<rank>", "@01" given'],
+            [[ConstExprClosureFixture::class, '@1x'], 'const-expr-closure id must be of the form "<site>@<rank>", "@1x" given'],
+            [['No\\Such\\ClassAtAll', '@0'], 'const-expr-closure references unknown class "No\\Such\\ClassAtAll"'],
+            [[ConstExprClosureFixture::class, '$nope@0'], 'const-expr-closure references unknown property "$nope"'],
+            [[ConstExprClosureFixture::class, 'nope()@0'], 'const-expr-closure references unknown method "nope()"'],
+            [[ConstExprClosureFixture::class, 'NOPE@0'], 'const-expr-closure references unknown constant "NOPE"'],
+            [[ConstExprClosureFixture::class, '$tagged::bad()@0'], 'const-expr-closure references unknown hook "$tagged::bad()"'],
+            [[ConstExprClosureFixture::class, '@9'], 'const-expr-closure references unknown closure id "@9" in class "'.ConstExprClosureFixture::class.'"'],
+            [[ConstExprClosureFixture::class, 'tagged()@9'], 'const-expr-closure references unknown closure id "tagged()@9" in class "'.ConstExprClosureFixture::class.'"'],
         ];
 
         foreach ($cases as [$prepared, $expected]) {
@@ -2592,12 +2593,9 @@ class DeepCloneTest extends TestCase
     public function testFromArrayConstExprClosureGlobalInternalFunction()
     {
         // The extension can reference a global internal function declared in an
-        // attribute (e.g. #[ConstExprAttr(strlen(...))]); such a reference has
-        // no start line and is encoded with line 0. The polyfill cannot produce
-        // these (no reflection hook), but must decode them: ReflectionFunction
-        // reports no start line for an internal function, so the line-0
-        // reference must not be treated as stale.
-        $payload = ['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprGlobalFccFixture::class, '$p@0', 0], 'mask' => 1];
+        // attribute (e.g. #[ConstExprAttr(strlen(...))]). The polyfill cannot
+        // produce these (no reflection hook), but must decode them positionally.
+        $payload = ['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprGlobalFccFixture::class, '$p@0'], 'mask' => 1];
 
         $r = deepclone_from_array($payload);
         $this->assertSame(5, $r('hello'));
@@ -2610,8 +2608,9 @@ class DeepCloneTest extends TestCase
     {
         $args = (new \ReflectionClass(ConstExprAmbiguousFixture::class))->getAttributes()[0]->getArguments();
 
-        $this->assertSame('@0', deepclone_to_array($args[0])['prepared'][1]);
-        $this->assertSame('@1', deepclone_to_array($args[1])['prepared'][1]);
+        // Distinct ranks; the engine suffixes each with a "#<hash>" of its code.
+        $this->assertSame('@0', preg_replace('/#[0-9a-f]{8}$/', '', deepclone_to_array($args[0])['prepared'][1]));
+        $this->assertSame('@1', preg_replace('/#[0-9a-f]{8}$/', '', deepclone_to_array($args[1])['prepared'][1]));
     }
 
     /**
@@ -2620,13 +2619,8 @@ class DeepCloneTest extends TestCase
     public function testFromArrayConstExprClosureResolvesFccByRank()
     {
         // A first-class callable consumes a rank in its element like any other
-        // closure; a reference to it resolves on every version. Its line is the
-        // target function's relative to the declaring class, like on the
-        // encoding side.
-        $line = (new \ReflectionMethod(ConstExprFccFixture::class, 'helper'))->getStartLine()
-            - (new \ReflectionClass(ConstExprFccFixture::class))->getStartLine();
-
-        $r = deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprFccFixture::class, 'helper()@0', $line], 'mask' => 1]);
+        // closure; a reference to it resolves positionally on every version.
+        $r = deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprFccFixture::class, 'helper()@0'], 'mask' => 1]);
 
         $this->assertTrue($r());
     }

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -2057,8 +2057,10 @@ class DeepCloneTest extends TestCase
     private static function expectedConstExprPayload(\Closure $closure, string $id): array
     {
         $r = new \ReflectionFunction($closure);
+        $scope = $r->getClosureScopeClass();
 
-        return [$r->getClosureScopeClass()->name, $id, $r->getStartLine()];
+        // The stored line is relative to the declaring class.
+        return [$scope->name, $id, ($r->getStartLine() ?: 0) ? $r->getStartLine() - $scope->getStartLine() : 0];
     }
 
     /**
@@ -2619,8 +2621,10 @@ class DeepCloneTest extends TestCase
     {
         // A first-class callable consumes a rank in its element like any other
         // closure; a reference to it resolves on every version. Its line is the
-        // target function's, like on the encoding side.
-        $line = (new \ReflectionMethod(ConstExprFccFixture::class, 'helper'))->getStartLine();
+        // target function's relative to the declaring class, like on the
+        // encoding side.
+        $line = (new \ReflectionMethod(ConstExprFccFixture::class, 'helper'))->getStartLine()
+            - (new \ReflectionClass(ConstExprFccFixture::class))->getStartLine();
 
         $r = deepclone_from_array(['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprFccFixture::class, 'helper()@0', $line], 'mask' => 1]);
 

--- a/tests/DeepClone/fixtures85.php
+++ b/tests/DeepClone/fixtures85.php
@@ -126,6 +126,15 @@ class ConstExprTraitAliasFixture
     }
 }
 
+class ConstExprFccFixture
+{
+    #[ConstExprAttr(self::helper(...))]
+    public static function helper(): bool
+    {
+        return true;
+    }
+}
+
 class ConstExprHookedFixture
 {
     public string $virtual {
@@ -140,17 +149,22 @@ class ConstExprHookedFixture
     }
 }
 
-class ConstExprFccFixture
-{
-    #[ConstExprAttr(self::helper(...))]
-    public static function helper(): bool
-    {
-        return true;
-    }
-}
-
 class ConstExprGlobalFccFixture
 {
     #[ConstExprAttr(strlen(...))]
     public string $p = '';
+}
+
+class ConstExprCrossTarget
+{
+    public static function check(): bool { return true; }
+}
+
+function dc_constexpr_global_fcc(): int { return 7; }
+
+class ConstExprCrossFccFixture
+{
+    #[ConstExprAttr(ConstExprCrossTarget::check(...))] public int $x = 0;
+    #[ConstExprAttr(strlen(...))] public int $g = 0;
+    #[ConstExprAttr(dc_constexpr_global_fcc(...))] public int $u = 0;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The proposed PHP 8.6 "Serializable closures" engine support (implementation at nicolas-grekas/php-src#4) gives every closure declared in an attribute argument or in a parameter default value a canonical per-class id, derived from a deterministic, non-evaluating walk over the class's constant expressions, exposed as `ReflectionFunction::getConstExprId()` and resolved by `Closure::fromConstExpr()`. This PR makes the polyfill use those ids, gated on `\PHP_VERSION_ID >= 80600`, assuming the RFC lands.

- **Encoding.** On PHP 8.6, `deepclone_to_array()` emits `[class, id, line]` under the existing mask marker, from a single `getConstExprId()` call. Everything that existed only because userland could not see closure identity stops being needed for these sites: the per-class evaluated index, the name/file/line/signature keys, the token-level aliasing guard, and the documented refusals all become moot, since same-line literals get distinct ids and no source files are read. Closures declared in class constant values and in property default values are evaluated in place by the engine and have no id; they keep the site-based 5-element form (and, on 8.6, the index lookup ignores attribute and parameter-default candidates, which can only be stale line-mates there).
- **Decoding.** `deepclone_from_array()` accepts both forms on every PHP version, discriminated by the type of element 1 (int id vs string site). Site-based payloads written on PHP 8.5 keep resolving on PHP 8.6, so caches survive the upgrade; engine-id payloads on older PHP fail with a message saying they need PHP 8.6. Resolution goes through `Closure::fromConstExpr()` plus the same staleness check as before (`stale payload` when the declaration line moved). Crafted payloads addressing a first-class-callable site are rejected; FCCs keep the named-closure form. The allow-list gates are unchanged on both sides, including the payload-class check before autoloading.
- **Runtime closures** now surface the engine's own `Closure::__serialize()` refusal (`Serialization of 'Closure' is not allowed`) instead of `NotInstantiableException`, matching what `serialize()` itself says on 8.6.

Measured on the patched engine (release build): encoding an attribute closure goes from 3.2 us to 1.6 us with no more ~30 us cold per-class index, and decoding from 2.5 us to 1.2 us; both implementations now also outperform native `serialize()`/`unserialize()` of the same closures, which carry the wrapping format.

Payloads stay byte-identical and interchangeable with the extension, now covered by an in-suite interchange test that runs when the extension is loaded. The suite passes on PHP 8.5 (current behavior unchanged) and on the patched 8.6 build with the extension compiled in, on both the native and polyfill legs.

Companion extension implementation: symfony/php-ext-deepclone#24

**Expected CI failures until dependencies ship:** the 8.2-8.5 lanes with the extension enabled fail on the two new payload-validation tests because they install the latest tagged extension, which predates the engine-id form; they go green once symfony/php-ext-deepclone#24 is released (same sequence as #630/#632). The 8.6 lanes run php-src master, which does not include the engine patch yet, so `ReflectionFunction::getConstExprId()` is undefined there; they go green once the engine implementation lands.
