### PR TITLE
[Grapheme] Match the intl extension on ill-formed UTF-8

### DIFF
--- a/src/Intl/Grapheme/Grapheme.php
+++ b/src/Intl/Grapheme/Grapheme.php
@@ -40,6 +40,10 @@ final class Grapheme
     // This regular expression is a work around for http://bugs.exim.org/1279
     public const GRAPHEME_CLUSTER_RX = '(?:\r\n|[\x{1F1E6}-\x{1F1FF}][\x{1F1E6}-\x{1F1FF}]?|(?:[ -~\x{200C}\x{200D}]|[ᆨ-ᇹ]+|[ᄀ-ᅟ]*(?:[가개갸걔거게겨계고과괘괴교구궈궤귀규그긔기까깨꺄꺠꺼께껴꼐꼬꽈꽤꾀꾜꾸꿔꿰뀌뀨끄끠끼나내냐냬너네녀녜노놔놰뇌뇨누눠눼뉘뉴느늬니다대댜댸더데뎌뎨도돠돼되됴두둬뒈뒤듀드듸디따때땨떄떠떼뗘뗴또똬뙈뙤뚀뚜뚸뛔뛰뜌뜨띄띠라래랴럐러레려례로롸뢔뢰료루뤄뤠뤼류르릐리마매먀먜머메며몌모뫄뫠뫼묘무뭐뭬뮈뮤므믜미바배뱌뱨버베벼볘보봐봬뵈뵤부붜붸뷔뷰브븨비빠빼뺘뺴뻐뻬뼈뼤뽀뽜뽸뾔뾰뿌뿨쀄쀠쀼쁘쁴삐사새샤섀서세셔셰소솨쇄쇠쇼수숴쉐쉬슈스싀시싸쌔쌰썌써쎄쎠쎼쏘쏴쐐쐬쑈쑤쒀쒜쒸쓔쓰씌씨아애야얘어에여예오와왜외요우워웨위유으의이자재쟈쟤저제져졔조좌좨죄죠주줘줴쥐쥬즈즤지짜째쨔쨰쩌쩨쪄쪠쪼쫘쫴쬐쬬쭈쭤쮀쮜쮸쯔쯰찌차채챠챼처체쳐쳬초촤쵀최쵸추춰췌취츄츠츼치카캐캬컈커케켜켸코콰쾌쾨쿄쿠쿼퀘퀴큐크킈키타태탸턔터테텨톄토톼퇘퇴툐투퉈퉤튀튜트틔티파패퍄퍠퍼페펴폐포퐈퐤푀표푸풔풰퓌퓨프픠피하해햐햬허헤혀혜호화홰회효후훠훼휘휴흐희히]?[ᅠ-ᆢ]+|[가-힣])[ᆨ-ᇹ]*|[ᄀ-ᅟ]+|[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}])[\p{Mn}\p{Mc}\p{Me}\x{09BE}\x{09D7}\x{0B3E}\x{0B57}\x{0BBE}\x{0BD7}\x{0CC2}\x{0CD5}\x{0CD6}\x{0D3E}\x{0D57}\x{0DCF}\x{0DDF}\x{200C}\x{1D165}\x{1D16E}-\x{1D172}\x{1F3FB}-\x{1F3FF}\x{FE0E}-\x{FE0F}\x{E0020}-\x{E007F}]*(?:\x{200D}(?:[\x{1F1E6}-\x{1F1FF}]|[ -~\x{200C}\x{200D}]|[ᆨ-ᇹ]+|[ᄀ-ᅟ]*(?:[가-힣]?[ᅠ-ᆢ]+|[가-힣])[ᆨ-ᇹ]*|[ᄀ-ᅟ]+|[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}])[\p{Mn}\p{Mc}\p{Me}\x{09BE}\x{09D7}\x{0B3E}\x{0B57}\x{0BBE}\x{0BD7}\x{0CC2}\x{0CD5}\x{0CD6}\x{0D3E}\x{0D57}\x{0DCF}\x{0DDF}\x{200C}\x{1D165}\x{1D16E}-\x{1D172}\x{1F3FB}-\x{1F3FF}\x{FE0E}-\x{FE0F}\x{E0020}-\x{E007F}]*)*|[\p{Cc}\p{Cf}\p{Zl}\p{Zp}])';
 
+    // Table 3-7 of the Unicode standard for the well-formed byte sequences (group 1),
+    // then the maximal subparts an ill-formed sequence is made of (group 2).
+    private const UTF8_CHAR_OR_SUBPART_RX = '/([\x00-\x7F]|[\xC2-\xDF][\x80-\xBF]|\xE0[\xA0-\xBF][\x80-\xBF]|[\xE1-\xEC][\x80-\xBF]{2}|\xED[\x80-\x9F][\x80-\xBF]|[\xEE-\xEF][\x80-\xBF]{2}|\xF0[\x90-\xBF][\x80-\xBF]{2}|[\xF1-\xF3][\x80-\xBF]{3}|\xF4[\x80-\x8F][\x80-\xBF]{2})|(\xF0[\x90-\xBF][\x80-\xBF]?|[\xF1-\xF3][\x80-\xBF]{1,2}|\xF4[\x80-\x8F][\x80-\xBF]?|\xE0[\xA0-\xBF]|[\xE1-\xEC][\x80-\xBF]|\xED[\x80-\x9F]|[\xEE-\xEF][\x80-\xBF]|[\x80-\xFF])/s';
+
     private const CASE_FOLD = [
         ['µ', 'ſ', "\xCD\x85", 'ς', "\xCF\x90", "\xCF\x91", "\xCF\x95", "\xCF\x96", "\xCF\xB0", "\xCF\xB1", "\xCF\xB5", "\xE1\xBA\x9B", "\xE1\xBE\xBE"],
         ['μ', 's', 'ι',        'σ', 'β',        'θ',        'φ',        'π',        'κ',        'ρ',        'ε',        "\xE1\xB9\xA1", 'ι'],
@@ -130,6 +134,10 @@ final class Grapheme
             $len = 2147483647;
         }
 
+        if (!self::isUtf8($s)) {
+            return false;
+        }
+
         preg_match_all('/'.SYMFONY_GRAPHEME_CLUSTER_RX.'/u', $s, $s);
 
         $slen = \count($s[0]);
@@ -189,11 +197,19 @@ final class Grapheme
 
     public static function grapheme_stristr($s, $needle, $beforeNeedle = false)
     {
+        if (!self::isUtf8($s) || !self::isUtf8($needle)) {
+            return false;
+        }
+
         return mb_stristr($s, $needle, $beforeNeedle, 'UTF-8');
     }
 
     public static function grapheme_strstr($s, $needle, $beforeNeedle = false)
     {
+        if (!self::isUtf8($s) || !self::isUtf8($needle)) {
+            return false;
+        }
+
         return mb_strstr($s, $needle, $beforeNeedle, 'UTF-8');
     }
 
@@ -207,15 +223,21 @@ final class Grapheme
             return [];
         }
 
-        if (!preg_match_all('/('.SYMFONY_GRAPHEME_CLUSTER_RX.')/u', $s, $matches)) {
+        if (preg_match_all('/('.SYMFONY_GRAPHEME_CLUSTER_RX.')/u', $s, $matches)) {
+            $graphemes = $matches[0];
+        } else {
+            $graphemes = self::splitIllFormed($s);
+        }
+
+        if (!$graphemes) {
             return false;
         }
 
         if (1 === $len) {
-            return $matches[0];
+            return $graphemes;
         }
 
-        $chunks = array_chunk($matches[0], $len);
+        $chunks = array_chunk($graphemes, $len);
 
         foreach ($chunks as &$chunk) {
             $chunk = implode('', $chunk);
@@ -346,5 +368,54 @@ final class Grapheme
         }
 
         return implode('', array_reverse($units));
+    }
+
+    private static function isUtf8(?string $s)
+    {
+        $s = $s ?? '';
+
+        return '' === $s || preg_match('/./us', $s);
+    }
+
+    /**
+     * Splits a string that is not valid UTF-8 into grapheme clusters.
+     *
+     * The intl extension keeps the ill-formed bytes and breaks around them the
+     * way it would around the U+FFFD each maximal subpart stands for. Standing
+     * one in for real makes the cluster regexp applicable, then each cluster is
+     * mapped back to the bytes it was made of.
+     */
+    private static function splitIllFormed($s)
+    {
+        preg_match_all(self::UTF8_CHAR_OR_SUBPART_RX, $s, $matches, \PREG_SET_ORDER);
+
+        $segments = [];
+        $segmentAt = [];
+        $sanitized = '';
+
+        foreach ($matches as $m) {
+            $segmentAt[\strlen($sanitized)] = \count($segments);
+
+            if (isset($m[2]) && '' !== $m[2]) {
+                $segments[] = $m[2];
+                $sanitized .= "\xEF\xBF\xBD";
+            } else {
+                $segments[] = $m[1];
+                $sanitized .= $m[1];
+            }
+        }
+
+        $segmentAt[\strlen($sanitized)] = \count($segments);
+
+        preg_match_all('/'.SYMFONY_GRAPHEME_CLUSTER_RX.'/u', $sanitized, $clusters, \PREG_OFFSET_CAPTURE);
+
+        $graphemes = [];
+
+        foreach ($clusters[0] as $cluster) {
+            $start = $segmentAt[$cluster[1]];
+            $graphemes[] = implode('', \array_slice($segments, $start, $segmentAt[$cluster[1] + \strlen($cluster[0])] - $start));
+        }
+
+        return $graphemes;
     }
 }

--- a/src/Php84/Php84.php
+++ b/src/Php84/Php84.php
@@ -210,15 +210,21 @@ final class Php84
             ? '\X'
             : '(?:\r\n|[\x{1F1E6}-\x{1F1FF}][\x{1F1E6}-\x{1F1FF}]?|(?:[ -~\x{200C}\x{200D}]|[ᆨ-ᇹ]+|[ᄀ-ᅟ]*(?:[가개갸걔거게겨계고과괘괴교구궈궤귀규그긔기까깨꺄꺠꺼께껴꼐꼬꽈꽤꾀꾜꾸꿔꿰뀌뀨끄끠끼나내냐냬너네녀녜노놔놰뇌뇨누눠눼뉘뉴느늬니다대댜댸더데뎌뎨도돠돼되됴두둬뒈뒤듀드듸디따때땨떄떠떼뗘뗴또똬뙈뙤뚀뚜뚸뛔뛰뜌뜨띄띠라래랴럐러레려례로롸뢔뢰료루뤄뤠뤼류르릐리마매먀먜머메며몌모뫄뫠뫼묘무뭐뭬뮈뮤므믜미바배뱌뱨버베벼볘보봐봬뵈뵤부붜붸뷔뷰브븨비빠빼뺘뺴뻐뻬뼈뼤뽀뽜뽸뾔뾰뿌뿨쀄쀠쀼쁘쁴삐사새샤섀서세셔셰소솨쇄쇠쇼수숴쉐쉬슈스싀시싸쌔쌰썌써쎄쎠쎼쏘쏴쐐쐬쑈쑤쒀쒜쒸쓔쓰씌씨아애야얘어에여예오와왜외요우워웨위유으의이자재쟈쟤저제져졔조좌좨죄죠주줘줴쥐쥬즈즤지짜째쨔쨰쩌쩨쪄쪠쪼쫘쫴쬐쬬쭈쭤쮀쮜쮸쯔쯰찌차채챠챼처체쳐쳬초촤쵀최쵸추춰췌취츄츠츼치카캐캬컈커케켜켸코콰쾌쾨쿄쿠쿼퀘퀴큐크킈키타태탸턔터테텨톄토톼퇘퇴툐투퉈퉤튀튜트틔티파패퍄퍠퍼페펴폐포퐈퐤푀표푸풔풰퓌퓨프픠피하해햐햬허헤혀혜호화홰회효후훠훼휘휴흐희히]?[ᅠ-ᆢ]+|[가-힣])[ᆨ-ᇹ]*|[ᄀ-ᅟ]+|[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}])[\p{Mn}\p{Mc}\p{Me}\x{09BE}\x{09D7}\x{0B3E}\x{0B57}\x{0BBE}\x{0BD7}\x{0CC2}\x{0CD5}\x{0CD6}\x{0D3E}\x{0D57}\x{0DCF}\x{0DDF}\x{200C}\x{1D165}\x{1D16E}-\x{1D172}\x{1F3FB}-\x{1F3FF}\x{FE0E}-\x{FE0F}\x{E0020}-\x{E007F}]*(?:\x{200D}(?:[\x{1F1E6}-\x{1F1FF}]|[ -~\x{200C}\x{200D}]|[ᆨ-ᇹ]+|[ᄀ-ᅟ]*(?:[가-힣]?[ᅠ-ᆢ]+|[가-힣])[ᆨ-ᇹ]*|[ᄀ-ᅟ]+|[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}])[\p{Mn}\p{Mc}\p{Me}\x{09BE}\x{09D7}\x{0B3E}\x{0B57}\x{0BBE}\x{0BD7}\x{0CC2}\x{0CD5}\x{0CD6}\x{0D3E}\x{0D57}\x{0DCF}\x{0DDF}\x{200C}\x{1D165}\x{1D16E}-\x{1D172}\x{1F3FB}-\x{1F3FF}\x{FE0E}-\x{FE0F}\x{E0020}-\x{E007F}]*)*|[\p{Cc}\p{Cf}\p{Zl}\p{Zp}])';
 
-        if (!preg_match_all('/'.$regex.'/u', $string, $matches)) {
+        if (preg_match_all('/'.$regex.'/u', $string, $matches)) {
+            $graphemes = $matches[0];
+        } else {
+            $graphemes = self::splitIllFormed($string, $regex);
+        }
+
+        if (!$graphemes) {
             return false;
         }
 
         if (1 === $length) {
-            return $matches[0];
+            return $graphemes;
         }
 
-        $chunks = array_chunk($matches[0], $length);
+        $chunks = array_chunk($graphemes, $length);
         foreach ($chunks as &$chunk) {
             $chunk = implode('', $chunk);
         }
@@ -440,5 +446,49 @@ final class Php84
         $length = \strlen($digits);
 
         return $length ? \ord($digits[$length - 1]) - 48 : 0;
+    }
+
+    /**
+     * Splits a string that is not valid UTF-8 into grapheme clusters.
+     *
+     * The intl extension keeps the ill-formed bytes and breaks around them the
+     * way it would around the U+FFFD each maximal subpart stands for. Standing
+     * one in for real makes the cluster regexp applicable, then each cluster is
+     * mapped back to the bytes it was made of.
+     */
+    private static function splitIllFormed(string $string, string $regex): array
+    {
+        // Table 3-7 of the Unicode standard for the well-formed byte sequences (group 1),
+        // then the maximal subparts an ill-formed sequence is made of (group 2).
+        preg_match_all('/([\x00-\x7F]|[\xC2-\xDF][\x80-\xBF]|\xE0[\xA0-\xBF][\x80-\xBF]|[\xE1-\xEC][\x80-\xBF]{2}|\xED[\x80-\x9F][\x80-\xBF]|[\xEE-\xEF][\x80-\xBF]{2}|\xF0[\x90-\xBF][\x80-\xBF]{2}|[\xF1-\xF3][\x80-\xBF]{3}|\xF4[\x80-\x8F][\x80-\xBF]{2})|(\xF0[\x90-\xBF][\x80-\xBF]?|[\xF1-\xF3][\x80-\xBF]{1,2}|\xF4[\x80-\x8F][\x80-\xBF]?|\xE0[\xA0-\xBF]|[\xE1-\xEC][\x80-\xBF]|\xED[\x80-\x9F]|[\xEE-\xEF][\x80-\xBF]|[\x80-\xFF])/s', $string, $matches, \PREG_SET_ORDER);
+
+        $segments = [];
+        $segmentAt = [];
+        $sanitized = '';
+
+        foreach ($matches as $m) {
+            $segmentAt[\strlen($sanitized)] = \count($segments);
+
+            if (isset($m[2]) && '' !== $m[2]) {
+                $segments[] = $m[2];
+                $sanitized .= "\xEF\xBF\xBD";
+            } else {
+                $segments[] = $m[1];
+                $sanitized .= $m[1];
+            }
+        }
+
+        $segmentAt[\strlen($sanitized)] = \count($segments);
+
+        preg_match_all('/'.$regex.'/u', $sanitized, $clusters, \PREG_OFFSET_CAPTURE);
+
+        $graphemes = [];
+
+        foreach ($clusters[0] as $cluster) {
+            $start = $segmentAt[$cluster[1]];
+            $graphemes[] = implode('', \array_slice($segments, $start, $segmentAt[$cluster[1] + \strlen($cluster[0])] - $start));
+        }
+
+        return $graphemes;
     }
 }

--- a/tests/Intl/Grapheme/GraphemeTest.php
+++ b/tests/Intl/Grapheme/GraphemeTest.php
@@ -135,6 +135,7 @@ class GraphemeTest extends TestCase
         $this->assertFalse(grapheme_substr($c, -5, 1));
         $this->assertFalse(grapheme_substr($c, -42, 1));
         $this->assertFalse(grapheme_substr($c, 42, 5));
+        $this->assertFalse(grapheme_substr('', 0, 2));
     }
 
     /**
@@ -149,6 +150,7 @@ class GraphemeTest extends TestCase
         $this->assertSame('d', grapheme_substr($c, -5, 1));
         $this->assertSame('d', grapheme_substr($c, -42, 1));
         $this->assertSame('', grapheme_substr($c, 42, 5));
+        $this->assertSame('', grapheme_substr('', 0, 2));
     }
 
     /**
@@ -387,5 +389,44 @@ class GraphemeTest extends TestCase
     public function testGraphemeStrrevInvalidUtf8()
     {
         $this->assertFalse(grapheme_strrev("\xFF"));
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_str_split
+     */
+    public function testGraphemeStrSplitInvalidUtf8()
+    {
+        // Ill-formed bytes are kept, and cluster the way U+FFFD would.
+        $this->assertSame(['a', 'b', "\xFF", 'c', 'd'], grapheme_str_split("ab\xFFcd"));
+        $this->assertSame(['a', "\xE4\xB8", 'b'], grapheme_str_split("a\xE4\xB8b"));
+        $this->assertSame(["\xC3\u{0301}"], grapheme_str_split("\xC3\u{0301}"));
+
+        // One cluster per maximal subpart: the truncated 4-byte sequence is one
+        // subpart, the encoded surrogate is three.
+        $this->assertSame(["\xF0\x9F\x98"], grapheme_str_split("\xF0\x9F\x98"));
+        $this->assertSame(["\xED", "\xA0", "\x80"], grapheme_str_split("\xED\xA0\x80"));
+
+        $this->assertSame(['ab', "\xFFc", 'd'], grapheme_str_split("ab\xFFcd", 2));
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_substr
+     */
+    public function testGraphemeSubstrInvalidUtf8()
+    {
+        $this->assertFalse(grapheme_substr("ab\xFFcd", 0, 2));
+        $this->assertFalse(grapheme_substr("\xFF", 0));
+    }
+
+    /**
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_strstr
+     * @covers \Symfony\Polyfill\Intl\Grapheme\Grapheme::grapheme_stristr
+     */
+    public function testGraphemeStrstrInvalidUtf8()
+    {
+        $this->assertFalse(grapheme_strstr("ab\xFFcd", 'a'));
+        $this->assertFalse(grapheme_stristr("ab\xFFcd", 'A'));
+        $this->assertFalse(grapheme_strstr('abcd', "\xFF"));
+        $this->assertFalse(grapheme_stristr('abcd', "\xFF"));
     }
 }

--- a/tests/Php84/Php84Test.php
+++ b/tests/Php84/Php84Test.php
@@ -724,6 +724,21 @@ class Php84Test extends TestCase
         $this->assertSame($expectedValues, grapheme_str_split($string, $length));
     }
 
+    public function testGraphemeStrSplitInvalidUtf8()
+    {
+        // Ill-formed bytes are kept, and cluster the way U+FFFD would.
+        $this->assertSame(['a', 'b', "\xFF", 'c', 'd'], grapheme_str_split("ab\xFFcd"));
+        $this->assertSame(['a', "\xE4\xB8", 'b'], grapheme_str_split("a\xE4\xB8b"));
+        $this->assertSame(["\xC3\u{0301}"], grapheme_str_split("\xC3\u{0301}"));
+
+        // One cluster per maximal subpart: the truncated 4-byte sequence is one
+        // subpart, the encoded surrogate is three.
+        $this->assertSame(["\xF0\x9F\x98"], grapheme_str_split("\xF0\x9F\x98"));
+        $this->assertSame(["\xED", "\xA0", "\x80"], grapheme_str_split("\xED\xA0\x80"));
+
+        $this->assertSame(['ab', "\xFFc", 'd'], grapheme_str_split("ab\xFFcd", 2));
+    }
+
     public static function graphemeStrSplitDataProvider(): array
     {
         $cases = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Three of the `grapheme_*()` polyfills answer differently from the extension when the subject is not valid UTF-8:

| call | ext-intl | polyfill |
| --- | --- | --- |
| `grapheme_str_split("ab\xFFcd")` | `['a', 'b', "\xFF", 'c', 'd']` | `false` |
| `grapheme_substr("ab\xFFcd", 0, 2)` | `false` | `''` |
| `grapheme_strstr("ab\xFFcd", 'a')` | `false` | `'ab?cd'` |

The rest of the family already agrees: `grapheme_strlen()` returns `null`, and `grapheme_str[ri]?pos()`, `grapheme_strrev()` and `grapheme_levenshtein()` return `false`, each behind an explicit validity guard.

`grapheme_strstr()` and `grapheme_stristr()` are the worst of the three. They delegate to `mb_strstr()`/`mb_stristr()` with no guard, and mbstring substitutes `?` for every ill-formed byte, so the caller gets silently corrupted text where the extension would have failed. They now carry the same guard `grapheme_position()` already had, and `grapheme_substr()` returns `false` instead of `''` by checking what `preg_match_all()` returned.

`grapheme_str_split()` needs more than a guard, because the extension returns data here. It keeps the ill-formed bytes and breaks around them the way it would around the U+FFFD each maximal subpart stands for, which is Unicode's substitution of maximal subparts, so `"\xF0\x9F\x98"` is one cluster while `"\xED\xA0\x80"` is three, and a combining mark attaches to the ill-formed byte in front of it. One `preg_match_all()` implements Table 3-7 plus that rule, each subpart is stood in for by a real U+FFFD so the existing cluster regexp applies, and offsets map every cluster back to the bytes it was made of.

Verified against the extension over 50828 random malformed strings: no mismatch for either implementation, and the two agree byte for byte on all of them. The alphabet included genuine U+FFFD characters, since the mapping is by offset rather than by content. The strings that still differ from the extension are the ones where the cluster regexp already differs on the sanitized valid string, which is its ZWJ and regional-indicator simplification and is untouched here.

Both implementations, because `Php84` carries its own copy of `grapheme_str_split()` for PHP < 8.4 with the extension loaded, and the design principles ask the two to behave identically.

Reachability: `Tui\Ansi\AnsiUtils::sliceByColumn()` and `TextWrapper::wrapTextWithAnsi()` split a line into graphemes to measure and slice it. With `false` coming back they return an empty string, so one stray byte anywhere in a line, such as a paste cut mid-character, drops the whole line from the render. That is symfony/symfony#65929, whose test for it fails on the job that runs without ext-intl.

`grapheme_extract()` is left alone on purpose. It also returns `false` where the extension returns a cluster, but the extension's own answers there are not consistent enough to reproduce: `grapheme_extract("\xC3", 1)` gives `"\xC3"` while `grapheme_extract("\xFF", 1)` gives `false`, and `grapheme_extract("\xFFa", 1)` returns `"a"` with `$next = 2`, skipping the ill-formed byte.

Why this survived: the bootstrap files of a polyfill form a chain, the version-specific one declaring the signatures of that PHP version and requiring the more generic one for the rest, and the test listener reads only the first of them. Every function that file does not mention keeps running natively in both passes, so the suite compares it with itself. On PHP 8.5 that leaves 36 functions uncovered across `Php84`, `Php85`, `Php86`, `Uuid` and `Intl/Grapheme`, and it is what the standing `No polyfills found in bootstrap.php for UuidTest` warning reports. Concretely, the `grapheme_str_split()` test added here passes on PHP 8.5 without the fix and fails on PHP 8.4.

Reading the chain is a separate change, on the `test-listener-bootstrap-chain` branch, because it uncovers three more problems that each want their own decision: `Php84Test::testBcCeilError` and its siblings expect a `ValueError` and get the listener's `SkippedTestError` instead, so they fail rather than skip wherever bcmath is loaded and `bcceil()` is not native; `UuidTest::testCreateNoOverlap` finds a duplicate in 100000 draws on PHP 8.0 once the Uuid polyfill is actually exercised; and the exclusion meant for the generic bootstrap never matched, because `getPath()` is the directory rather than the file name, which is what kept the `mixed` return types of `array_find()` and friends from being compared.

The full suite is green with this change on 8.1, 8.2, 8.3, 8.4 and 8.5. The one failure seen while checking was `Php73Test::testHardwareTimeAsArraySeconds`, which sleeps a second and asserts the whole-seconds component moved, and which fails on 1 run in 8 on the branch point as well.

The added tests fail without the change and pass with it.
