### PR TITLE
[Php83][Php85][Grapheme] Throw ValueError on PHP 7 for functions that never returned false

### DIFF
--- a/src/Intl/Grapheme/Grapheme.php
+++ b/src/Intl/Grapheme/Grapheme.php
@@ -197,10 +197,6 @@ final class Grapheme
     public static function grapheme_str_split($s, $len = 1)
     {
         if (0 > $len || 1073741823 < $len) {
-            if (80000 > \PHP_VERSION_ID) {
-                return false;
-            }
-
             throw new \ValueError('grapheme_str_split(): Argument #2 ($length) must be greater than 0 and less than or equal to 1073741823.');
         }
 
@@ -232,10 +228,6 @@ final class Grapheme
         }
 
         if (0 > $insertion_cost || 0 > $replacement_cost || 0 > $deletion_cost) {
-            if (80000 > \PHP_VERSION_ID) {
-                return false;
-            }
-
             throw new \ValueError('grapheme_levenshtein(): Argument #3 ($insertion_cost), #4 ($replacement_cost), and #5 ($deletion_cost) must be greater than or equal to 0');
         }
 

--- a/src/Intl/Grapheme/bootstrap.php
+++ b/src/Intl/Grapheme/bootstrap.php
@@ -15,6 +15,12 @@ if (\PHP_VERSION_ID >= 80000) {
     return require __DIR__.'/bootstrap80.php';
 }
 
+if (!class_exists('ValueError', false)) {
+    class ValueError extends Error
+    {
+    }
+}
+
 if (!defined('GRAPHEME_EXTR_COUNT')) {
     define('GRAPHEME_EXTR_COUNT', 0);
 }

--- a/src/Php83/bootstrap72.php
+++ b/src/Php83/bootstrap72.php
@@ -11,6 +11,12 @@
 
 use Symfony\Polyfill\Php83 as p;
 
+if (!class_exists('ValueError', false)) {
+    class ValueError extends Error
+    {
+    }
+}
+
 if (extension_loaded('mbstring')) {
     if (!function_exists('mb_str_pad')) {
         /** @return string|false */

--- a/src/Php85/bootstrap.php
+++ b/src/Php85/bootstrap.php
@@ -41,6 +41,12 @@ if (\PHP_VERSION_ID >= 80000) {
     return;
 }
 
+if (!class_exists('ValueError', false)) {
+    class ValueError extends Error
+    {
+    }
+}
+
 if (extension_loaded('intl') && !function_exists('grapheme_levenshtein')) {
     function grapheme_levenshtein(string $string1, string $string2, int $insertion_cost = 1, int $replacement_cost = 1, int $deletion_cost = 1, string $locale = '') { return p\Php85::grapheme_levenshtein($string1, $string2, $insertion_cost, $replacement_cost, $deletion_cost); }
 }

--- a/tests/Intl/Grapheme/GraphemeTest.php
+++ b/tests/Intl/Grapheme/GraphemeTest.php
@@ -218,6 +218,16 @@ class GraphemeTest extends TestCase
         $this->assertSame($expectedValues, grapheme_str_split($string, $length));
     }
 
+    /**
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_str_split
+     */
+    public function testGraphemeStrSplitNegativeLength()
+    {
+        $this->expectException(\ValueError::class);
+
+        grapheme_str_split('abc', -1);
+    }
+
     public static function graphemeStrSplitDataProvider(): array
     {
         $cases = [
@@ -288,12 +298,11 @@ class GraphemeTest extends TestCase
 
     /**
      * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_levenshtein
-     *
-     * @requires PHP 8
      */
     public function testGraphemeLevenshteinNegativeCost()
     {
         $this->expectException(\ValueError::class);
+
         grapheme_levenshtein('a', 'b', -1);
     }
 

--- a/tests/Php85/Php85Test.php
+++ b/tests/Php85/Php85Test.php
@@ -154,6 +154,26 @@ class Php85Test extends TestCase
         $this->assertFalse(locale_is_right_to_left('zh'));
         $this->assertFalse(locale_is_right_to_left(''));
     }
+
+    /**
+     * @requires extension intl
+     */
+    public function testGraphemeLevenshtein()
+    {
+        $this->assertSame(3, grapheme_levenshtein('kitten', 'sitting'));
+        $this->assertSame(1, grapheme_levenshtein('한국어', '한국'));
+        $this->assertFalse(grapheme_levenshtein("\xFF", 'a'));
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testGraphemeLevenshteinNegativeCost()
+    {
+        $this->expectException(\ValueError::class);
+
+        grapheme_levenshtein('a', 'b', -1);
+    }
 }
 
 class TestHandler


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #636
| License       | MIT

`grapheme_levenshtein()` (8.5), `grapheme_str_split()` (8.4), `json_validate()`, `str_increment()` and `str_decrement()` (8.3) throw a `ValueError` for invalid arguments. Unlike the mbstring family, these functions were never designed to return `false`, so the polyfills should reproduce the exception on every supported PHP version.

On PHP < 8 they either returned `false` (grapheme) or referenced the missing `ValueError` class, which fatals unless `polyfill-php80` happens to be installed (the case reported in #636). Each affected bootstrap now declares a guarded `ValueError` stub on PHP < 8, the same way the Apcu polyfill declares `APCuIterator`, and the functions throw on all versions.

The mbstring functions (including `mb_str_pad`) keep their `trigger_error()` + `false` behavior on PHP < 8, which matches how the extension behaves there.
