### PR TITLE
[Intl-Idn] Don't Punycode-encode domains the intl extension would refuse

### DIFF
--- a/src/Intl/Idn/Idn.php
+++ b/src/Intl/Idn/Idn.php
@@ -69,6 +69,14 @@ final class Idn
     private const MAX_DECODE_PAYLOAD_SIZE = 1024;
 
     /**
+     * Encoding is quadratic the same way: it is O(n*r) in the length of a label
+     * and in its number of distinct code points. ext-intl never runs it on a
+     * domain this large, because it fails before converting when the result
+     * would not fit its own output buffer.
+     */
+    private const MAX_CODE_POINTS = 255;
+
+    /**
      * Contains the numeric value of a basic code point (for use in representing integers) in the
      * range 0 to BASE-1, or -1 if b is does not represent a value.
      *
@@ -158,6 +166,14 @@ final class Idn
 
         if (self::INTL_IDNA_VARIANT_2003 === $variant) {
             @trigger_error('idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated', \E_USER_DEPRECATED);
+        }
+
+        // The ASCII form is at least as long as the number of code points in the
+        // domain, so beyond this many code points no result can fit in the output
+        // buffer ext-intl uses: it returns false there without reporting details,
+        // and so do we, rather than Punycode-encoding a label that cannot be used.
+        if (self::MAX_CODE_POINTS < \strlen((string) $domainName) && self::MAX_CODE_POINTS < self::countCodePoints((string) $domainName)) {
+            return false;
         }
 
         $options = [
@@ -781,6 +797,24 @@ final class Idn
         }
 
         return $output;
+    }
+
+    /**
+     * Counts the code points of a UTF-8 string, malformed bytes included.
+     *
+     * This is the expression Mbstring::mb_strlen() falls back to in
+     * symfony/polyfill-mbstring, inlined because this package does not depend on it.
+     * Counting only the bytes that can start a sequence would be shorter, but then a
+     * run of continuation bytes would pad a label without being counted, which is the
+     * one thing this bound has to prevent.
+     *
+     * @param string $input
+     *
+     * @return int
+     */
+    private static function countCodePoints($input)
+    {
+        return preg_match_all('/[\x00-\x7F]|[\xC0-\xDF][\x80-\xBF]?|[\xE0-\xEF][\x80-\xBF]{0,2}|[\xF0-\xF7][\x80-\xBF]{0,3}|[\xF8-\xFB][\x80-\xBF]{0,4}|[\xFC-\xFD][\x80-\xBF]{0,5}|[\x80-\xBF\xFE\xFF]/s', $input);
     }
 
     /**

--- a/tests/Intl/Idn/IdnTest.php
+++ b/tests/Intl/Idn/IdnTest.php
@@ -602,4 +602,38 @@ class IdnTest extends TestCase
 
         return $errors;
     }
+
+    /**
+     * A domain with more code points than the ASCII form could ever fit is refused
+     * before any Punycode encoding happens, the way the intl extension refuses it.
+     */
+    public function testIdnToAsciiRefusesDomainsLongerThanTheOutputBuffer()
+    {
+        $domain = str_repeat("\xE4\xB8\x80", 256);
+        $info = [];
+
+        $this->assertFalse(Idn::idn_to_ascii($domain, Idn::IDNA_DEFAULT, Idn::INTL_IDNA_VARIANT_UTS46, $info));
+        $this->assertSame([], $info);
+    }
+
+    /**
+     * Bytes that cannot start a UTF-8 sequence still count towards the bound, so a
+     * label cannot be padded with them to stay under it while growing the work.
+     */
+    public function testIdnToAsciiCountsMalformedBytesTowardsTheBound()
+    {
+        $domain = str_repeat("\xE4\xB8\x80", 200).str_repeat("\x80", 60000);
+        $info = [];
+
+        $this->assertFalse(Idn::idn_to_ascii($domain, Idn::IDNA_DEFAULT, Idn::INTL_IDNA_VARIANT_UTS46, $info));
+        $this->assertSame([], $info);
+    }
+
+    public function testIdnToAsciiStillConvertsDomainsThatFitTheOutputBuffer()
+    {
+        $info = [];
+
+        $this->assertSame('xn--4gq.example', Idn::idn_to_ascii("\xE4\xB8\x80.example", Idn::IDNA_DEFAULT, Idn::INTL_IDNA_VARIANT_UTS46, $info));
+        $this->assertSame(0, $info['errors']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #646, which bounded the Punycode *decoder*. The *encoder* has the mirror problem and was not covered there. Rebased on top of it, so the two changes are disjoint.

`Idn::punycodeEncode()` walks the whole code point array twice for every distinct code point it still has to emit, so encoding costs O(n*r) and becomes quadratic when a label is made of distinct code points. Measured on PHP 8.5 without ext-intl, one label of distinct CJK code points:

| label | before |
| --- | --- |
| 1 KB | 27 ms |
| 8 KB | 430 ms |
| 16 KB | 1.6 s |
| 32 KB | 6.1 s |
| 64 KB | 25 s |

The reason this is reachable is the one #646 already identified: the polyfill converts input the extension refuses outright. ext-intl fails before converting when the result would not fit its own output buffer, and answers the 64 KB case above in 0.8 ms.

So `idn_to_ascii()` now returns `false` without filling `$idna_info` when the domain has more than 255 code points. The ASCII form is at least as long as the code point count, so beyond that no result can fit that buffer, and ext-intl already returns `false` there without reporting anything. Encoding is then bounded to 255 code points, and a 20k-code-point label goes from 25 s to about 1.4 ms.

Reachability inside Symfony: `HttpClientTrait::parseUrl()` calls `idn_to_ascii()` on the host with no length bound, so an application passing a user-supplied URL to HttpClient pays this when the extension is missing.

I checked for behaviour changes by running every input in `IdnaTestV2.txt`, 7691 of them, through both directions before and after and comparing the return value, the error bits and the result. Nothing changes except domains over 255 code points, which returned `false` before as well; the difference is that `$idna_info` is no longer populated for them, which is what ext-intl does.

Counting is done with the expression `Mbstring::mb_strlen()` falls back to, inlined since this package does not depend on mbstring. Counting only the bytes that can start a sequence would be shorter, but it would leave the bound trivially evadable: continuation bytes would not be counted, so a label could be padded with them while staying under the limit. Measured with the short version in place, 200 distinct code points followed by continuation bytes still cost 575 ms at 60 KB, 1.0 s at 120 KB and 2.1 s at 240 KB, against 3 to 6 ms once malformed bytes count too. There is a test for that case.

The added tests fail without the change and pass with it.
