### PR TITLE
[Idn] Bound the Punycode decoder input length

### DIFF
--- a/src/Intl/Idn/Idn.php
+++ b/src/Intl/Idn/Idn.php
@@ -62,6 +62,13 @@ final class Idn
     public const MAX_INT = 2147483647;
 
     /**
+     * Punycode decoding does work quadratic in the payload length. Valid ACE
+     * labels are limited to 63 bytes, so payloads beyond this (generous) bound
+     * are rejected without being decoded to keep the work bounded.
+     */
+    private const MAX_DECODE_PAYLOAD_SIZE = 1024;
+
+    /**
      * Contains the numeric value of a basic code point (for use in representing integers) in the
      * range 0 to BASE-1, or -1 if b is does not represent a value.
      *
@@ -353,6 +360,16 @@ final class Idn
                 // Step 4.1. If the label contains any non-ASCII code point (i.e., a code point greater than U+007F),
                 // record that there was an error, and continue with the next label.
                 if (preg_match('/[^\x00-\x7F]/', $label)) {
+                    $info->errors |= self::ERROR_PUNYCODE;
+
+                    continue;
+                }
+
+                // The decoder does work quadratic in the payload length. Valid
+                // labels are at most 63 bytes long, so a payload beyond this
+                // bound is always invalid input: reject it without decoding,
+                // like ext-intl does, to avoid spending unbounded time on it.
+                if (\strlen($label) - 4 > self::MAX_DECODE_PAYLOAD_SIZE) {
                     $info->errors |= self::ERROR_PUNYCODE;
 
                     continue;

--- a/tests/Intl/Idn/IdnTest.php
+++ b/tests/Intl/Idn/IdnTest.php
@@ -352,6 +352,45 @@ class IdnTest extends TestCase
     }
 
     /**
+     * Punycode decoding does work quadratic in the payload length. Valid ACE
+     * labels are limited to 63 bytes, so a multi-kilobyte payload is always
+     * invalid input and must be rejected without being decoded (like ext-intl,
+     * which never decodes absurdly long labels).
+     */
+    public function testHugeAcePayloadIsRejectedWithoutDecoding()
+    {
+        $input = 'example.xn--'.str_repeat('w', 5000).'.com';
+
+        $info = [];
+        $r = idn_to_utf8($input, \IDNA_DEFAULT, \INTL_IDNA_VARIANT_UTS46, $info);
+        $this->assertFalse($r);
+        // ext-intl does not populate $info when it bails out early.
+        if ([] !== $info) {
+            $this->assertSame(\IDNA_ERROR_PUNYCODE, \IDNA_ERROR_PUNYCODE & $info['errors']);
+        }
+
+        $info = [];
+        $r = idn_to_ascii($input, \IDNA_DEFAULT, \INTL_IDNA_VARIANT_UTS46, $info);
+        $this->assertFalse($r);
+        if ([] !== $info) {
+            $this->assertSame(\IDNA_ERROR_PUNYCODE, \IDNA_ERROR_PUNYCODE & $info['errors']);
+        }
+    }
+
+    /**
+     * Labels above the DNS limit but below the decoder bound still decode:
+     * ToUnicode reports their decoded form even though they are invalid.
+     */
+    public function testOverLongButDecodableAceLabelStillDecodes()
+    {
+        $input = 'example.xn--'.str_repeat('w', 101).'.de';
+
+        idn_to_utf8($input, \IDNA_DEFAULT, \INTL_IDNA_VARIANT_UTS46, $info);
+        $this->assertStringContainsString('example.', $info['result']);
+        $this->assertStringNotContainsString('xn--', $info['result']);
+    }
+
+    /**
      * UTS #46 revision 33: a label starting with "xn--" whose Punycode payload decodes
      * to an empty string or to a string containing only ASCII code points must be rejected.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

`punycodeDecode()` inserts every decoded character into an array with `array_splice()`, making the decode **quadratic** in the payload length. The label size is only checked *after* decoding, so a crafted multi-kilobyte `xn--` label reaching `idn_to_utf8()` / `idn_to_ascii()` spends minutes of CPU in a single call before being rejected:

| payload | time (before) |
|---|---|
| 5 KB | 36 ms |
| 80 KB | 12.4 s |
| 200 KB | **177 s** |

This is reachable from any application that validates attacker-controlled domains while ext-intl is not installed — the deployment this polyfill targets. `egulias/emailvalidator`, for one, depends on this package for exactly that.

Valid ACE labels are limited to 63 bytes, so the patch rejects payloads beyond a generous 1024-byte bound up front with `ERROR_PUNYCODE`, capping worst-case work at roughly half a million elementary operations (~ms). This mirrors observable native behavior: native ICU never decodes absurdly long labels — it rejects a 5 KB domain instantly.

Labels above the DNS limit but below the bound still decode exactly as before, so ToUnicode keeps reporting their decoded form even when invalid, and all UTS #46 spec fixtures pass unchanged (37602 tests green, run both with and without ext-intl).

After the patch: same 200 KB input completes in 125 ms (the residual is the linear mapping pass), and legitimate domains (`xn--bcher-kva.com`, `bücher.example`) behave identically.
