### PR TITLE
[DeepClone] Hydrate mangled keys through the grouped path even when they resolve to the object's own scope

### DIFF
--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -443,14 +443,17 @@ final class DeepClone
         // parent-privates are reachable via "\0Parent\0foo". Unknown
         // keys fall through to the object's own class scope.
         //
-        // Scan first: if every key maps to $class, hand $vars straight
-        // to the $class hydrator and skip the intermediate grouping.
+        // Scan first: if every key is a bare name that maps to $class, hand
+        // $vars straight to the $class hydrator and skip the intermediate
+        // grouping. Mangled keys always take the grouped path, which re-keys
+        // them to their real name — the simple hydrators write keys verbatim,
+        // so a mangled name would fail even when its scope resolves to $class.
         $r ??= self::$reflectors[$class] ?? new \ReflectionClass($class);
         $propertyScopes = self::$propertyScopes[$class] ??= self::getPropertyScopes($r);
 
         $needsGroup = false;
         foreach ($vars as $name => $_) {
-            if (\array_key_exists($name, $propertyScopes) ? $class !== $propertyScopes[$name][0] : "\0" === ($name[0] ?? '')) {
+            if ("\0" === ($name[0] ?? '') || $class !== ($propertyScopes[$name][0] ?? $class)) {
                 $needsGroup = true;
                 break;
             }

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -1304,6 +1304,20 @@ class DeepCloneTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testHydrateFlatOwnScopeMangledKeys()
+    {
+        $src = new HydrateFoo();
+        (function () {
+            $this->prot = 345;
+            $this->priv = 123;
+        })->call($src);
+
+        $vars = (array) $src;
+        $obj = deepclone_hydrate(HydrateFoo::class, $vars);
+
+        $this->assertSame($vars, (array) $obj);
+    }
+
     public function testHydrateFlatExceptionTrace()
     {
         $e = deepclone_hydrate('Exception', ['trace' => [234]]);


### PR DESCRIPTION
 `deepclone_hydrate()` fails on mangled keys when they all resolve to the object's own class scope: 

  ```php
class Foo
{
    protected $prot;
    private $priv;
}

// 💥 Error: Cannot access property starting with "\0"
deepclone_hydrate(Foo::class, (array) new Foo());
```
(errors in the CI seems unrelated)
