### PR TITLE
[Intl][Icu] Avoid pulling deprecated symfony/intl 5.4 on PHP < 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,10 @@ jobs:
                     php --ri deepclone || echo "extension=deepclone" | sudo tee "$(php -r 'echo PHP_CONFIG_FILE_SCAN_DIR;')/99-deepclone.ini"
                     php -m | grep -q deepclone && echo "deepclone loaded" || echo "deepclone NOT loaded"
 
+            -   name: Drop symfony/intl on PHP < 8.1
+                if: matrix.php < '8.1'
+                run: composer remove --dev --no-update symfony/intl
+
             -   name: Install dependencies
                 run: |
                     composer --prefer-source --no-progress --ansi install

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2"
     },
     "require-dev": {
-        "symfony/intl": "^5.4|^6.4",
+        "symfony/intl": "^6.4",
         "symfony/phpunit-bridge": "^6.4",
         "symfony/var-dumper": "^5.4|^6.4"
     },

--- a/tests/Intl/Icu/CurrenciesTest.php
+++ b/tests/Intl/Icu/CurrenciesTest.php
@@ -24,6 +24,10 @@ class CurrenciesTest extends TestCase
     {
         $dataDir = \dirname(__DIR__, 3).'/vendor/symfony/intl/Resources/data/currencies/';
 
+        if (!is_dir($dataDir)) {
+            $this->markTestSkipped('symfony/intl is not installed.');
+        }
+
         if (is_file($dataDir.'en.php')) {
             $en = require $dataDir.'en.php';
             $meta = require $dataDir.'meta.php';


### PR DESCRIPTION
Fixes #625.

`symfony/intl` is a dev dependency used only by `CurrenciesTest`, which reads the package's currency data files and is gated `@requires PHP 8.1`.

On PHP < 8.1 Composer cannot use `symfony/intl` 6.4 (it requires PHP 8.1) and falls back to the deprecated **5.4**. That version ships `Resources/functions.php` as a `files` autoload, which loads *before* the polyfill's `src/Intl/Icu/bootstrap.php`:

```
'.../symfony/intl/Resources/functions.php'   # loaded first
'.../src/Intl/Icu/bootstrap.php'             # guard sees function_exists, skips
```

As a result `intl_is_failure` / `intl_get_error_code` / `intl_get_error_message` / `intl_error_name` resolve to symfony/intl's implementation, which delegates to a different error-state holder (`IntlGlobals`) than the polyfill's `Icu` class. This happens precisely on the PHP versions where the only test wanting `symfony/intl` is skipped anyway.

This restricts the dev dependency to `^6.4` (only installable on PHP 8.1+, and shipping no conflicting autoload) and drops it in CI on PHP < 8.1 so `composer install` still resolves there. `CurrenciesTest` now skips cleanly when the package is absent.