### PR TITLE
[DeepClone] Suggest the extension when refusing a named callable, and decode its global-function references

### DIFF
--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -684,7 +684,7 @@ final class DeepClone
                     // method of that name, so it is gated behind
                     // allow_named_closures, which both ends must enable.
                     if (!$allowNamedClosures) {
-                        throw new \ValueError('deepclone_to_array(): serializing a closure over the named callable "'.$r->name.'" requires enabling the allow_named_closures option');
+                        throw new \ValueError('deepclone_to_array(): serializing a closure over the named callable "'.$r->name.'" requires enabling the "allow_named_closures" option; do it only if you trust the input; alternatively, install the "deepclone" extension, which can reference callables declared in constant expressions');
                     }
                     if (null !== $allowedSet && !isset($allowedSet['closure'])) {
                         throw new \ValueError('deepclone_to_array(): class "Closure" is not allowed');
@@ -1655,7 +1655,11 @@ final class DeepClone
         if (null === $found) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) malformed payload, const-expr-closure references unknown closure index '.$closureIndex);
         }
-        if ($line !== $foundLine = (new \ReflectionFunction($found))->getStartLine()) {
+        // Internal functions (e.g. a global strlen(...) reference) have no
+        // start line; getStartLine() returns false, which the extension encodes
+        // as 0. Normalize so such a reference does not look stale.
+        $foundLine = (new \ReflectionFunction($found))->getStartLine() ?: 0;
+        if ($line !== $foundLine) {
             throw new \ValueError('deepclone_from_array(): Argument #1 ($data) stale payload, const-expr-closure moved from line '.$line.' to line '.$foundLine);
         }
 

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -584,7 +584,9 @@ class DeepCloneTest extends TestCase
     public function testToArrayNamedClosureRequiresOptIn()
     {
         $this->expectException(\ValueError::class);
-        $this->expectExceptionMessage('serializing a closure over the named callable "strlen" requires enabling the allow_named_closures option');
+        // Substring common to the polyfill and extension messages (the polyfill
+        // quotes the option name and appends an extension hint).
+        $this->expectExceptionMessage('serializing a closure over the named callable "strlen" requires enabling the');
         deepclone_to_array(\Closure::fromCallable('strlen'));
     }
 
@@ -2553,5 +2555,22 @@ class DeepCloneTest extends TestCase
         $this->assertSame(1, $d['mask']);
         $this->assertSame(ConstExprFccFixture::class, $d['prepared'][0]);
         $this->assertTrue(deepclone_from_array($d)());
+    }
+
+    /**
+     * @requires PHP 8.5
+     */
+    public function testFromArrayConstExprClosureGlobalInternalFunction()
+    {
+        // The extension can reference a global internal function declared in an
+        // attribute (e.g. #[ConstExprAttr(strlen(...))]); such a reference has
+        // no start line and is encoded with line 0. The polyfill cannot produce
+        // these (no reflection hook), but must decode them: ReflectionFunction
+        // reports no start line for an internal function, so the line-0
+        // reference must not be treated as stale.
+        $payload = ['classes' => '', 'objectMeta' => 0, 'prepared' => [ConstExprGlobalFccFixture::class, '$p', 0, 0, 0], 'mask' => 1];
+
+        $r = deepclone_from_array($payload);
+        $this->assertSame(5, $r('hello'));
     }
 }

--- a/tests/DeepClone/fixtures85.php
+++ b/tests/DeepClone/fixtures85.php
@@ -148,3 +148,9 @@ class ConstExprFccFixture
         return true;
     }
 }
+
+class ConstExprGlobalFccFixture
+{
+    #[ConstExprAttr(strlen(...))]
+    public string $p = '';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Two related improvements to how the polyfill cooperates with the extension on first-class callables declared in constant expressions.

**Refusal message.** `deepclone_to_array()` refuses to serialize a closure over a named callable unless `allow_named_closures` is set. The message now warns that the option should only be enabled for trusted input, and points at the extension, which resolves more of these without the opt-in — a first-class callable declared in a **constant expression**, including **cross-class** references (`Validators::check(...)`) and **global functions** (`strlen(...)`), gets its declaring class recovered from reflection and is serialized as a declaration-site reference. Userland has no equivalent reflection hook, and this path only runs when the extension is absent, so the suggestion always applies.

```
deepclone_to_array(): serializing a closure over the named callable "strlen" requires enabling
the "allow_named_closures" option; do it only if you trust the input; alternatively, install the
"deepclone" extension, which can reference callables declared in constant expressions
```

**Decoding the extension's global-function references.** The extension can encode a reference to a global *internal* function declared in an attribute; such a function has no start line, so the reference is stored with line `0`. The polyfill cannot produce these (no reflection hook), but must be able to **decode** them. `ReflectionFunction::getStartLine()` returns `false` for an internal function, so a `line 0` reference was wrongly treated as stale; it is now normalized. With this, an extension-produced reference to a global internal function in an attribute round-trips through the polyfill.

The leading part of the refusal message is unchanged, so the tests (which match a substring) and any callers matching on it are unaffected.

Companion extension implementation: symfony/php-ext-deepclone#27
