### PR TITLE
[Php74] Align mb_str_split() polyfill with Mbstring and native

### DIFF
--- a/src/Php74/Php74.php
+++ b/src/Php74/Php74.php
@@ -50,9 +50,13 @@ final class Php74
         }
 
         if (1 > $split_length = (int) $split_length) {
-            trigger_error('The length of each segment must be greater than zero', \E_USER_WARNING);
+            if (80000 > \PHP_VERSION_ID) {
+                trigger_error('The length of each segment must be greater than zero', \E_USER_WARNING);
 
-            return false;
+                return false;
+            }
+
+            throw new \ValueError('Argument #2 ($length) must be greater than 0');
         }
 
         if (null === $encoding) {
@@ -60,7 +64,14 @@ final class Php74
         }
 
         if ('UTF-8' === $encoding || \in_array(strtoupper($encoding), ['UTF-8', 'UTF8'], true)) {
-            return preg_split("/(.{{$split_length}})/us", $string, -1, \PREG_SPLIT_DELIM_CAPTURE | \PREG_SPLIT_NO_EMPTY);
+            $rx = '/(';
+            while (65535 < $split_length) {
+                $rx .= '.{65535}';
+                $split_length -= 65535;
+            }
+            $rx .= '.{'.$split_length.'})/us';
+
+            return preg_split($rx, $string, -1, \PREG_SPLIT_DELIM_CAPTURE | \PREG_SPLIT_NO_EMPTY);
         }
 
         $result = [];

--- a/tests/Php74/Php74Test.php
+++ b/tests/Php74/Php74Test.php
@@ -12,6 +12,7 @@
 namespace Symfony\Polyfill\Tests\Php74;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Polyfill\Php74\Php74;
 
 /**
  * @author Ion Bazan <ion.bazan@gmail.com>
@@ -115,6 +116,27 @@ class Php74Test extends TestCase
         $this->expectWarning();
         $this->expectWarningMessage('The length of each segment must be greater than zero');
         mb_str_split('победа', 0);
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php74\Php74::mb_str_split
+     *
+     * @requires PHP 8
+     */
+    public function testStrSplitThrowsOnInvalidLength()
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('Argument #2 ($length) must be greater than 0');
+
+        Php74::mb_str_split('победа', 0);
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Php74\Php74::mb_str_split
+     */
+    public function testStrSplitWithLengthAbovePcreLimit()
+    {
+        $this->assertSame([str_repeat('x', 70000)], Php74::mb_str_split(str_repeat('x', 70000), 70000, 'UTF-8'));
     }
 }
 


### PR DESCRIPTION
Refs #624.

`mb_str_split()` is polyfilled by both `Php74` and `Mbstring`, and either implementation can end up registered depending on the PHP version and whether ext-mbstring is loaded. The two had drifted:

- `Php74::mb_str_split()` returned `false` for a length lower than 1 even on PHP 8+, where the function raises a `ValueError`.
- It built a single `.{N}` quantifier, which fails to compile once the length exceeds the PCRE limit of 65535 (`preg_split(): Compilation failed: number too big in {} quantifier`).

`Mbstring::mb_str_split()` already handles both. This aligns the `Php74` copy with it and with native:

```
                               native                       Php74 (before)   Php74 (after)
mb_str_split('победа', 0)      ValueError                   false            ValueError
mb_str_split(str_repeat('x',70000), 70000)   [70000 chars]  false (+warning) [70000 chars]
```

The other overlapping functions (`mb_str_pad` in `Php83`, `mb_ucfirst`/`mb_lcfirst`/`mb_trim`/`mb_ltrim`/`mb_rtrim` in `Php84`) were checked against `Mbstring` and native and already behave identically, so they are left untouched.

Tests exercise `Php74::mb_str_split()` directly, since the `Php74` polyfill is only the active provider of the global function on PHP < 7.4, where the PHP 8 path is unreachable through the global.