### PR TITLE
Align tests with PHP 8.6 changes to ext/tidy and ext/intl

### DIFF
--- a/src/DeepClone/DeepClone.php
+++ b/src/DeepClone/DeepClone.php
@@ -25,6 +25,7 @@ final class DeepClone
         'XMLReader' => true,
         'SNMP' => true,
         'tidy' => true,
+        'tidyNode' => true,
     ];
 
     private static array $reflectors = [];

--- a/src/Intl/Normalizer/Normalizer.php
+++ b/src/Intl/Normalizer/Normalizer.php
@@ -129,7 +129,8 @@ class Normalizer
                     return false;
                 }
 
-                throw new \ValueError('normalizer_normalize(): Argument #2 ($form) must be a a valid normalization form');
+                // the doubled article was fixed in PHP 8.6
+                throw new \ValueError('normalizer_normalize(): Argument #2 ($form) must be a '.(80600 > \PHP_VERSION_ID ? 'a ' : '').'valid normalization form');
         }
 
         if ('' === $s) {

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -1193,18 +1193,31 @@ class DeepCloneTest extends TestCase
     /**
      * @requires extension tidy
      */
-    public function testTidyNodeRoundTrip()
+    public function testTidyNodeIsNotInstantiable()
     {
         $tidy = new \tidy();
         $tidy->parseString('<p><b>hello</b></p>', [], 'utf8');
         $b = $tidy->body()->child[0]->child[0]; // <b> node
 
-        $clone = deepclone_from_array(deepclone_to_array($b));
+        if (\PHP_VERSION_ID < 80600 && \extension_loaded('deepclone') && !TestListenerTrait::$enabledPolyfills) {
+            // tidyNode is final and bare-instantiable there, so the extension
+            // still restores it property by property.
+            $clone = deepclone_from_array(deepclone_to_array($b));
 
-        $this->assertInstanceOf(\tidyNode::class, $clone);
-        $this->assertNotSame($b, $clone);
-        $this->assertSame($b->name, $clone->name);
-        $this->assertSame($b->value, $clone->value);
+            $this->assertInstanceOf(\tidyNode::class, $clone);
+            $this->assertNotSame($b, $clone);
+            $this->assertSame($b->name, $clone->name);
+            $this->assertSame($b->value, $clone->value);
+
+            return;
+        }
+
+        // tidyNode wraps a libTidy handle that cannot survive serialization; PHP 8.6
+        // marks it NOT_SERIALIZABLE, and the polyfill mirrors that on every version.
+        $this->expectException(\DeepClone\NotInstantiableException::class);
+        $this->expectExceptionMessage('Type "tidyNode" is not instantiable.');
+
+        deepclone_to_array($b);
     }
 
     public function testHydrateScopedInstantiate()

--- a/tests/Intl/Normalizer/NormalizerTest.php
+++ b/tests/Intl/Normalizer/NormalizerTest.php
@@ -97,7 +97,7 @@ class NormalizerTest extends TestCase
     {
         if (80000 <= \PHP_VERSION_ID) {
             $this->expectException(\ValueError::class);
-            $this->expectExceptionMessage('normalizer_normalize(): Argument #2 ($form) must be a a valid normalization form');
+            $this->expectExceptionMessage('normalizer_normalize(): Argument #2 ($form) must be a '.(80600 > \PHP_VERSION_ID ? 'a ' : '').'valid normalization form');
         }
 
         $this->assertFalse(normalizer_normalize('foo', -1));

--- a/tests/Php73/Php73Test.php
+++ b/tests/Php73/Php73Test.php
@@ -83,8 +83,11 @@ class Php73Test extends TestCase
         usleep(1000);
         $hrtime2 = hrtime();
 
-        $this->assertSame(0, $hrtime2[0] - $hrtime[0]);
-        $this->assertGreaterThanOrEqual(1000000, $hrtime2[1] - $hrtime[1]);
+        // don't compare the components separately: the pair can straddle a whole second
+        $elapsed = 1000000000 * ($hrtime2[0] - $hrtime[0]) + $hrtime2[1] - $hrtime[1];
+
+        $this->assertGreaterThanOrEqual(1000000, $elapsed);
+        $this->assertLessThan(1000000000, $hrtime2[1]);
     }
 
     public function testHardwareTimeAsArraySeconds()


### PR DESCRIPTION
Fixes the two failures of the `PHPUnit Tests (8.6, apc, apcu, ... intl-73.2 ...)` job, which is red on `1.x` itself, plus an unrelated flaky test that failed in the same run.

### `DeepCloneTest::testTidyNodeRoundTrip`

php-src [`4782ec55aae`](https://github.com/php/php-src/commit/4782ec55aae) (*Add NOT_SERIALIZABLE to XMLWriter, XMLReader, SNMP, tidy, and tidyNode*, php/php-src#21694, master only) marks `tidyNode` `@not-serializable` — it wraps a libTidy handle and "segfaults on use" once unserialized.

`ext/deepclone` honours `ZEND_ACC_NOT_SERIALIZABLE`, so on 8.6 both engines now refuse the node: the extension via that flag, the polyfill because `unserialize('O:8:"tidyNode":0:{}')` throws. Same exception, same message — only the test was stale.

Per the design principle that the `deepclone` polyfill mirrors the newest native state rather than each intermediate version, `tidyNode` joins `NOT_ROUND_TRIPPABLE`. The extension is more lenient below 8.6 (`tidyNode` is `final` and bare-instantiable there, so it passes the probe), so the test keeps the round-trip expectation for that combination.

### `NormalizerTest::testNormalizeWithInvalidForm`

php-src [`94e8c54ef27`](https://github.com/php/php-src/commit/94e8c54ef27) (*ext/intl: Fix various error messages*, php/php-src#22828, master only) dropped the doubled article introduced back when intl warnings were promoted to exceptions. Both the polyfill and its test hardcoded `must be a a valid`, so the message is now conditional on `PHP_VERSION_ID >= 80600`.

### `Php73Test::testHardwareTimeAsArrayNanos`

Unrelated, and the reason the `(7.3, apc, apcu, ...)` job failed in the same run: the test asserted `$hrtime2[0] - $hrtime[0] === 0`, which fails whenever the two `hrtime()` calls straddle a whole second. It now measures total elapsed nanoseconds and checks the sub-second component stays in range.