### PR TITLE
[Grapheme] Reject out-of-range offsets in the grapheme_str[ri]?pos() family

### DIFF
--- a/src/Intl/Grapheme/Grapheme.php
+++ b/src/Intl/Grapheme/Grapheme.php
@@ -45,6 +45,9 @@ final class Grapheme
         ['μ', 's', 'ι',        'σ', 'β',        'θ',        'φ',        'π',        'κ',        'ρ',        'ε',        "\xE1\xB9\xA1", 'ι'],
     ];
 
+    // indexed by the $mode argument of grapheme_position()
+    private const POSITION_FUNCTIONS = ['grapheme_strpos', 'grapheme_stripos', 'grapheme_strrpos', 'grapheme_strripos'];
+
     public static function grapheme_extract($s, $size, $type = \GRAPHEME_EXTR_COUNT, $start = 0, &$next = 0)
     {
         if (0 > $start) {
@@ -272,14 +275,25 @@ final class Grapheme
             return false;
         }
         $s = (string) $s;
-        if (!preg_match('/./us', $s)) {
+        // let the empty string through: it accepts no offset but 0, which is checked below
+        if ('' !== $s && !preg_match('/./us', $s)) {
+            return false;
+        }
+        if ($offset && ($offset > ($len = self::grapheme_strlen($s)) || $offset < -$len)) {
+            if (80000 > \PHP_VERSION_ID) {
+                return false;
+            }
+
+            throw new \ValueError(self::POSITION_FUNCTIONS[$mode].'(): Argument #3 ($offset) must be contained in argument #1 ($haystack)');
+        }
+        if ('' === $s) {
             return false;
         }
         if ($offset > 0) {
             $s = self::grapheme_substr($s, $offset);
         } elseif ($offset < 0) {
             if (2 > $mode) {
-                $offset += self::grapheme_strlen($s);
+                $offset += $len;
                 $s = self::grapheme_substr($s, $offset);
                 if (0 > $offset) {
                     $offset = 0;

--- a/tests/Intl/Grapheme/GraphemeTest.php
+++ b/tests/Intl/Grapheme/GraphemeTest.php
@@ -201,6 +201,53 @@ class GraphemeTest extends TestCase
     }
 
     /**
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_strpos
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_stripos
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_strrpos
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_strripos
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_position
+     */
+    public function testGraphemeStrposWithOutOfRangeOffset()
+    {
+        // the haystack has 3 graphemes, so offsets -3 to 3 are in range
+        $this->assertFalse(grapheme_strpos('abc', 'b', 3));
+        $this->assertSame(1, grapheme_strpos('abc', 'b', -3));
+        $this->assertFalse(grapheme_strrpos('abc', 'b', 3));
+        $this->assertFalse(grapheme_strrpos('abc', 'b', -3));
+
+        // the empty haystack has no grapheme, so only offset 0 is in range
+        $this->assertFalse(grapheme_strpos('', 'b', 0));
+        $this->assertFalse(grapheme_strrpos('', 'b', 0));
+
+        // the calls must be literal, a variable function would bypass the polyfilled functions
+        $calls = [
+            'grapheme_strpos' => static function ($s, $offset) { return grapheme_strpos($s, 'b', $offset); },
+            'grapheme_stripos' => static function ($s, $offset) { return grapheme_stripos($s, 'b', $offset); },
+            'grapheme_strrpos' => static function ($s, $offset) { return grapheme_strrpos($s, 'b', $offset); },
+            'grapheme_strripos' => static function ($s, $offset) { return grapheme_strripos($s, 'b', $offset); },
+        ];
+
+        foreach ($calls as $function => $call) {
+            foreach ([['abc', 4], ['abc', -4], ['', 1], ['', -1]] as [$s, $offset]) {
+                $case = $function.'() with haystack "'.$s.'" and offset '.$offset;
+
+                if (80000 > \PHP_VERSION_ID) {
+                    $this->assertFalse(@$call($s, $offset), $case.' should return false');
+
+                    continue;
+                }
+
+                try {
+                    $call($s, $offset);
+                    $this->fail($case.' should have thrown a ValueError');
+                } catch (\ValueError $e) {
+                    $this->assertSame($function.'(): Argument #3 ($offset) must be contained in argument #1 ($haystack)', $e->getMessage());
+                }
+            }
+        }
+    }
+
+    /**
      * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_strstr
      * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_stristr
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

ext-intl requires the offset of `grapheme_strpos()`, `grapheme_stripos()`, `grapheme_strrpos()` and `grapheme_strripos()` to be contained in the haystack, and throws a `ValueError` on PHP >= 8 otherwise:

```
grapheme_strpos('abc', 'b', 4);   // ValueError: Argument #3 ($offset) must be contained in argument #1 ($haystack)
grapheme_strpos('abc', 'b', -4);  // ValueError, same message
```

The polyfill clamped the offset while cutting the haystack instead, so out-of-range values silently returned either `false` or, for negative offsets far enough from the end, a match found in the whole haystack:

```
Grapheme::grapheme_strpos('abc', 'b', 4);    // false
Grapheme::grapheme_strpos('abc', 'b', -10);  // 1
```

The valid range is `-$len` to `$len` inclusive, `$len` being the length of the haystack in grapheme units. Out of it, this PR throws the same `ValueError` as ext-intl on PHP >= 8, and returns `false` on PHP 7 like ext-intl did there. In-range behaviour is untouched.

This is what made symfony/string return a position where ext-intl makes `UnicodeString::indexOf()` return `null`: symfony/symfony#64992 relies on catching that `ValueError`, so its new test cases fail on the `x86 / minimal-exts / lowest-php` job, where intl is missing.

The added test covers the four functions on both implementations. Note the calls have to be literal, since a variable function call bypasses the namespaced functions `TestListenerTrait` installs and would only ever exercise ext-intl.